### PR TITLE
v1.1.0-beta0: Horse fixes, aa exp per hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Summarizes notable changes to Zeal
 
+## [1.0.0] - 2025/08/02
+
+### New Features:
+
+* Luclin era enabled for /mystats
+* Focus effects should now show up in item info windows
+* Using /rt will now also target the player in the raid window (if active)
+  - **Description:** targets the last tell or active tell window player, also selects the player in your raid window
+* New crash dialog with additional information for screen capturing the summary info
+  - The send crash reporter exe has been removed.
+
+## Fixes and infrastructure
+
+* Spellsets were refactored to eliminate a rare right click context menu issue
+* Fixed return signature of GetClickedActor() (used by self click thru)
+* Source code house keeping (formatting, renaming)
+
+## Known issues
+
+* Mounts (horses) have multiple issues with ZealCam, spellsets, targeting, and more.
+
+
 ## [0.6.8] - 2025/06/02
 
 ### New Features:

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ ___
   - `25` Global cast recovery countdown timer
   - `26` to `33` Recast recovery countdown timers for spell0 - spell7
   - `34` Attack (melee/range) recovery timer
+  - `35` AA Exp Per Hour
 
 - **Label Type's**
   - `80` Mana/Max Mana
@@ -452,6 +453,7 @@ ___
   - `83` Count of empty inventory slots
   - `84` Count of all inventory slots
   - `85` Count of filled inventory slots
+  - `86` AA Exp Per Hour Percent
   - `124` Current Mana
   - `125` Max Mana
   - `134` Spell being casted

--- a/Zeal/Zeal.cpp
+++ b/Zeal/Zeal.cpp
@@ -137,13 +137,11 @@ void ZealService::basic_binds() {
   });  // back
 
   binds_hook->replace_cmd(5, [this](int state) {
-    camera_mods->handle_camera_motion_binds(5, state);
     movement->handle_movement_binds(5, state);
     return false;
   });  // turn right
 
   binds_hook->replace_cmd(6, [this](int state) {
-    camera_mods->handle_camera_motion_binds(6, state);
     movement->handle_movement_binds(6, state);
     return false;
   });  // turn left

--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -7,7 +7,7 @@
 
 #include "framework.h"
 #include "game_addresses.h"
-#define ZEAL_VERSION "1.0.0"
+#define ZEAL_VERSION "1.1.0-beta0"
 #ifndef ZEAL_BUILD_VERSION               // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -217,6 +217,29 @@
   <ItemGroup>
     <None Include="..\CHANGELOG.md" />
     <None Include="..\README.md" />
+    <None Include="uifiles\zeal\optional\README.md" />
+    <None Include="uifiles\zeal\spell_info\fetch_spell_info.py" />
+    <None Include="uifiles\zeal\spell_info\README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Xml Include="uifiles\zeal\EQUI_GuildManagementWnd.xml" />
+    <Xml Include="uifiles\zeal\EQUI_OptionsWindow.xml" />
+    <Xml Include="uifiles\zeal\EQUI_Tab_Cam.xml" />
+    <Xml Include="uifiles\zeal\EQUI_Tab_Colors.xml" />
+    <Xml Include="uifiles\zeal\EQUI_Tab_FloatingDamage.xml" />
+    <Xml Include="uifiles\zeal\EQUI_Tab_General.xml" />
+    <Xml Include="uifiles\zeal\EQUI_Tab_Map.xml" />
+    <Xml Include="uifiles\zeal\EQUI_Tab_Nameplate.xml" />
+    <Xml Include="uifiles\zeal\EQUI_Tab_TargetRing.xml" />
+    <Xml Include="uifiles\zeal\EQUI_ZealButtonWnd.xml" />
+    <Xml Include="uifiles\zeal\EQUI_ZealInputDialog.xml" />
+    <Xml Include="uifiles\zeal\EQUI_ZealMap.xml" />
+    <Xml Include="uifiles\zeal\EQUI_ZealOptions.xml" />
+    <Xml Include="uifiles\zeal\EQUI_ZoneSelect.xml" />
+    <Xml Include="uifiles\zeal\optional\EQUI_CharacterSelect.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="uifiles\zeal\spell_info\spell_info.txt" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -46,6 +46,9 @@
     <Filter Include="Header Files\helpers">
       <UniqueIdentifier>{527e20ee-c27c-458f-94eb-b5dffd5cee70}</UniqueIdentifier>
     </Filter>
+    <Filter Include="UI Files">
+      <UniqueIdentifier>{5ac2a0c8-3a18-4026-bc6e-1cf0e43c27cf}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="framework.h">
@@ -494,5 +497,66 @@
   <ItemGroup>
     <None Include="..\README.md" />
     <None Include="..\CHANGELOG.md" />
+    <None Include="uifiles\zeal\spell_info\fetch_spell_info.py">
+      <Filter>UI Files</Filter>
+    </None>
+    <None Include="uifiles\zeal\spell_info\README.md">
+      <Filter>UI Files</Filter>
+    </None>
+    <None Include="uifiles\zeal\optional\README.md">
+      <Filter>UI Files</Filter>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Xml Include="uifiles\zeal\optional\EQUI_CharacterSelect.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_GuildManagementWnd.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_OptionsWindow.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_Tab_Cam.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_Tab_Colors.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_Tab_FloatingDamage.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_Tab_General.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_Tab_Map.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_Tab_Nameplate.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_Tab_TargetRing.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_ZealButtonWnd.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_ZealInputDialog.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_ZealMap.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_ZealOptions.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+    <Xml Include="uifiles\zeal\EQUI_ZoneSelect.xml">
+      <Filter>UI Files</Filter>
+    </Xml>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="uifiles\zeal\spell_info\spell_info.txt">
+      <Filter>UI Files</Filter>
+    </Text>
   </ItemGroup>
 </Project>

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -9,11 +9,10 @@ Binds::~Binds() {}
 
 bool Binds::execute_cmd(UINT cmd, bool isdown) {
   ZealService *zeal = ZealService::get_instance();
-  // Don't call our binds on keydown when the game wants input except for reply cycling.
+  // Don't call our binds on keydown when the game wants input except for reply cycling and auto-run.
   bool reply_cycle = (cmd == 0x3c || cmd == 0x3d);
-  if (!Zeal::Game::game_wants_input() || !isdown || reply_cycle) {
-    // if (isdown)
-    //	Zeal::Game::print_chat("cmd: %i down: %i", cmd, isdown);
+  bool auto_run = (cmd == 1);  // ProcessKeyDown() already filters normal keys during chat. Fixes numlock.
+  if (!Zeal::Game::game_wants_input() || !isdown || reply_cycle || auto_run) {
     if (zeal->binds_hook->ReplacementFunctions.count(cmd) > 0) {
       for (auto &fn : zeal->binds_hook->ReplacementFunctions[cmd])
         if (fn(isdown))  // if the replacement function returns true, end here otherwise its really just adding more to

--- a/Zeal/callbacks.cpp
+++ b/Zeal/callbacks.cpp
@@ -296,7 +296,7 @@ CallbackManager::CallbackManager(ZealService *zeal) {
   if (gfx_dx8) zeal->hooks->Add("RenderUI", (DWORD)gfx_dx8 + 0x6b7f0, render_ui, hook_type_detour);
 
   zeal->hooks->Add("EnterZone", 0x53D2C4, enterzone_hk, hook_type_detour);
-  zeal->hooks->Add("CDisplayCleanGameUI", 0x4A6EBC, CDisplayCleanGameUI, hook_type_detour);
+  zeal->hooks->Add("CDisplayCleanGameUI", 0x4A6EBC, CDisplayCleanGameUI, hook_type_detour);  // Also char select.
   zeal->hooks->Add("DoCharacterSelection", 0x53b9cf, charselect_hk, hook_type_detour);
   zeal->hooks->Add("InitGameUI", 0x4a60b5, initgameui_hk, hook_type_detour);
   zeal->hooks->Add("InitCharSelectUI", 0x4a5f85, initcharselectui_hk, hook_type_detour);

--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -8,17 +8,9 @@
 
 class CameraMods {
  public:
-  std::chrono::steady_clock::time_point prevTime;
-
-  // cam_lock = ini->getValue<bool>("Zeal", "CamLock");
-  // fov = ini->getValue<float>("Zeal", "Fov");
-
-  ZealSetting<bool> enabled = {true, "Zeal", "MouseSmoothing", false};
+  ZealSetting<bool> enabled = {true, "Zeal", "MouseSmoothing", false, [this](bool val) { synchronize_set_enable(); }};
   ZealSetting<bool> cam_lock = {true, "Zeal", "CamLock", false};
   ZealSetting<bool> use_old_sens = {false, "Zeal", "OldSens", false};
-  ZealSetting<bool> camera3_strafe_enabled = {false, "Zeal", "Camera3StrafeEnabled", false};
-  ZealSetting<bool> camera4_strafe_enabled = {false, "Zeal", "Camera4StrafeEnabled", false};
-  ZealSetting<bool> cycle_to_zeal_cam_enabled = {true, "Zeal", "cycle_to_zeal_cam_enabled", false};
   ZealSetting<float> user_sensitivity_x = {0.1f, "Zeal", "MouseSensitivityX", false};
   ZealSetting<float> user_sensitivity_y = {0.1f, "Zeal", "MouseSensitivityY", false};
   ZealSetting<float> user_sensitivity_x_3rd = {0.1f, "Zeal", "MouseSensitivityX3rd", false};
@@ -31,45 +23,38 @@ class CameraMods {
   ZealSetting<bool> setting_selfclickthru = {false, "Zeal", "SelfClickThru", false};
 
   const float max_zoom_out = 100;
+  const float min_zoom_in = 5.f;  // Transitions to first person below this.
   const float zoom_speed = 5.f;
 
-  int game_ptr = 0;
-  float height;
-  float fps = 0;
-  float zeal_cam_pitch;
-  float zeal_cam_yaw;
-  float current_zoom = 0.f;
-  float desired_zoom = 0.f;
-  void set_smoothing(bool val);
-  void callback_main();
-  void callback_render();
-  void callback_characterselect();
-  void callback_endmainloop();
-  bool update_cam();  // returns true on collision
-  void mouse_wheel(int delta);
-  void update_zoom(float zoom);
-  void toggle_zeal_cam(bool enabled, bool reset_pitch = true);
-  void proc_mouse();
-  void handle_camera_motion_binds(int cmd, bool is_down);
-  void handle_cycle_camera_views(int cmd, bool is_down);
-  void proc_rmousedown(int x, int y);
   CameraMods(class ZealService *pHookWrapper);
   ~CameraMods();
+  bool handle_mouse_wheel(int delta);
+  bool handle_proc_mouse();
+  void handle_proc_rmousedown(int x, int y);
+  void handle_do_cam_ai();
 
  private:
-  bool main_loop_ended = false;
-  bool check_snap = false;
+  float fps = 60.f;
+  float zeal_cam_pitch = 0.f;
+  float zeal_cam_yaw = 0.f;
+  float zeal_cam_zoom = 0.f;
+  float desired_zoom = 0.f;
   ULONGLONG lmouse_time = 0;
   POINT lmouse_cursor_pos;
   bool hide_cursor = false;
   float sensitivity_x = 0.7f;
   float sensitivity_y = 0.4f;
-  void interpolate_zoom();
-  std::unordered_map<int, bool> cmd_key_map;
-  BYTE original_cam[6] = {0};
   std::chrono::steady_clock::time_point lastTime;
-  Vec2 local_delta = {0, 0};
-  bool shutting_down = false;
-  void tick_key_move();
+  bool ui_active = false;
+
+  void synchronize_set_enable();
+  void callback_main();
+  void update_desired_zoom(float zoom);
+  void set_zeal_cam_active(bool activate);
+  bool is_zeal_cam_active() const;
+  bool calc_camera_positions(Vec3 &head_pos, Vec3 &wanted_pos) const;
+  void update_left_pan(DWORD camera_view);
+  void interpolate_zoom();
+  void process_time_tick();
   void update_fps_sensitivity();
 };

--- a/Zeal/cycle_target.cpp
+++ b/Zeal/cycle_target.cpp
@@ -34,6 +34,7 @@ Zeal::GameStructures::Entity *CycleTarget::get_next_ent(float dist, byte type) {
   for (auto &ent : visible_ents) {
     if (ent->StructType != 0x03) continue;
     if (ent->Type == type && ent->Level > 0) {
+      if (Zeal::Game::is_a_mount(ent)) continue;  // Skip mounts like horses.
       if (ent->PetOwnerSpawnId) {
         Zeal::GameStructures::Entity *owner = Zeal::Game::get_entity_by_id(ent->PetOwnerSpawnId);
         if ((owner && (owner->Type == Zeal::GameEnums::EntityTypes::NPC ||
@@ -70,6 +71,7 @@ Zeal::GameStructures::Entity *CycleTarget::get_nearest_ent(float dist, byte type
   for (auto &ent : visible_ents) {
     if (ent->StructType != 0x03) continue;
     if (ent->Type == type && ent->Level > 0) {
+      if (Zeal::Game::is_a_mount(ent)) continue;  // Skip mounts like horses.
       if (ent->PetOwnerSpawnId) {
         Zeal::GameStructures::Entity *owner = Zeal::Game::get_entity_by_id(ent->PetOwnerSpawnId);
         if ((owner && (owner->Type == Zeal::GameEnums::EntityTypes::NPC ||

--- a/Zeal/experience.h
+++ b/Zeal/experience.h
@@ -2,30 +2,49 @@
 #include <Windows.h>
 
 #include <deque>
-#include <string>
 
-struct _ExpData {
-  ULONGLONG TimeStamp;
-  ULONGLONG Duration;
-  int Gained;
+class ExperienceCalc {
+ public:
+  static constexpr int kExpPerLevel = 330;  // 330 exp points = 100%.
 
-  _ExpData(int _gained, ULONGLONG LastTimeStamp) {
-    TimeStamp = GetTickCount64();
-    Gained = _gained;
-    Duration = TimeStamp - LastTimeStamp;
-  }
+  ExperienceCalc();
+
+  void reset(int level = 0, int exp = 0);
+  void update(int level, int exp);
+  void dump() const;  // Debug use.
+
+  float get_exp_per_hour_pct() const { return exp_per_hour_pct; }
+
+ private:
+  static constexpr int kMaxQueueSize = 20;  // Calculate rate based on last 20 exp updates.
+
+  struct ExpData {
+    ULONGLONG timestamp;
+    int total_exp;
+
+    ExpData(ULONGLONG _timestamp, int _total_exp) : timestamp(_timestamp), total_exp(_total_exp){};
+  };
+
+  float exp_per_hour_pct = 0;     // Calculated latest experience rate.
+  std::deque<ExpData> exp_queue;  // Timestamped fifo list of most recent exp changes.
 };
 
 class Experience {
  public:
-  void callback_main();
-  void check_reset();
   Experience(class ZealService *zeal);
-  ~Experience();
-  int exp;
-  static constexpr float max_exp = 330.f;
-  float exp_per_hour_tot;
-  float exp_per_hour_pct_tot;
-  std::string ttl;
-  std::deque<_ExpData> ExpInfo;
+
+  float get_exp_per_hour_pct() const { return exp_calc.get_exp_per_hour_pct(); }
+
+  float get_aa_exp_per_hour_pct() const { return aa_calc.get_exp_per_hour_pct(); }
+
+ private:
+  void reset();                     // Resets both exp and aa calcs.
+  void reset_exp();                 // Resets exp rate to zero and initializes state.
+  void reset_aa();                  // Resets aa rate to zero and initializes state.
+  int get_exp_level() const;        // Returns the current level (if level and exp valid).
+  int get_aa_total_points() const;  // Returns the total number of AA points.
+  void callback_main();             // Periodic update and recalculation of exp rates.
+
+  ExperienceCalc exp_calc;  // Normal experience.
+  ExperienceCalc aa_calc;   // Altenate advancement experience.
 };

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -236,6 +236,7 @@ Zeal::GameStructures::SPELLMGR *get_spell_mgr();
 int get_spell_level(int spell_id);
 const char *get_spell_name(int spell_id);
 Zeal::GameStructures::Entity *get_controlled();
+Zeal::GameStructures::ViewActor *get_view_actor();
 Zeal::GameStructures::CameraInfo *get_camera();
 Zeal::GameStructures::Entity *get_entity_by_id(short id);  // Returns nullptr if invalid id.
 Zeal::GameStructures::Entity *get_entity_by_parent_id(short parent_id);
@@ -294,6 +295,9 @@ void sort_list_wnd(Zeal::GameUI::ListWnd *list_wnd, int sort_column, SortType so
 short total_spell_affects(Zeal::GameStructures::GAMECHARINFO *char_info, BYTE affect_type, BYTE a3,
                           int *per_buff_values);
 void sit();
+void dismount();
+bool is_mounted();
+bool is_a_mount(const Zeal::GameStructures::Entity *entity);
 
 // game.dll patch support that expanded the number of available bank slots.
 int get_num_personal_bank_slots();

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -106,14 +106,14 @@ namespace GameEnums {
 enum EntityTypes { Player, NPC, NPCCorpse, PlayerCorpse, Unknown };
 
 enum CameraView {
-  FirstPerson,
-  ThirdPerson1,
-  ThirdPerson2,
-  ThirdPerson3,
-  ThirdPerson4,
-  CharacterSelect,
-  ZealCam,
-  TotalCameras
+  FirstPerson = 0,
+  ThirdPerson1 = 1,  // Top-down view.  Alt+PgUp/Dn for pitch.
+  ThirdPerson2 = 2,  // Chase-camera view. Default for mouse zoom out.
+  ZealCam = 2,       // Replaces ThirdPerson2 when enabled.
+  ThirdPerson3 = 3,  // User camera control (manual).
+  ThirdPerson4 = 4,  // User camera control (manual).
+  CharacterSelect = 5,
+  TotalCameras = 6
 };
 
 enum Stance { Sitting = 110, Ducking = 111, Standing = 100, Frozen = 102, Looting = 105, Feigned = 115, Dead = 120 };
@@ -741,12 +741,15 @@ struct ActorInfo {
   /* 0x0160 */ DWORD FizzleTimeout;  // Set in the OP_MemorizeSpell handler.
   /* 0x0164 */ BYTE Unknown0164[0x20];
   /* 0x0184 */ DWORD Animation;
-  /* 0x0188 */ BYTE Unknown0188[0xc];
-  /* 0x0194 */ struct Entity *Entity0194;  // Entity is linked in UpdatePlayerVisibility.
-  /* 0x0198 */ struct Entity *Entity0198;  // Appears to be a horse entity in UpdatePlayerVisiblity.
+  /* 0x0188 */ BYTE Unknown0188[0x8];
+  /* 0x0190 */ struct Entity *AttachedEntity;
+  /* 0x0194 */ struct Entity *Mount;
+  /* 0x0198 */ struct Entity *Rider;
   /* 0x019C */ BYTE Unknown019c[24];
   /* 0x01B4 */ DWORD IsInvisible;  // NPCs only? used by /hidecorpses command
-  /* 0x01B8 */ BYTE Unknown01B8[10];
+  /* 0x01B8 */ struct Entity *Horse;
+  /* 0x01BC */ DWORD HorseSpellEffect;
+  /* 0x01C0 */ WORD HorseSpellId;
   /* 0x01C2 */ SHORT PetID;
   /* 0x01C4 */ BYTE Unknown01C4[156];
   /* 0x0260 */ DWORD IsHoldingBoth;
@@ -768,7 +771,9 @@ struct ActorInfo {
   /* 0x0294 */ GAMEDAGINFO *DagRightPoint;
   /* 0x0298 */ GAMEDAGINFO *DagLeftPoint;
   /* 0x029C */ GAMEDAGINFO *DagShieldPoint;
-  /* 0x02A0 */ BYTE Unknown02A0[128];
+  /* 0x02A0 */ BYTE Unknown02A0[0x44];
+  /* 0x02E4 */ struct Entity *Following;  // Non-zero if auto-following this entity.
+  /* 0x02E8 */ BYTE Unknown02E8[0x38];
   /* 0x0320 */ BYTE MovementType;  // 0 = None, 4 = Walking, 6 = Running, 7 = Swimming
   /* 0x0321 */ BYTE Unknown0321[12];
   /* 0x032D */ BYTE IsMovingTimer;  // 0 = Moving, 1-6 = Recently Stopped Moving, 200 = Not Moving
@@ -1041,10 +1046,14 @@ struct GAMECHARINFO  // common/patches/mac_structs.h::PlayerProfile_Struct
   /* 0x1363 */ BYTE GuildStatus;  // guild rank
   /* 0x1364 */ BYTE Drunkness;    // 0 = Not Drunk, counts down over time
   /* 0x1365 */ BYTE Unknown1365[451];
-  /* 0x1528 */ DWORD AlternateAdvancementExperience;
-  /* 0x152C */ BYTE Unknown152C[476];
+  /* 0x1528 */ DWORD AlternateAdvancementExperience;  // 330 = 100%.
+  /* 0x152C */ BYTE Unknown152C;
+  /* 0x152D */ BYTE AlternateAdvancementShareOfExpPercent;
+  /* 0x152E */ BYTE Unknown152E[0x1DA];
   /* 0x1708 */ BYTE AirSupply;  // air remaining while swimming underwater
-  /* 0x1709 */ BYTE Unknown1709[2475];
+  /* 0x1709 */ BYTE Unknown1709;
+  /* 0x170A */ WORD AlternateAdvancementUnspent;  // Unspent AA points.
+  /* 0x170C */ BYTE Unknown170C[0x9A8];
 
   // Note: The unmodified client GAMECHARINFO has 8 bank slots with the rest of the structure
   //       effectively unused to the original size of 0x2104. If the server provided game.dll patch

--- a/Zeal/player_movement.cpp
+++ b/Zeal/player_movement.cpp
@@ -11,6 +11,9 @@ static void CloseSpellbook(void) {
 
 void PlayerMovement::handle_movement_binds(int cmd, bool key_down) {
   if (!Zeal::Game::game_wants_input() && key_down) {
+    // Reset strafing if forward/back keys are pressed down without a strafe key down.
+    if ((cmd == 3 || cmd == 4) && !current_strafe_key_down_state && (current_strafe != strafe_direction::None))
+      set_strafe(strafe_direction::None);
     if (!Zeal::Game::KeyMods->Alt && !Zeal::Game::KeyMods->Shift && !Zeal::Game::KeyMods->Ctrl) {
       if (Zeal::Game::is_new_ui()) {
         if (Zeal::Game::Windows->Loot && Zeal::Game::Windows->Loot->IsOpen && Zeal::Game::Windows->Loot->IsVisible) {
@@ -21,6 +24,7 @@ void PlayerMovement::handle_movement_binds(int cmd, bool key_down) {
             case 3:
               CloseSpellbook();
               break;
+            case 4:
             case 5:
             case 6:
             case 211:
@@ -87,8 +91,23 @@ void PlayerMovement::handle_spellcast_binds(int cmd) {
   }
 }
 
+void PlayerMovement::handle_movement_keys(int dinput_code) {
+  unsigned int key = dinput_code & 0xd00000ff;  // 0xd mask ignores ctrl key state.
+  // These special movement keys bypass the input check.
+  const unsigned int *numpad_8_up = (unsigned int *)0x007cd858;
+  const unsigned int *numpad_2_down = (unsigned int *)0x007cd85c;
+  const unsigned int *key_up = (unsigned int *)0x007cdc58;
+  const unsigned int *key_down = (unsigned int *)0x007cdc5c;
+
+  // Reset strafing if they are pressed down without a strafe key down.
+  if ((key == *numpad_8_up || key == *numpad_2_down || key == *key_up || key == *key_down) &&
+      !current_strafe_key_down_state && (current_strafe != strafe_direction::None))
+    set_strafe(strafe_direction::None);
+}
+
 void PlayerMovement::set_strafe(strafe_direction dir) {
   // slightly revised so the game properly sets speed based on encumber and handles the stance checks
+  current_strafe_lock = false;  // Always reset when setting (key is pressed, resetting).
   if (dir == strafe_direction::None || !Zeal::Game::can_move()) {
     current_strafe = strafe_direction::None;
     *Zeal::Game::strafe_direction = 0;
@@ -113,14 +132,15 @@ void PlayerMovement::set_strafe(strafe_direction dir) {
 void PlayerMovement::callback_main() {
   if (current_strafe != strafe_direction::None) {
     Zeal::GameStructures::Entity *controlled_player = Zeal::Game::get_controlled();
-    float encumberance = Zeal::Game::encum_factor();
-    *Zeal::Game::strafe_speed = encumberance + encumberance;
-    if (controlled_player->IsSneaking || controlled_player->StandingState == Stance::Duck)
+    *Zeal::Game::strafe_speed = 2.f;  // Default for mounts.
+    if (controlled_player != Zeal::Game::get_self()) {
+      float encumberance = Zeal::Game::encum_factor();
+      *Zeal::Game::strafe_speed = encumberance + encumberance;
+    }
+    if (controlled_player->IsSneaking || controlled_player->StandingState == Stance::Duck ||
+        (controlled_player->ActorInfo && controlled_player->ActorInfo->MovementSpeedModifier < 0))
       *Zeal::Game::strafe_speed *= .5f;
-    if (controlled_player->ActorInfo && controlled_player->ActorInfo->MovementSpeedModifier < 0)
-      *Zeal::Game::strafe_speed *= .5f;
-    if (controlled_player->ActorInfo && controlled_player->ActorInfo->Entity0198 != 0)
-      *Zeal::Game::strafe_speed *= .25f;
+    if (controlled_player->ActorInfo && controlled_player->ActorInfo->Rider != 0) *Zeal::Game::strafe_speed *= .25f;
     if (controlled_player->ActorInfo && controlled_player->ActorInfo->MovementSpeedModifier < -1000.0f) {
       *Zeal::Game::strafe_direction = 0;
       *Zeal::Game::strafe_speed = 0;
@@ -148,8 +168,8 @@ void PlayerMovement::callback_main() {
 // }
 //
 
-int __fastcall CastSpell(void *this_ptr, void *not_used, unsigned char a1, short a2,
-                         Zeal::GameStructures::GAMEITEMINFO **a3, short a4) {
+static int __fastcall CastSpell(void *this_ptr, void *not_used, unsigned char a1, short a2,
+                                Zeal::GameStructures::GAMEITEMINFO **a3, short a4) {
   if (ZealService::get_instance()->movement->CastAutoStand.get() && Zeal::Game::get_self() &&
       Zeal::Game::get_self()->StandingState == Zeal::GameEnums::Stance::Sitting)
     Zeal::Game::get_self()->ChangeStance(Stance::Stand);
@@ -157,25 +177,57 @@ int __fastcall CastSpell(void *this_ptr, void *not_used, unsigned char a1, short
                                                                                         a4);
 }
 
+static int ProcessMovementKeys(int dinput_code, int unknown) {
+  ZealService::get_instance()->movement->handle_movement_keys(dinput_code);
+  return ZealService::get_instance()->hooks->hook_map["ProcessMovementKeys"]->original(ProcessMovementKeys)(dinput_code,
+                                                                                                            unknown);
+}
+
 PlayerMovement::PlayerMovement(ZealService *zeal) {
   zeal->hooks->Add("CastSpell", 0x004C483B, CastSpell, hook_type_detour);
+  zeal->hooks->Add("ProcessMovementKeys", 0x005257fa, ProcessMovementKeys, hook_type_detour);
   Binds *binds = zeal->binds_hook.get();
+
+  // Support enhanced auto-run: more consistent 'lock on' behavior including strafe support
+  binds->replace_cmd(1, [this](int state) {
+    // Change nothing on key release or if setting disabled.
+    if (!state || !EnhancedAutoRun.get()) return false;
+
+    bool auto_run_active = *reinterpret_cast<int *>(0x00798600) != 0;
+    bool forwards_key_down = *reinterpret_cast<int *>(0x007ce058) != 0;
+    if (forwards_key_down || (current_strafe_key_down_state && current_strafe != strafe_direction::None)) {
+      // Lock strafing if currently active.
+      current_strafe_lock = (current_strafe != strafe_direction::None);
+      // Skip processing if already in auto-run mode so that it isn't toggled off.
+      return auto_run_active;
+    }
+
+    if (auto_run_active) set_strafe(strafe_direction::None);  // Disables strafing when auto_run is toggling off.
+    return false;                                             // Auto_run will toggle off in primary handler.
+  });
+
   // ISSUE: Mapping LEFT/RIGHT arrow keys to strafe on TAKP2.1 client fails to function.
   binds->replace_cmd(211, [this](int state) {
-    if (!state && current_strafe == strafe_direction::Left) {
-      set_strafe(strafe_direction::None);
-    } else if (state) {
-      handle_movement_binds(211, state);
-      set_strafe(strafe_direction::Left);
+    current_strafe_key_down_state = state;
+    if (!Zeal::Game::game_wants_input()) {
+      if (!state && current_strafe == strafe_direction::Left && !current_strafe_lock) {
+        set_strafe(strafe_direction::None);
+      } else if (state) {
+        handle_movement_binds(211, state);
+        set_strafe(strafe_direction::Left);
+      }
     }
     return false;
   });  // strafe left
   binds->replace_cmd(212, [this](int state) {
-    if (!state && current_strafe == strafe_direction::Right) {
-      set_strafe(strafe_direction::None);
-    } else if (state) {
-      handle_movement_binds(212, state);
-      set_strafe(strafe_direction::Right);
+    current_strafe_key_down_state = state;
+    if (!Zeal::Game::game_wants_input()) {
+      if (!state && current_strafe == strafe_direction::Right && !current_strafe_lock) {
+        set_strafe(strafe_direction::None);
+      } else if (state) {
+        handle_movement_binds(212, state);
+        set_strafe(strafe_direction::Right);
+      }
     }
     return false;
   });  // strafe right
@@ -198,4 +250,10 @@ PlayerMovement::PlayerMovement(ZealService *zeal) {
     return false;
   });
   zeal->callbacks->AddGeneric([this]() { callback_main(); }, callback_type::MainLoop);
+  zeal->callbacks->AddGeneric(
+      [this]() {
+        current_strafe_key_down_state = false;
+        set_strafe(strafe_direction::None);  // Reset strafe logic including strafe_lock.
+      },
+      callback_type::InitUI);
 }

--- a/Zeal/player_movement.h
+++ b/Zeal/player_movement.h
@@ -9,15 +9,19 @@ class PlayerMovement {
  public:
   void handle_movement_binds(int cmd, bool key_down);
   void handle_spellcast_binds(int cmd);
+  void handle_movement_keys(int dinput_code);
   // void set_spellbook_autostand(bool enabled);
   // bool spellbook_autostand = false;
   ZealSetting<bool> CastAutoStand = {true, "Zeal", "CastAutoStand", false};
   ZealSetting<bool> SpellBookAutoStand = {true, "Zeal", "SpellBookAutoStand", false};
+  ZealSetting<bool> EnhancedAutoRun = {false, "Zeal", "EnhancedAutoRun", false};
   PlayerMovement(class ZealService *zeal);
 
  private:
   void set_strafe(strafe_direction dir);
   void callback_main();
   strafe_direction current_strafe = strafe_direction::None;
+  bool current_strafe_key_down_state = false;  // A bound strafe key is currently pressed.
+  bool current_strafe_lock = false;            // Current strafing direction is locked on.
   BYTE orig_reset_strafe[7] = {0};
 };

--- a/Zeal/spellsets.cpp
+++ b/Zeal/spellsets.cpp
@@ -100,7 +100,7 @@ void SpellSets::handle_finished_memorizing(int a1, int a2) {
   // Handle interruptions gracefully by clearing state and restoring stance.
   if (!Zeal::Game::Windows->SpellBook || !Zeal::Game::Windows->SpellBook->IsVisible) {
     if (Zeal::Game::get_self() && Zeal::Game::is_in_game() && original_stance != Stance::Sit &&
-        ((Stance)Zeal::Game::get_self()->StandingState == Stance::Sit))
+        ((Stance)Zeal::Game::get_self()->StandingState == Stance::Sit) && !Zeal::Game::is_mounted())
       Zeal::Game::get_self()->ChangeStance(original_stance);
     mem_buffer.clear();
     return;
@@ -110,7 +110,7 @@ void SpellSets::handle_finished_memorizing(int a1, int a2) {
   if (mem_buffer.size())
     Zeal::Game::Spells::Memorize(mem_buffer.back().first, mem_buffer.back().second);
   else if (Zeal::Game::Windows->SpellBook->IsVisible) {
-    Zeal::Game::get_self()->ChangeStance(original_stance);
+    if (!Zeal::Game::is_mounted()) Zeal::Game::get_self()->ChangeStance(original_stance);
     Zeal::Game::Windows->SpellBook->show(0, false);
   }
 }

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -381,7 +381,7 @@ void ui_options::InitGeneral() {
     ZealService::get_instance()->looting_hook->set_hide_looted(wnd->Checked);
   });
   ui->AddCheckboxCallback(wnd, "Zeal_Cam", [](Zeal::GameUI::BasicWnd *wnd) {
-    ZealService::get_instance()->camera_mods->set_smoothing(wnd->Checked);
+    ZealService::get_instance()->camera_mods->enabled.set(wnd->Checked);
   });
   ui->AddCheckboxCallback(wnd, "Zeal_BlueCon", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->chat_hook->UseBlueCon.set(wnd->Checked);
@@ -451,6 +451,9 @@ void ui_options::InitGeneral() {
   });
   ui->AddCheckboxCallback(wnd, "Zeal_EnhancedSpellInfo", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->item_displays->setting_enhanced_spell_info.set(wnd->Checked);
+  });
+  ui->AddCheckboxCallback(wnd, "Zeal_EnhancedAutoRun", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->movement->EnhancedAutoRun.set(wnd->Checked);
   });
   ui->AddCheckboxCallback(wnd, "Zeal_SlashNotPoke",
                           [this](Zeal::GameUI::BasicWnd *wnd) { setting_slash_not_poke.set(wnd->Checked); });
@@ -929,6 +932,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_SingleClickGiveEnable", ZealService::get_instance()->give->setting_enable_give.get());
   ui->SetChecked("Zeal_EnhancedSpellInfo",
                  ZealService::get_instance()->item_displays->setting_enhanced_spell_info.get());
+  ui->SetChecked("Zeal_EnhancedAutoRun", ZealService::get_instance()->movement->EnhancedAutoRun.get());
   ui->SetChecked("Zeal_SlashNotPoke", setting_slash_not_poke.get());
   ui->SetChecked("Zeal_InviteDialog", setting_invite_dialog.get());
   ui->SetChecked("Zeal_AutoFollowEnable", ZealService::get_instance()->game_patches->AutoFollowEnable.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -1195,13 +1195,43 @@
       <Disabled>A_BtnDisabled</Disabled>
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
-  </Button>  
+  </Button>
+  <Button item="Zeal_EnhancedAutoRun">
+    <ScreenID>Zeal_EnhancedAutoRun</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>194</X>
+      <Y>442</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>More consistent 'lock on' behavior and adds strafe</TooltipReference>
+    <Text>Enhanced AutoRun</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Label item="Zeal_FPS_Label">
     <ScreenID>Zeal_FPS_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>194</X>
-      <Y>442</Y>
+      <Y>464</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -1221,7 +1251,7 @@
 		<ScreenID>Zeal_FPS_Combobox</ScreenID>
 		<Location>
 			<X>194</X>
-			<Y>462</Y>
+			<Y>484</Y>
 		</Location>
 		<Size>
 			<CX>140</CX>
@@ -1305,6 +1335,7 @@
     <Pieces>Zeal_SingleClickGiveEnable</Pieces>
     <Pieces>Zeal_EnhancedSpellInfo</Pieces>
     <Pieces>Zeal_SlashNotPoke</Pieces>
+    <Pieces>Zeal_EnhancedAutoRun</Pieces>
     <Pieces>Zeal_TellSound_Label</Pieces>
     <Pieces>Zeal_TellSound_Combobox</Pieces>
     <Pieces>Zeal_InviteSound_Label</Pieces>


### PR DESCRIPTION
* Bump to v1.1.0-beta0

* Luclin horse support
  - ZealCam: Now functional in first and third person
  - Self-click thru: Now also applies to your mount
  - Spellsets: Now functional when mounted
  - /camp: Performs an auto-dismount to allow sitting and camping
  - Fix to Type 134 (spell casting name) when mounted
  - Target nearest and cycle targets now excludes mounts (horses)

* New enhanced auto-run that instead of toggling state will always lock on if forward key is also pressed. Also will lock strafe key.

* UI labels:
  - Gauge type 35: AA Exp Per Hour
  - Label type 86: AA Exp Per Hour Percent

* Significant refactoring to ZealCam and Exp/hour to support the updates