### PR TITLE
v1.1.0-beta1 w/spell casting fix

### DIFF
--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -7,7 +7,7 @@
 
 #include "framework.h"
 #include "game_addresses.h"
-#define ZEAL_VERSION "1.1.0-beta0"
+#define ZEAL_VERSION "1.1.0-beta1"
 #ifndef ZEAL_BUILD_VERSION               // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -2195,7 +2195,7 @@ HWND get_game_window() {
 namespace Spells {
 void OpenBook() {
   if (!Windows->SpellBook) return;
-  Windows->SpellBook->OpenBook();
+  Windows->SpellBook->Activate();
 }
 
 void StopSpellBookAction() {
@@ -2205,10 +2205,11 @@ void StopSpellBookAction() {
 
 void Memorize(int book_index, int gem_index) {
   if (!Windows->SpellBook) return;
-  if (!Windows->SpellBook->IsVisible) Zeal::Game::Spells::OpenBook();
+  if (!Windows->SpellBook->Activated) Windows->SpellBook->Activate();
+  if (!Windows->SpellBook->Activated) return;
   ZealService::get_instance()->callbacks->AddDelayed(
       [book_index, gem_index]() {
-        if (Windows->SpellBook->IsVisible &&
+        if (Windows->SpellBook && Windows->SpellBook->Activated &&
             (Zeal::Game::get_self()->StandingState == Stance::Sit || Zeal::Game::is_mounted()))
           Windows->SpellBook->BeginMemorize(book_index, gem_index, false);
       },

--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -1067,12 +1067,14 @@ class SpellBookWnd : public SidlWnd {
                                                                                     unsure);
   }
 
-  void OpenBook() const { reinterpret_cast<void(__thiscall *)(const SidlWnd *)>(0x43441F)(this); }
-
   void StopSpellBookAction() const  // Aborts memorization or scribing.
   {
     reinterpret_cast<void(__thiscall *)(const SidlWnd *)>(0x00435531)(this);
   }
+
+  void Activate() const { reinterpret_cast<void(__thiscall *)(const SidlWnd *)>(0x0043441f)(this); }
+
+  void Deactivate() const { reinterpret_cast<void(__thiscall *)(const SidlWnd *)>(0x0043450a)(this); }
 
   int WndNotification(const BasicWnd *src_wnd, int param_2, void *param_3) {
     return reinterpret_cast<int(__thiscall *)(SpellBookWnd *, const BasicWnd *, int, void *)>(0x004345cb)(
@@ -1082,6 +1084,18 @@ class SpellBookWnd : public SidlWnd {
   void DisplaySpellInfo(const BasicWnd *src_wnd) {
     reinterpret_cast<int(__thiscall *)(SpellBookWnd *, const BasicWnd *)>(0x00435234)(this, src_wnd);
   }
+
+  /*0x134*/ BYTE Activated;  // Set to 1 when activated and 0 in Deactivate().
+  /*0x135*/ BYTE Unknown0x135[3];
+  /*0x138*/ DWORD SpellBookIndex;
+  /*0x13C*/ DWORD Unknown0x13C;
+  /*0x140*/ DWORD MemorizingSpellIndex;
+  /*0x144*/ DWORD MemorizingSpellId;
+  /*0x148*/ DWORD MemTicksLeft;
+  /*0x14C*/ DWORD ScribeIndex;  // Unsure.
+  /*0x150*/ DWORD ScribeTicksLeft;
+  /*0x154*/ DWORD CachedSittingState;
+  /*0x158*/ DWORD Timestamp;  // Used in process frame to trigger StopSpellBookAction.
 };
 
 // TODO: The current BasicWnd definition is not the true base class and should probably be

--- a/Zeal/player_movement.cpp
+++ b/Zeal/player_movement.cpp
@@ -6,7 +6,7 @@
 
 static void CloseSpellbook(void) {
   Zeal::Game::get_self()->ChangeStance(Stance::Stand);
-  Zeal::Game::Windows->SpellBook->IsVisible = false;
+  if (Zeal::Game::Windows->SpellBook->Activated) Zeal::Game::Windows->SpellBook->Deactivate();
 }
 
 void PlayerMovement::handle_movement_binds(int cmd, bool key_down) {
@@ -19,7 +19,7 @@ void PlayerMovement::handle_movement_binds(int cmd, bool key_down) {
         if (Zeal::Game::Windows->Loot && Zeal::Game::Windows->Loot->IsOpen && Zeal::Game::Windows->Loot->IsVisible) {
           Zeal::Game::GameInternal::CLootWndDeactivate((int)Zeal::Game::Windows->Loot, 0);
           return;
-        } else if (Zeal::Game::Windows->SpellBook && Zeal::Game::Windows->SpellBook->IsVisible) {
+        } else if (Zeal::Game::Windows->SpellBook && Zeal::Game::Windows->SpellBook->Activated) {
           switch (cmd) {
             case 3:
               CloseSpellbook();
@@ -73,7 +73,7 @@ void PlayerMovement::handle_spellcast_binds(int cmd) {
     if (Zeal::Game::is_new_ui()) {
       if (Zeal::Game::Windows->Loot && Zeal::Game::Windows->Loot->IsOpen && Zeal::Game::Windows->Loot->IsVisible) {
         return;
-      } else if (Zeal::Game::Windows->SpellBook && Zeal::Game::Windows->SpellBook->IsVisible) {
+      } else if (Zeal::Game::Windows->SpellBook && Zeal::Game::Windows->SpellBook->Activated) {
         return;
       }
     } else {
@@ -151,22 +151,6 @@ void PlayerMovement::callback_main() {
     }
   }
 }
-
-// void PlayerMovement::load_settings()
-//{
-//	if (!ini_handle->exists("Zeal", "SpellbookAutostand"))
-//		ini_handle->setValue<bool>("Zeal", "SpellbookAutostand", false);
-//	//if (!ini_handle->exists("Zeal", "LeftStrafeSpellbookAutostand"))
-//	//	ini_handle->setValue<bool>("Zeal", "LeftStrafeSpellbookAutostand", true);
-//	//if (!ini_handle->exists("Zeal", "RightStrafeSpellbookAutostand"))
-//	//	ini_handle->setValue<bool>("Zeal", "RightStrafeSpellbookAutostand", true);
-//
-//	SpellBookAutoStand = ini_handle->getValue<bool>("Zeal", "SpellbookAutostand");
-//	/*spellbook_right_autostand = ini_handle->getValue<bool>("Zeal", "RightTurnSpellbookAutostand");
-//	spellbook_left_strafe_autostand = ini_handle->getValue<bool>("Zeal", "LeftStrafeSpellbookAutostand");
-//	spellbook_right_strafe_autostand = ini_handle->getValue<bool>("Zeal", "RightStrafeSpellbookAutostand");*/
-// }
-//
 
 static int __fastcall CastSpell(void *this_ptr, void *not_used, unsigned char a1, short a2,
                                 Zeal::GameStructures::GAMEITEMINFO **a3, short a4) {

--- a/Zeal/spellsets.h
+++ b/Zeal/spellsets.h
@@ -53,7 +53,6 @@ class SpellSets {
 
   std::vector<MenuPair> spells_menus;               // Spellbook spells.
   Zeal::GameUI::SpellGemWnd *last_gem_clicked = 0;  // Caches clicked gem between operations.
-  Stance original_stance = Stance::Stand;           // Preserves starting stance across operations.
 
   std::vector<MenuPair> spellsets_menus;        // Spellsets.
   std::map<int, std::string> spellsets_map;     // Links menu IDs to spellset names.


### PR DESCRIPTION
- Bump to v1.1.0-beta1

- SpellBook wnd was not completely deactivating after swapping spells on horse which blocked spell casting. Switch to using Activate/Deactivate instead of directly toggling visibility.