### PR TITLE
v1.1.0-beta2 with non-mounted 3rd person lev fix

### DIFF
--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -7,7 +7,7 @@
 
 #include "framework.h"
 #include "game_addresses.h"
-#define ZEAL_VERSION "1.1.0-beta1"
+#define ZEAL_VERSION "1.1.0-beta2"
 #ifndef ZEAL_BUILD_VERSION               // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif

--- a/Zeal/camera_mods.cpp
+++ b/Zeal/camera_mods.cpp
@@ -277,16 +277,17 @@ void CameraMods::process_time_tick() {
     zeal_cam_yaw = self->Heading;
   }
 
-  // Allow keyboard control of zeal camera and self pitch.
+  // In Zeal camera mode, we allow some keyboard control of pitch.
+  if (kKeyDownStates[CMD_CENTER_VIEW]) zeal_cam_pitch = 0.f;  // Center to match client behavior.
+
+  // The self pitch is controlled to enhance control during levitation or swimming.
+  // - The client doesn't center the self pitch when center_view is pressed.
+  // - The current integrated self pitch isn't visible in 3rd person, so just cancel out
+  //   any integrated large pitch if an opposite direction key is pressed.
   auto pitch_self = get_pitch_control_entity();
-  if (kKeyDownStates[CMD_CENTER_VIEW]) {
-    zeal_cam_pitch = 0;
-    if (pitch_self) pitch_self->Pitch = 0;  // Center first-person pitch.
-  } else if (kKeyDownStates[CMD_PITCH_UP] || kKeyDownStates[CMD_PITCH_DOWN]) {
-    zeal_cam_pitch += (kKeyDownStates[CMD_PITCH_UP] ? -0.3f : +0.3f);
-    zeal_cam_pitch = std::clamp(zeal_cam_pitch, -89.9f, 89.9f);
-    if (pitch_self) pitch_self->Pitch = 0;  // Center first-person pitch for now.
-  }
+  if (pitch_self && (kKeyDownStates[CMD_CENTER_VIEW] || (kKeyDownStates[CMD_PITCH_UP] && pitch_self->Pitch < 0) ||
+                     (kKeyDownStates[CMD_PITCH_DOWN] && pitch_self->Pitch > 0)))
+    pitch_self->Pitch = 0.f;
 }
 
 void CameraMods::update_fps_sensitivity() {

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -602,13 +602,13 @@ typedef struct _GAMEITEMINFO : public GAMEITEMINFOBASE {
 
 struct ViewActor {
   /* 0x0000 */ DWORD Type;  // Checked if it is set to 0x18 in GetClickedActor()
-  /* 0x0004 */ DWORD Unknown0004;
-  /* 0x0008 */ DWORD Unknown0008;
+  /* 0x0004 */ DWORD Index;
+  /* 0x0008 */ DWORD Model;
   /* 0x000C */ DWORD Flags;  // Bit 0x40000000 = invisible
   /* 0x0010 */ Vec3 Position;
-  /* 0x001C */ DWORD Unknown001C;
-  /* 0x0020 */ DWORD Unknown0020;
-  /* 0x0024 */ DWORD Unknown0024;
+  /* 0x001C */ DWORD Heading;
+  /* 0x0020 */ DWORD Pitch;
+  /* 0x0024 */ DWORD Roll;
   /* 0x0028 */ DWORD RegionNumber;
   /* 0x002C */ struct _GAMEACTORCOLLISIONINFO *CollisionInfo;
   /* 0x0030 */ DWORD Unknown0030;
@@ -1101,7 +1101,7 @@ struct Entity {
   /* 0x0044 */ DWORD ZoneId;  // Game_ZONE_ID_x
   /* 0x0048 */ Vec3 Position;
   /* 0x0054 */ FLOAT Heading;  // camera view left/right, yaw
-  /* 0x0058 */ FLOAT Unk;
+  /* 0x0058 */ FLOAT ViewActorPitch;
   /* 0x005C */ FLOAT MovementSpeed;
   /* 0x0060 */ FLOAT MovementSpeedY;
   /* 0x0064 */ FLOAT MovementSpeedX;


### PR DESCRIPTION
- Bump to v1.1.0-beta2

- Fix the numpad pg up and pg down controls in third person so they adjust the internal pitch for going up or down during levitation and swimming (non-mounted only)
  - Note: This does not work on mounts where the client does not support first or third person lev/swimming pitch control.