### PR TITLE
Fix invisible cursor after left pan

### DIFF
--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -48,6 +48,7 @@ class CameraMods {
   bool ui_active = false;
 
   void synchronize_set_enable();
+  void callback_zone();
   void callback_main();
   void update_desired_zoom(float zoom);
   void set_zeal_cam_active(bool activate);


### PR DESCRIPTION
- Ensure the call to restore the hidden cursor during left panning is not skipped when zeal cam mode is disabled (such as left panning while zooming into first person)
- Also make the Zeal cam re-center behind person when zoning