### PR TITLE
Local AA Title Choice in Nameplate tab

### DIFF
--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -577,8 +577,23 @@ std::string NamePlate::generate_nameplate_text(const Zeal::GameStructures::Entit
     text += "Trader ";  // String id 0x157f.
 
   else if (entity.AlternateAdvancementRank > 0 && entity.Gender != 2 && should_show_title(show_name)) {
-    text += Zeal::Game::get_title_desc(entity.Class, entity.AlternateAdvancementRank, entity.Gender);
+    bool should_show_aa_title = true;
+    int display_rank = entity.AlternateAdvancementRank;
+
+    // Override for self if local AA title setting is active
+    if (&entity == Zeal::Game::get_self()) {
+      int choice = setting_local_aa_title.get();
+      if (choice == 0) {
+        should_show_aa_title = false;  // "Off" selected
+      } else if (choice > 0 && choice <= entity.AlternateAdvancementRank) {
+        display_rank = choice;
+      }
+    }
+
+    if (should_show_aa_title) {
+      text += Zeal::Game::get_title_desc(entity.Class, display_rank, entity.Gender);
     text += " ";
+    }
   }
 
   // Finally work on the primary player name with embellishments.

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -582,13 +582,8 @@ else if (entity.AlternateAdvancementRank > 0 && entity.Gender != 2 && should_sho
     int display_rank = entity.AlternateAdvancementRank;
 
     // For self, apply local AA title choice
-    if (&entity == Zeal::Game::get_self()) {
-      int choice = setting_local_aa_title.get();
-      if (choice == 0)
-        display_rank = 0;  // Signal to skip title
-      else
-        display_rank = min(entity.AlternateAdvancementRank, choice);
-    }
+    if (&entity == Zeal::Game::get_self())
+      display_rank = min(entity.AlternateAdvancementRank, setting_local_aa_title.get());
 
     if (display_rank > 0) {
       text += Zeal::Game::get_title_desc(entity.Class, display_rank, entity.Gender);

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -1,5 +1,7 @@
 #include "nameplate.h"
 
+#include <algorithm>
+
 #include "game_addresses.h"
 #include "string_util.h"
 #include "zeal.h"
@@ -576,23 +578,21 @@ std::string NamePlate::generate_nameplate_text(const Zeal::GameStructures::Entit
   if (entity.ActorInfo->IsTrader == 1 && Zeal::Game::get_self() && Zeal::Game::get_self()->ZoneId == 0x97)
     text += "Trader ";  // String id 0x157f.
 
-  else if (entity.AlternateAdvancementRank > 0 && entity.Gender != 2 && should_show_title(show_name)) {
-    bool should_show_aa_title = true;
+else if (entity.AlternateAdvancementRank > 0 && entity.Gender != 2 && should_show_title(show_name)) {
     int display_rank = entity.AlternateAdvancementRank;
 
-    // Override for self if local AA title setting is active
+    // For self, apply local AA title choice
     if (&entity == Zeal::Game::get_self()) {
       int choice = setting_local_aa_title.get();
-      if (choice == 0) {
-        should_show_aa_title = false;  // "Off" selected
-      } else if (choice > 0 && choice <= entity.AlternateAdvancementRank) {
-        display_rank = choice;
-      }
+      if (choice == 0)
+        display_rank = 0;  // Signal to skip title
+      else
+        display_rank = min(entity.AlternateAdvancementRank, choice);
     }
 
-    if (should_show_aa_title) {
+    if (display_rank > 0) {
       text += Zeal::Game::get_title_desc(entity.Class, display_rank, entity.Gender);
-    text += " ";
+      text += " ";
     }
   }
 

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -72,7 +72,7 @@ class NamePlate {
                                                   },
                                                   true};
   // Local AA Title Choice
-  ZealSetting<int> setting_local_aa_title = {0, "Zeal", "NameplateLocalAATitle", true};
+  ZealSetting<int> setting_local_aa_title = {3, "Zeal", "NameplateLocalAATitle", true};
 
   // Advanced fonts
   ZealSetting<bool> setting_health_bars = {false, "Zeal", "NameplateHealthBars", false};

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -71,6 +71,8 @@ class NamePlate {
                                                     }
                                                   },
                                                   true};
+  // Local AA Title Choice
+  ZealSetting<int> setting_local_aa_title = {0, "Zeal", "NameplateLocalAATitle", true};
 
   // Advanced fonts
   ZealSetting<bool> setting_health_bars = {false, "Zeal", "NameplateHealthBars", false};

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -35,20 +35,6 @@ int Shownames_Combobox_dropdown() {
   return names_enabled ? current_shownames : 0;
 }
 
-int LocalAATitleChoice_Combobox_dropdown() {
-  int current_choice = ZealService::get_instance()->nameplate->setting_local_aa_title.get();
-  auto self = Zeal::Game::get_self();
-  int max_choice = 0;
-
-  if (self) {
-    // Clamp max_choice to 3 or player's AA rank, whichever is smaller
-    max_choice = (self->AlternateAdvancementRank > 3) ? 3 : (int)self->AlternateAdvancementRank;
-  }
-
-  // Clamp current_choice to valid range based on current AA rank
-  return (current_choice > max_choice) ? max_choice : current_choice;
-}
-
 void ui_options::PlayTellSound() const {
   // For now at least just copy the same sound list from invites. A future goal is to
   // support custom wave sounds for tells.
@@ -901,12 +887,6 @@ void ui_options::InitNameplate() {
   });
 
   ui->AddComboCallback(wnd, "Zeal_NameplateLocalAATitle_Combobox", [this](Zeal::GameUI::BasicWnd *wnd, int value) {
-    auto self = Zeal::Game::get_self();
-    if (self) {
-      // Clamp selection to available AA ranks
-      int max_choice = (self->AlternateAdvancementRank > 3) ? 3 : (int)self->AlternateAdvancementRank;
-      value = (value > max_choice) ? max_choice : value;
-    }
     ZealService::get_instance()->nameplate->setting_local_aa_title.set(value);
   });
 }
@@ -1104,8 +1084,8 @@ void ui_options::UpdateOptionsNameplate() {
   int shownames_dropdown_value = Shownames_Combobox_dropdown();
   ui->SetComboValue("Zeal_NameplateShownames_Combobox", shownames_dropdown_value);
 
-  int local_aa_title_choice_dropdown_value = LocalAATitleChoice_Combobox_dropdown();
-  ui->SetComboValue("Zeal_NameplateLocalAATitle_Combobox", local_aa_title_choice_dropdown_value);
+  ui->SetComboValue("Zeal_NameplateLocalAATitle_Combobox",
+                    ZealService::get_instance()->nameplate->setting_local_aa_title.get());
 }
 
 void ui_options::UpdateOptionsFloatingDamage() {
@@ -1274,21 +1254,9 @@ void ui_options::UpdateDynamicUI() {
   if (cmb) {
     cmb->DeleteAll();
 
-    auto self = Zeal::Game::get_self();
-    int max_aa_rank = self ? self->AlternateAdvancementRank : 0;
-
-    std::vector<std::string> choices = {"Off"};
-    if (max_aa_rank >= 1) choices.push_back("General");
-    if (max_aa_rank >= 2) choices.push_back("Archetype");
-    if (max_aa_rank >= 3) choices.push_back("Class");
-
+    // Static choices - always show all options
+    std::vector<std::string> choices = {"Off", "General", "Archetype", "Class"};
     ZealService::get_instance()->ui->AddListItems(cmb, choices);
-
-    // Set the current selection after populating
-    int current_choice = ZealService::get_instance()->nameplate->setting_local_aa_title.get();
-    int max_choice = (max_aa_rank > 3) ? 3 : max_aa_rank;
-    current_choice = (current_choice > max_choice) ? max_choice : current_choice;
-    cmb->SetChoice(current_choice);
   }
 }
 

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -316,6 +316,50 @@
     <Style_Border>true</Style_Border>
     <Choices>Off</Choices>
   </Combobox>
+<!-- Local AA Title Label -->
+  <Label item="Zeal_NameplateLocalAATitle_Label">
+    <ScreenID>Zeal_NameplateLocalAATitle_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>268</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Local AA Title Choice</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <!-- Local AA Title Combobox -->
+  <Combobox item="Zeal_NameplateLocalAATitle_Combobox">
+    <ScreenID>Zeal_NameplateLocalAATitle_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>10</X>
+      <Y>284</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>140</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>Off</Choices>
+  </Combobox>
   <Button item="Zeal_NameplateTargetColor">
     <ScreenID>Zeal_NameplateTargetColor</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -668,6 +712,8 @@
     <Pieces>Zeal_NameplateExtended</Pieces>
     <Pieces>Zeal_NameplateShownames_Label</Pieces>
     <Pieces>Zeal_NameplateShownames_Combobox</Pieces>
+    <Pieces>Zeal_NameplateLocalAATitle_Label</Pieces>
+    <Pieces>Zeal_NameplateLocalAATitle_Combobox</Pieces>
     <Pieces>Zeal_NameplateInlineGuild</Pieces>
     <Pieces>Zeal_NameplateTargetColor</Pieces>
     <Pieces>Zeal_NameplateTargetMarker</Pieces>


### PR DESCRIPTION
Gives the Player the option in Nameplate tab to choose their AA title as long as they have appropriate AA rank.  This is only displayed locally on a player's own screen and does not propogate to the server