### PR TITLE
Bump to v1.1.0 official

### DIFF
--- a/Zeal/Zeal.h
+++ b/Zeal/Zeal.h
@@ -7,7 +7,7 @@
 
 #include "framework.h"
 #include "game_addresses.h"
-#define ZEAL_VERSION "1.1.0-beta3"
+#define ZEAL_VERSION "1.1.0"
 #ifndef ZEAL_BUILD_VERSION               // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif

--- a/Zeal/camera_mods.cpp
+++ b/Zeal/camera_mods.cpp
@@ -326,7 +326,7 @@ void CameraMods::update_fps_sensitivity() {
 void CameraMods::callback_zone() {
   if (Zeal::Game::get_controlled()) {
     zeal_cam_yaw = Zeal::Game::get_controlled()->Heading;
-    zeal_cam_pitch = camera_math::pitch_to_normal(get_pitch_control_entity()->Pitch);
+    zeal_cam_pitch = 0;  // First person pitch is not reset on zoning.
   }
   if (desired_zoom > 0) {
     desired_zoom = std::clamp(desired_zoom, min_zoom_in, max_zoom_out);

--- a/Zeal/crash_handler.cpp
+++ b/Zeal/crash_handler.cpp
@@ -265,7 +265,8 @@ void WriteMiniDump(EXCEPTION_POINTERS *pep, const std::string &reason, const std
   std::string CrashFileName = ZipCrash(folderName, dumpFilePath, reasonFilePath);
 
   // Trigger optional crash sender.
-  HandleCrashSender(pep, CrashFileName, reasonStream.str());
+  // Note: Disabled to avoid using crashsender.exe versions installed by earlier Zeal versions.
+  // HandleCrashSender(pep, CrashFileName, reasonStream.str());
 }
 
 void ShowCrashLoopDialog(PEXCEPTION_POINTERS pep) {

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -278,7 +278,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>230</Y>
+      <Y>234</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -300,7 +300,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>248</Y>
+      <Y>254</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -322,7 +322,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>10</X>
-      <Y>268</Y>
+      <Y>289</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -344,7 +344,7 @@
     <DrawTemplate>WDT_Inner</DrawTemplate>
     <Location>
       <X>10</X>
-      <Y>284</Y>
+      <Y>309</Y>
     </Location>
     <Size>
       <CX>150</CX>


### PR DESCRIPTION
- Fixed ZealCam pitch to reset to zero (not character first person pitch) upon zoning
- Disabled invocation of deprecrated crashsender executable for legacy installs with it still around
- Tweaked nameplate ui combobox spacing