### PR TITLE
Fix strip_name crash, reset zeal camera on summon

### DIFF
--- a/Zeal/callbacks.cpp
+++ b/Zeal/callbacks.cpp
@@ -266,7 +266,7 @@ void CallbackManager::invoke_ReportSuccessfulHit(Zeal::Packets::Damage_Struct *d
   Zeal::GameStructures::Entity *target = em->Get(dmg->target);
   Zeal::GameStructures::Entity *source = em->Get(dmg->source);
   if (target && source) {
-    for (auto &fn : ReportSuccessfulHit_functions)
+    for (const auto &fn : ReportSuccessfulHit_functions)
       fn(source, target, dmg->type, dmg->spellid, dmg->damage, output_text);
   }
 }

--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -52,12 +52,14 @@ class CameraMods {
   float sensitivity_y = 0.4f;
   std::chrono::steady_clock::time_point lastTime;
   bool ui_active = false;
+  bool reset_camera = false;  // Allows for a deferred reset of zeal cam.
 
   void synchronize_set_enable();
   void synchronize_old_ui();
   void handle_toggle_cam();
   void callback_zone();
   void callback_main();
+  bool callback_packet(UINT opcode, char *buffer, UINT len);
   void update_desired_zoom(float zoom);
   void set_zeal_cam_active(bool activate);
   bool is_zeal_cam_active() const;

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -43,6 +43,8 @@ class chatfilter {
   void AddOutputText(Zeal::GameUI::ChatWnd *&wnd, std::string msg, short &channel);
   void LoadSettings(Zeal::GameUI::CChatManager *cm);
   void callback_clean_ui();
+  void callback_hit(Zeal::GameStructures::Entity *source, Zeal::GameStructures::Entity *target, WORD type,
+                    short spell_id, short damage, char output_text);
   ZealSetting<bool> setting_suppress_missed_notes = {false, "Zeal", "SuppressMissedNotes", false};
   ZealSetting<bool> setting_suppress_other_fizzles = {false, "Zeal", "SupressOtherFizzles", false};
   bool isExtendedCM(int channelMap, int applyOffset = 0);

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -529,7 +529,7 @@ const char *strip_name(const char *name)  // aka stripName in client
 {
   // Returns a pointer to a modified name stored in a 64-entry global circular buffer. Does not increment buffer index.
   // Strips any numbers and any text after an apostrophe.  Use for name's corpse123 => name.
-  if (name == NULL) return (const char *)"";
+  if (name == nullptr) return "";
   return Zeal::Game::get_game()->stripName(name);
 }
 

--- a/Zeal/game_packets.h
+++ b/Zeal/game_packets.h
@@ -17,6 +17,7 @@ enum opcodes {
   Animation = 0x40a1,
   Assist = 0x4200,
   Stamina = 0x4157,
+  RequestClientZoneChange = 0x414d,
   ItemLinkResponse = 0x4264
 };
 

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -1104,7 +1104,7 @@ struct GameClass {
   }
 
   char *stripName(const char *spawn_name) {
-    return reinterpret_cast<char *(__thiscall *)(GameClass *, const char *)>(0x00537f99)(this, spawn_name);
+    return reinterpret_cast<char *(__thiscall *)(GameClass *, const char *)>(0x00537E4B)(this, spawn_name);
   }
 
   char *trimName(const char *spawn_name) {


### PR DESCRIPTION
- Fixed a strip_name (copy and paste adddress error) crash introduced during 1.2 refactor

- Cleaned up some related code while tracking down the crash

- A RequestClientZoneChange will now trigger a reset of the zeal camera parameters (same as a normal zone event)
  - This happens when summoned