### PR TITLE
Refactor initialization sequence

### DIFF
--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -1,19 +1,11 @@
 #include "binds.h"
 
-#include "autofire.h"
-#include "cycle_target.h"
+#include "callbacks.h"
 #include "game_addresses.h"
 #include "game_functions.h"
 #include "game_structures.h"
 #include "hook_wrapper.h"
-#include "item_display.h"
-#include "nameplate.h"
-#include "netstat.h"
-#include "player_movement.h"
-#include "tellwindows.h"
-#include "ui_manager.h"
 #include "zeal.h"
-#include "zone_map.h"
 
 Binds::~Binds() {}
 
@@ -39,12 +31,11 @@ bool Binds::execute_cmd(unsigned int cmd, bool isdown) {
   return false;
 }
 
-void __fastcall InitKeyboardAssignments(int t, int unused) {
+void __fastcall InitKeyboardAssignments(void *options_window, int unused) {
   ZealService *zeal = ZealService::get_instance();
-  zeal->binds_hook->ptr_binds = t;
-  zeal->binds_hook->add_binds();
+  zeal->binds_hook->initialize_options_with_keybinds(options_window);
   zeal->binds_hook->read_ini();
-  zeal->hooks->hook_map["initbinds"]->original(InitKeyboardAssignments)(t, unused);
+  zeal->hooks->hook_map["InitKeyboardAssignments"]->original(InitKeyboardAssignments)(options_window, unused);
 }
 
 UINT32 read_internal_from_ini(int index, int key_type) {
@@ -77,380 +68,30 @@ void Binds::read_ini() {
   }
 }
 
-static void cycle_targets(int key_down, Zeal::GameEnums::EntityTypes type) {
-  if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-    Zeal::GameStructures::Entity *ent = ZealService::get_instance()->cycle_target->get_next_ent(250, type);
-    if (ent) Zeal::Game::set_target(ent);
-  }
-}
-
-void Binds::basic_binds() {
-  replace_cmd(28, [this](int state) {
-    if (state && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::GameStructures::Entity *ent = ZealService::get_instance()->cycle_target->get_nearest_ent(250, 0);
-      if (ent) Zeal::Game::set_target(ent);
-    }
-    return true;
-  });  // nearest pc
-  replace_cmd(29, [this](int state) {
-    if (state && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::GameStructures::Entity *ent = ZealService::get_instance()->cycle_target->get_nearest_ent(250, 1);
-      if (ent) Zeal::Game::set_target(ent);
-    }
-    return true;
-  });  // nearest npc
-  replace_cmd(3, [this](int state) {
-    ZealService::get_instance()->movement->handle_movement_binds(3, state);
-    return false;
-  });  // foward
-
-  replace_cmd(4, [this](int state) {
-    ZealService::get_instance()->movement->handle_movement_binds(4, state);
-    return false;
-  });  // back
-
-  replace_cmd(5, [this](int state) {
-    ZealService::get_instance()->movement->handle_movement_binds(5, state);
-    return false;
-  });  // turn right
-
-  replace_cmd(6, [this](int state) {
-    ZealService::get_instance()->movement->handle_movement_binds(6, state);
-    return false;
-  });  // turn left
-
-  replace_cmd(30, [this](int state) {
-    ZealService::get_instance()->netstat->toggle_netstat(state);
-    return false;
-  });
-
-  for (int bind_index = 51; bind_index < 59; ++bind_index) {
-    replace_cmd(bind_index, [this, bind_index](int state) {
-      ZealService::get_instance()->movement->handle_spellcast_binds(bind_index);
-      return false;
-    });  // spellcasting auto-stand
-  }
-
-  replace_cmd(0xC8, [this](int state) {
-    auto zeal = ZealService::get_instance();
-    if (zeal->ui && zeal->ui->inputDialog && zeal->ui->inputDialog->isVisible()) {
-      zeal->ui->inputDialog->hide();
-      return true;
-    }
-    if (Zeal::Game::get_target()) {
-      Zeal::Game::set_target(0);
-      return true;
-    }
-
-    if (!zeal->ini->getValue<bool>("Zeal", "EscapeRaidLock")) {
-      if (Zeal::Game::Windows && Zeal::Game::Windows->RaidOptions && Zeal::Game::Windows->RaidOptions->IsVisible) {
-        Zeal::Game::Windows->RaidOptions->show(0, false);
-        return true;
-      }
-      if (Zeal::Game::Windows && Zeal::Game::Windows->Raid && Zeal::Game::Windows->Raid->IsVisible) {
-        Zeal::Game::execute_cmd(109, 1, 0);
-        Zeal::Game::execute_cmd(109, 0, 0);
-        return true;
-      }
-    }
-
-    if (zeal->ini->getValue<bool>("Zeal", "Escape"))  // toggle is set to not close any windows
-      return true;
-
-    if (zeal->item_displays && zeal->item_displays->close_latest_window()) return true;
-
-    return false;
-  });  // handle escape
-}
-
-void Binds::add_binds() {
-  // just start binds at 211 to avoid overwriting any existing cmd/bind
-  add_bind(211, "Strafe Left", "StrafeLeft", key_category::Movement, [this](int key_down) {});    // stub
-  add_bind(212, "Strafe Right", "StrafeRight", key_category::Movement, [this](int key_down) {});  // stub
-  add_bind(213, "Cycle through nearest NPCs", "CycleTargetNPC", key_category::Target,
-           [](int key_down) { cycle_targets(key_down, Zeal::GameEnums::NPC); });
-  add_bind(214, "Cycle through nearest PCs", "CycleTargetPC", key_category::Target,
-           [](int key_down) { cycle_targets(key_down, Zeal::GameEnums::Player); });
-  add_bind(
-      215, "Toggle all containers", "OpenCloseContainers", key_category::UI | key_category::Commands, [](int key_down) {
-        if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-          Zeal::GameStructures::Entity *self = Zeal::Game::get_self();
-          std::vector<std::pair<Zeal::GameStructures::_GAMEITEMINFO *, int>> containers;
-          std::vector<Zeal::GameStructures::_GAMEITEMINFO *> opened_containers;  // don't need an index to close
-          for (int i = 0; i < 8; i++)                                            // 8 inventory slots for containers
-          {
-            Zeal::GameStructures::_GAMEITEMINFO *item = self->CharInfo->InventoryPackItem[i];
-            if (item && item->Type == 1 && item->Container.Capacity > 0) {
-              containers.push_back({item, i});
-              if (item->Container.IsOpen) opened_containers.push_back(item);
-            }
-          }
-          if (opened_containers.size() == containers.size())  // all the containers are open..
-          {
-            Zeal::Game::GameInternal::CloseAllContainers(*Zeal::Game::ptr_ContainerMgr, 0);
-          } else {
-            for (auto &[c, index] : containers) {
-              if (!c->Container.IsOpen)
-                Zeal::Game::GameInternal::OpenContainer(*Zeal::Game::ptr_ContainerMgr, 0, (int)&c->Name, 22 + index);
-            }
-          }
-        }
-      });
-  add_bind(216, "Toggle last two targets", "ToggleLastTwo", key_category::Target, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::GameStructures::Entity *target = Zeal::Game::get_target();
-      if (target) {
-        if (last_targets.first == target->SpawnId && last_targets.second != 0) {
-          Zeal::GameStructures::Entity *ent = Zeal::Game::get_entity_by_id(last_targets.second);
-          if (ent) Zeal::Game::set_target(ent);
-        }
-      } else {
-        if (last_targets.first != 0) {
-          Zeal::GameStructures::Entity *ent = Zeal::Game::get_entity_by_id(last_targets.first);
-          if (ent) Zeal::Game::set_target(ent);
-        }
-      }
-    }
-  });
-  add_bind(217, "Reply Target", "ReplyTarget", key_category::Target, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::Game::GameInternal::ReplyTarget(Zeal::Game::get_self(), "");
-    }
-  });
-  add_bind(218, "Pet Attack", "PetAttack", key_category::Commands,
-           [this](int key_down) {  // probably need to add a check if you have a pet
-             if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-               Zeal::GameStructures::Entity *target = Zeal::Game::get_target();
-               if (target) Zeal::Game::pet_command(Zeal::GameEnums::PetCommand::Attack, target->SpawnId);
-             }
-           });
-  add_bind(219, "Pet Guard", "PetGuard", key_category::Commands, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::Game::pet_command(Zeal::GameEnums::PetCommand::Guard, 0);
-    }
-  });
-  add_bind(220, "Pet Back", "PetBack", key_category::Commands, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::Game::pet_command(Zeal::GameEnums::PetCommand::Back, 0);
-    }
-  });
-  add_bind(221, "Pet Follow", "PetFollow", key_category::Commands, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::Game::pet_command(Zeal::GameEnums::PetCommand::Follow, 0);
-    }
-  });
-  add_bind(222, "Pet Sit", "PetSit", key_category::Commands, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::Game::pet_command(Zeal::GameEnums::PetCommand::Sit, 0);
-    }
-  });
-  add_bind(223, "Slow Turn Right", "SlowMoveRight", key_category::Movement, [this](int key_down) {
-    if (!Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::Game::execute_cmd(5, key_down, 0);
-      if (key_down) {
-        mem::write<BYTE>(0x53fb60, 4);
-        mem::write<BYTE>(0x53fb66, 4);
-      } else {
-        if (*(BYTE *)0x53fb60 != 12) {
-          mem::write<BYTE>(0x53fb60, 12);
-          mem::write<BYTE>(0x53fb66, 12);
-        }
-      }
-    }
-  });
-  add_bind(224, "Slow Turn Left", "SlowMoveLeft", key_category::Movement, [this](int key_down) {
-    if (!Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::Game::execute_cmd(6, key_down, 0);
-      if (key_down) {
-        mem::write<BYTE>(0x53f758, 4);
-        mem::write<BYTE>(0x53f75E, 4);
-      } else {
-        if (*(BYTE *)0x53f758 != 12) {
-          mem::write<BYTE>(0x53f758, 12);
-          mem::write<BYTE>(0x53f75E, 12);
-        }
-      }
-    }
-  });
-  add_bind(225, "Auto Fire", "AutoFire", key_category::Commands, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->autofire->SetAutoFire(!ZealService::get_instance()->autofire->autofire, true);
-    }
-  });
-  add_bind(226, "Target Nearest NPC Corpse", "TargetNPCCorpse", key_category::Target, [](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::GameStructures::Entity *ent = ZealService::get_instance()->cycle_target->get_nearest_ent(250, 2);
-      if (ent) Zeal::Game::set_target(ent);
-    }
-  });
-  add_bind(227, "Target Nearest PC Corpse", "TargetPCCorpse", key_category::Target, [](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      Zeal::GameStructures::Entity *ent = ZealService::get_instance()->cycle_target->get_nearest_ent(250, 3);
-      if (ent) Zeal::Game::set_target(ent);
-    }
-  });
-  add_bind(228, "Toggle Map", "ToggleMap", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->set_enabled(!ZealService::get_instance()->zone_map->is_enabled());
-    }
-  });
-  add_bind(229, "Toggle Map Background", "ToggleMapBackground", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->toggle_background();
-    }
-  });
-  add_bind(230, "Toggle Map Zoom", "ToggleMapZoom", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->toggle_zoom();
-    }
-  });
-  add_bind(231, "Toggle Map Labels", "ToggleMapLabels", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->toggle_labels();
-    }
-  });
-  add_bind(232, "Toggle Map Level Up", "ToggleMapLevelUp", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->toggle_level_up();
-    }
-  });
-  add_bind(233, "Toggle Map Level Down", "ToggleMapLevelDown", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->toggle_level_down();
-    }
-  });
-  add_bind(234, "Toggle Map Show Raid", "ToggleMapShowRaid", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->set_show_raid(
-          !ZealService::get_instance()->zone_map->is_show_raid_enabled(), false);
-    }
-  });
-  add_bind(235, "Toggle Nameplate Colors", "ToggleNameplateColors", key_category::Target, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->nameplate->setting_colors.toggle(false);
-  });
-  add_bind(236, "Toggle Nameplate Con Colors", "ToggleNameplateConColors", key_category::Target, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->nameplate->setting_con_colors.toggle(false);
-  });
-  add_bind(237, "Toggle Map Member Names", "FlashMapMemberNames", key_category::UI, [this](int key_down) {
-    // Left the short name as "Flash" to stay consistent with previous keybinds.
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      ZealService::get_instance()->zone_map->set_show_all_names_override(
-          !ZealService::get_instance()->zone_map->is_show_all_names_override());
-    }
-  });
-  add_bind(238, "Toggle Nameplate Self", "ToggleNameplateSelf", key_category::Target, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->nameplate->setting_hide_self.toggle(false);
-  });
-  add_bind(239, "Toggle Nameplate Self as X", "ToggleNameplateX", key_category::Target, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->nameplate->setting_x.toggle(false);
-  });
-  add_bind(240, "Toggle Nameplate Raid Pets", "ToggleNameplateRaidPets", key_category::Target, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->nameplate->setting_hide_raid_pets.toggle(false);
-  });
-  add_bind(241, "Toggle Map Grid Lines", "ToggleMapGridLines", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->zone_map->set_show_grid(
-          !ZealService::get_instance()->zone_map->is_show_grid_enabled(), false);
-  });
-  add_bind(242, "Toggle Map Interactive Mode", "ToggleMapInteractiveMode", key_category::UI, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->zone_map->set_interactive_enable(
-          !ZealService::get_instance()->zone_map->is_interactive_enabled(), false);
-  });
-  add_bind(243, "Cycle through near PC corpses", "CycleTargetPCCorpses", key_category::Target,
-           [](int key_down) { cycle_targets(key_down, Zeal::GameEnums::PlayerCorpse); });
-  add_bind(244, "Buy/Sell Stack", "BuySell", key_category::UI, [](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
-      if (Zeal::Game::is_in_game() && Zeal::Game::Windows && Zeal::Game::Windows->Merchant &&
-          Zeal::Game::Windows->Merchant->IsVisible) {
-        Zeal::GameUI::CXWndManager *wnd_mgr = Zeal::Game::get_wnd_manager();
-        if (!wnd_mgr) return;
-        DWORD selected_slot = Zeal::Game::Windows->Merchant->InventoryItemSlot;
-        if (selected_slot >= 6000 && selected_slot < 6080) {
-          // Buying an item
-          if (!Zeal::Game::Windows->Merchant->BuyButton || !Zeal::Game::Windows->Merchant->BuyButton->IsEnabled) return;
-        } else {
-          // Selling an Item
-          if (!Zeal::Game::Windows->Merchant->SellButton || !Zeal::Game::Windows->Merchant->SellButton->IsEnabled)
-            return;
-        }
-        BYTE shift = wnd_mgr->ShiftKeyState;
-        BYTE ctrl = wnd_mgr->ControlKeyState;
-        BYTE alt = wnd_mgr->AltKeyState;
-        wnd_mgr->ShiftKeyState = 1;
-        wnd_mgr->ControlKeyState = 0;
-        wnd_mgr->AltKeyState = 0;
-        int quantity = -1;
-        Zeal::Game::Windows->Merchant->WndNotification((int)Zeal::Game::Windows->Merchant, 29, (int)&quantity);
-        wnd_mgr->ShiftKeyState = shift;
-        wnd_mgr->ControlKeyState = ctrl;
-        wnd_mgr->AltKeyState = alt;
-      }
-    }
-  });
-  add_bind(245, "Close all tell windows", "CloseAllTellWindows", key_category::Chat, [](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      ZealService::get_instance()->tells->CloseAllWindows();
-  });
-  add_bind(246, "Loot target", "LootTarget", key_category::Commands, [](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      reinterpret_cast<void (*)(void)>(0x004fb5ae)();  // do_loot().
-  });
-  add_bind(247, "Pet Health", "PetHealth", key_category::Commands, [this](int key_down) {
-    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
-      Zeal::Game::pet_command(Zeal::GameEnums::PetCommand::Health, 0);
-  });
-  add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros, [](int key_down) {
-    if (key_down) {
-      if (Zeal::Game::can_inventory_item(Zeal::Game::get_char_info()->CursorItem)) {
-        Zeal::Game::GameInternal::auto_inventory(Zeal::Game::get_char_info(), &Zeal::Game::get_char_info()->CursorItem,
-                                                 0);
-      } else {
-        if (Zeal::Game::get_char_info()->CursorItem)
-          Zeal::Game::print_chat(USERCOLOR_LOOT, "Cannot auto inventory %s",
-                                 Zeal::Game::get_char_info()->CursorItem->Name);
-      }
-    }
-  });
-}
-
+// Loads the internal cache with the custom keybind for later initialization.
 void Binds::add_bind(int cmd, const char *name, const char *short_name, key_category category,
                      std::function<void(int state)> callback) {
-  char *str = new char[64];
-  strcpy_s(str, 64, short_name);
-  KeyMapNames[cmd] = str;
-
-  int options = ZealService::get_instance()->binds_hook->ptr_binds;
-  if (!options) return;
-  Zeal::Game::GameInternal::InitKeyBindStr((options + cmd * 0x8 + 0x20c), 0, (char *)name);
-  *(int *)((options + cmd * 0x8 + 0x210)) = (int)category;
+  if (cmd < 0 || cmd >= kNumBinds) return;
+  strcpy_s(KeyMapNamesBuffer[cmd], kNameBufferSize, short_name);
+  KeyMapNames[cmd] = KeyMapNamesBuffer[cmd];
+  KeyMapCategories[cmd] = static_cast<int>(category);
   KeyMapFunctions[cmd] = callback;
+}
+
+void Binds::initialize_options_with_keybinds(void *options_window) {
+  int options = reinterpret_cast<int>(options_window);  // TODO: Add an OptionsWindow class.
+  for (int cmd = 0; cmd < kNumBinds; ++cmd) {
+    if (KeyMapNames[cmd] == nullptr || !KeyMapFunctions.count(cmd)) continue;  // Empty, skip.
+    Zeal::Game::GameInternal::InitKeyBindStr((options + cmd * 0x8 + 0x20c), 0, KeyMapNames[cmd]);
+    *(int *)((options + cmd * 0x8 + 0x210)) = KeyMapCategories[cmd];
+  }
 }
 
 void Binds::replace_cmd(int cmd, std::function<bool(int state)> callback) {
   ReplacementFunctions[cmd].push_back(callback);
 }
 
-void Binds::main_loop() {
-  if (Zeal::Game::get_target() && Zeal::Game::get_target()->SpawnId != last_targets.first) {
-    last_targets.second = last_targets.first;
-    last_targets.first = Zeal::Game::get_target()->SpawnId;
-  }
-}
-
-void Binds::on_zone() {
-  last_targets.first = 0;
-  last_targets.second = 0;
-}
-
 Binds::Binds(ZealService *zeal) {
-  zeal->callbacks->AddGeneric([this]() { main_loop(); }, callback_type::MainLoop);
-  zeal->callbacks->AddGeneric([this]() { on_zone(); }, callback_type::Zone);
   zeal->callbacks->AddCommand([this](UINT opcode, bool state) { return execute_cmd(opcode, state); },
                               callback_type::ExecuteCmd);
   for (int i = 0; i < 128; i++)
@@ -458,12 +99,10 @@ Binds::Binds(ZealService *zeal) {
   mem::write(0x52507A, (int)KeyMapNames);             // write ini keymap
   mem::write(0x5254D9, (int)KeyMapNames);             // clear ini keymap
   mem::write(0x525544, (int)KeyMapNames);             // read ini keymap
-  mem::write(0x42C52F, (byte)0xEB);  // remove the check for max index of 116 being stored in client ini
+  mem::write(0x42C52F, (BYTE)0xEB);  // remove the check for max index of 116 being stored in client ini
   mem::write(0x52485A, (int)256);    // increase this for loop to look through all 256
   mem::write(0x52591C,
              (int)(Zeal::Game::ptr_AlternateKeyMap + (256 * 4)));  // fix another for loop to loop through all 256
-  zeal->hooks->Add("initbinds", Zeal::Game::GameInternal::fn_initkeyboardassignments, InitKeyboardAssignments,
-                   hook_type_detour);
-
-  basic_binds();  // Configure basic binds.
+  zeal->hooks->Add("InitKeyboardAssignments", Zeal::Game::GameInternal::fn_initkeyboardassignments,
+                   InitKeyboardAssignments, hook_type_detour);
 }

--- a/Zeal/binds.h
+++ b/Zeal/binds.h
@@ -23,20 +23,19 @@ class Binds {
  public:
   Binds(class ZealService *zeal);
   ~Binds();
-  char *KeyMapNames[256] = {0};
-  int ptr_binds = 0;
+
+  static constexpr int kNumBinds = 256;
+  static constexpr int kNameBufferSize = 64;
+  char *KeyMapNames[kNumBinds] = {0};
+  char KeyMapNamesBuffer[kNumBinds][kNameBufferSize] = {0};
+  int KeyMapCategories[kNumBinds] = {0};
   std::unordered_map<int, std::function<void(int state)>> KeyMapFunctions;
   std::unordered_map<int, std::vector<std::function<bool(int state)>>> ReplacementFunctions;
-  std::pair<int, int> last_targets;
+
   void read_ini();
-  void add_binds();
+  void initialize_options_with_keybinds(void *options_window);
   void add_bind(int index, const char *name, const char *short_name, key_category category,
                 std::function<void(int state)> callback);
   void replace_cmd(int cmd, std::function<bool(int state)> callback);
-  void main_loop();
-  void on_zone();
   bool execute_cmd(unsigned int opcode, bool state);
-
- private:
-  void basic_binds();
 };

--- a/Zeal/callbacks.cpp
+++ b/Zeal/callbacks.cpp
@@ -1,7 +1,5 @@
 #include "callbacks.h"
 
-#include "chatfilter.h"
-#include "entity_manager.h"
 #include "game_addresses.h"
 #include "game_functions.h"
 #include "game_packets.h"
@@ -263,8 +261,8 @@ void CallbackManager::AddReportSuccessfulHit(
 
 void CallbackManager::invoke_ReportSuccessfulHit(Zeal::Packets::Damage_Struct *dmg, char output_text) {
   auto em = ZealService::get_instance()->entity_manager.get();
-  Zeal::GameStructures::Entity *target = em->Get(dmg->target);
-  Zeal::GameStructures::Entity *source = em->Get(dmg->source);
+  Zeal::GameStructures::Entity *target = Zeal::Game::get_entity_by_id(dmg->target);
+  Zeal::GameStructures::Entity *source = Zeal::Game::get_entity_by_id(dmg->source);
   if (target && source) {
     for (const auto &fn : ReportSuccessfulHit_functions)
       fn(source, target, dmg->type, dmg->spellid, dmg->damage, output_text);
@@ -276,10 +274,7 @@ static void __fastcall ReportSuccessfulHit(int t, int u, Zeal::Packets::Damage_S
   ZealService::get_instance()->callbacks->invoke_ReportSuccessfulHit(dmg, output_text);
   ZealService::get_instance()->hooks->hook_map["ReportSuccessfulHit"]->original(ReportSuccessfulHit)(
       t, u, dmg, output_text, always_zero);
-  chatfilter *cf = ZealService::get_instance()->chatfilter_hook.get();
-  if (cf) {
-    cf->isDamage = false;
-  }
+  ZealService::get_instance()->callbacks->invoke_generic(callback_type::ReportSuccessfulHitPost);
 }
 
 void DeactivateMainUI() {

--- a/Zeal/callbacks.h
+++ b/Zeal/callbacks.h
@@ -29,7 +29,8 @@ enum class callback_type {
   EntitySpawn,
   EntityDespawn,
   AddOutputText,
-  ReportSuccessfulHit,
+  ReportSuccessfulHit,      // Generic not implemented. Use AddReportSuccessfulHit().
+  ReportSuccessfulHitPost,  // Generic notification after client hooked call executes.
   DeactivateUI,
   CharacterSelectLoop,
   InitCharSelectUI

--- a/Zeal/camera_mods.cpp
+++ b/Zeal/camera_mods.cpp
@@ -12,7 +12,6 @@
 #include "game_structures.h"
 #include "hook_wrapper.h"
 #include "string_util.h"
-#include "ui_manager.h"
 #include "zeal.h"
 
 // #define debug_cam
@@ -212,8 +211,7 @@ void CameraMods::synchronize_set_enable() {
   set_zeal_cam_active(get_camera_view() == Zeal::GameEnums::CameraView::ZealCam);
 
   auto zeal = ZealService::get_instance();
-  if (zeal->ui && zeal->ui->options)
-    ZealService::get_instance()->ui->options->UpdateOptions();  // Can be called by command line.
+  if (update_options_ui_callback) update_options_ui_callback();  // Handle command line updates.
 }
 
 // Interpolate zoom is called repeatedly in main_callback(). The alpha coefficient below acts as a

--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -2,6 +2,7 @@
 #include <Windows.h>
 
 #include <chrono>
+#include <functional>
 
 #include "game_functions.h"
 #include "memory.h"
@@ -39,6 +40,8 @@ class CameraMods {
   void handle_proc_rmousedown(int x, int y);
   void handle_do_cam_ai();
 
+  void add_options_callback(std::function<void()> callback) { update_options_ui_callback = callback; };
+
  private:
   float fps = 60.f;
   float zeal_cam_pitch = 0.f;
@@ -53,6 +56,7 @@ class CameraMods {
   std::chrono::steady_clock::time_point lastTime;
   bool ui_active = false;
   bool reset_camera = false;  // Allows for a deferred reset of zeal cam.
+  std::function<void()> update_options_ui_callback;
 
   void synchronize_set_enable();
   void synchronize_old_ui();

--- a/Zeal/chat.h
+++ b/Zeal/chat.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -14,7 +15,24 @@ class Chat {
   ZealSetting<bool> UseUniqueNames = {false, "Zeal", "UniqueNames", false};
   ZealSetting<int> TimeStampsStyle = {0, "Zeal", "ChatTimestamps", false};
 
+  std::function<unsigned int(int)> get_color_callback;
+
   void set_classes();
+
+  void add_get_color_callback(std::function<unsigned int(int index)> callback) { get_color_callback = callback; };
+
+  void add_key_press_callback(std::function<bool(int key, bool down, int modifier)> callback) {
+    key_press_callback = callback;
+  }
+
+  void add_print_chat_callback(std::function<void(const char *data, int color_index)> callback) {
+    print_chat_callbacks.push_back(callback);
+  }
+
+  void handle_print_chat(const char *data, int color_index);
+
+  bool handle_key_press(int key, bool down, int modifier);
+
   void DoPercentReplacements(std::string &str_data);
   Chat(class ZealService *pHookWrapper);
   ~Chat();
@@ -22,4 +40,6 @@ class Chat {
  private:
   void InitPercentReplacements();
   std::vector<std::function<void(std::string &str_data)>> percent_replacements;
+  std::vector<std::function<void(const char *data, int color_index)>> print_chat_callbacks;
+  std::function<bool(int key, bool down, int modifier)> key_press_callback;
 };

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -5,7 +5,6 @@
 #include "game_ui.h"
 #include "hook_wrapper.h"
 #include "memory.h"
-#include "ui_manager.h"
 #include "zeal.h"
 
 // Standard ChannelMaps and filter offset
@@ -142,7 +141,7 @@ int32_t __fastcall AddMenu(int this_, int u, Zeal::GameUI::ContextMenu *menu) {
 }
 
 void chatfilter::LoadSettings(Zeal::GameUI::CChatManager *cman) {
-  std::string ini_name = ZealService::get_instance()->ui->GetUIIni();
+  std::string ini_name = Zeal::Game::get_ui_ini_filename();
   if (ini_name.length()) {
     IO_ini ui_ini(ini_name);
     std::string cmap = "ChannelMap";
@@ -183,7 +182,7 @@ void __fastcall UpdateContextMenus(Zeal::GameUI::CChatManager *cman, int u, Zeal
 }
 
 void __fastcall Deactivate(Zeal::GameUI::CChatManager *cman, int u) {
-  std::string ini_name = ZealService::get_instance()->ui->GetUIIni();
+  std::string ini_name = Zeal::Game::get_ui_ini_filename();
   if (ini_name.length()) {
     IO_ini ui_ini(ini_name);
     chatfilter *cf = ZealService::get_instance()->chatfilter_hook.get();
@@ -416,6 +415,8 @@ chatfilter::chatfilter(ZealService *zeal) {
   zeal->callbacks->AddReportSuccessfulHit(
       [this](Zeal::GameStructures::Entity *source, Zeal::GameStructures::Entity *target, WORD type, short spell_id,
              short damage, char out_text) { callback_hit(source, target, type, spell_id, damage, out_text); });
+
+  zeal->callbacks->AddGeneric([this]() { isDamage = false; }, callback_type::ReportSuccessfulHitPost);
 
   Extended_ChannelMaps.push_back(
       CustomFilter("Random", 0x10000, [this](short &color, std::string data) { return color == USERCOLOR_RANDOM; }));

--- a/Zeal/commands.h
+++ b/Zeal/commands.h
@@ -22,9 +22,16 @@ struct ZealCommand {
 class ChatCommands {
  public:
   void print_commands();
+
+  // Register a callback that returns the target character of the active tell window. Empty if none.
+  void add_get_tell_name_callback(std::function<std::string()> callback) { tell_callback = callback; };
+
+  bool handle_chat(std::string &str_cmd) const;  // Updates str with a tell target if needed.
+
   ChatCommands(class ZealService *zeal);
   ~ChatCommands();
   void Add(std::string cmd, std::vector<std::string> aliases, std::string description,
            std::function<bool(std::vector<std::string> &args)> callback);
   std::unordered_map<std::string, ZealCommand> CommandFunctions;
+  std::function<std::string()> tell_callback;
 };

--- a/Zeal/cycle_target.cpp
+++ b/Zeal/cycle_target.cpp
@@ -2,16 +2,39 @@
 
 #include <algorithm>
 
+#include "callbacks.h"
 #include "game_functions.h"
+#include "zeal.h"
 
-static size_t last_index = -1;
-static std::vector<Zeal::GameStructures::Entity *> near_ents;
-
-bool compareDist(Zeal::GameStructures::Entity *i1, Zeal::GameStructures::Entity *i2) {
+static bool compareDist(Zeal::GameStructures::Entity *i1, Zeal::GameStructures::Entity *i2) {
   return (i1->Position.Dist(Zeal::Game::get_self()->Position) < i2->Position.Dist(Zeal::Game::get_self()->Position));
 }
 
-void AddIndex() {
+void CycleTarget::handle_next_target(int key_down, Zeal::GameEnums::EntityTypes type) {
+  if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
+    Zeal::GameStructures::Entity *ent = get_next_ent(250, type);
+    if (ent) Zeal::Game::set_target(ent);
+  }
+}
+
+void CycleTarget::handle_toggle_last_two(int key_down) {
+  if (!key_down || Zeal::Game::GameInternal::UI_ChatInputCheck()) return;
+
+  Zeal::GameStructures::Entity *target = Zeal::Game::get_target();
+  if (target) {
+    if (last_targets.first == target->SpawnId && last_targets.second != 0) {
+      Zeal::GameStructures::Entity *ent = Zeal::Game::get_entity_by_id(last_targets.second);
+      if (ent) Zeal::Game::set_target(ent);
+    }
+  } else {
+    if (last_targets.first != 0) {
+      Zeal::GameStructures::Entity *ent = Zeal::Game::get_entity_by_id(last_targets.first);
+      if (ent) Zeal::Game::set_target(ent);
+    }
+  }
+}
+
+void CycleTarget::add_index() {
   last_index++;
   if (last_index >= near_ents.size()) last_index = 0;
 }
@@ -44,10 +67,10 @@ Zeal::GameStructures::Entity *CycleTarget::get_next_ent(float dist, BYTE type) {
   if (!near_ents.size()) return 0;
 
   std::sort(near_ents.begin(), near_ents.end(), compareDist);
-  AddIndex();
+  add_index();
 
   if (near_ents[last_index] && Zeal::Game::get_target() && Zeal::Game::get_target() == near_ents[last_index])
-    AddIndex();
+    add_index();
 
   if (near_ents[last_index])
     return near_ents[last_index];
@@ -81,10 +104,27 @@ Zeal::GameStructures::Entity *CycleTarget::get_nearest_ent(float dist, BYTE type
   if (!near_ents.size()) return 0;
 
   std::sort(near_ents.begin(), near_ents.end(), compareDist);
-  AddIndex();
+  add_index();
 
   if (near_ents.front())
     return near_ents.front();
   else
     return 0;
+}
+
+void CycleTarget::main_loop() {
+  if (Zeal::Game::get_target() && Zeal::Game::get_target()->SpawnId != last_targets.first) {
+    last_targets.second = last_targets.first;
+    last_targets.first = Zeal::Game::get_target()->SpawnId;
+  }
+}
+
+void CycleTarget::on_zone() {
+  last_targets.first = 0;
+  last_targets.second = 0;
+}
+
+CycleTarget::CycleTarget(ZealService *zeal) {
+  zeal->callbacks->AddGeneric([this]() { main_loop(); }, callback_type::MainLoop);
+  zeal->callbacks->AddGeneric([this]() { on_zone(); }, callback_type::Zone);
 }

--- a/Zeal/cycle_target.h
+++ b/Zeal/cycle_target.h
@@ -1,12 +1,24 @@
 #pragma once
+
+#include <utility>
+#include <vector>
+
 #include "game_structures.h"
 
 class CycleTarget {
  public:
-  CycleTarget(class ZealService *zeal){};
+  CycleTarget(class ZealService *zeal);
   Zeal::GameStructures::Entity *get_next_ent(float dist, BYTE type);
   Zeal::GameStructures::Entity *get_nearest_ent(float dist, BYTE type);
+  void handle_next_target(int key_down, Zeal::GameEnums::EntityTypes type);
+  void handle_toggle_last_two(int key_down);
 
  private:
-  // hook* hook;
+  void main_loop();
+  void on_zone();
+  void add_index();
+
+  std::pair<int, int> last_targets;
+  size_t last_index = -1;
+  std::vector<Zeal::GameStructures::Entity *> near_ents;
 };

--- a/Zeal/floating_damage.cpp
+++ b/Zeal/floating_damage.cpp
@@ -7,7 +7,6 @@
 #include "game_structures.h"
 #include "string_util.h"
 #include "target_ring.h"
-#include "ui_manager.h"
 #include "zeal.h"
 
 #if 0  // Not currently used.
@@ -229,9 +228,8 @@ void FloatingDamage::render_text() {
   }
 }
 
-static D3DCOLOR get_color(bool is_my_damage, bool is_damage_to_me, bool is_damage_to_player, bool is_spell) {
-  auto zeal = ZealService::get_instance();
-  if (!zeal->ui || !zeal->ui->options) return 0xffffffff;  // Defaults to white.
+D3DCOLOR FloatingDamage::get_color(bool is_my_damage, bool is_damage_to_me, bool is_damage_to_player, bool is_spell) {
+  if (!get_color_callback) return 0xffffffff;  // Defaults to white.
 
   int color_index = 0;
   if (is_my_damage)
@@ -243,7 +241,7 @@ static D3DCOLOR get_color(bool is_my_damage, bool is_damage_to_me, bool is_damag
   else
     color_index = is_spell ? 39 : 38;  // NPC being hit.
 
-  return zeal->ui->options->GetColor(static_cast<int>(color_index));
+  return get_color_callback(static_cast<int>(color_index));
 }
 
 void FloatingDamage::handle_hp_update_packet(const Zeal::Packets::SpawnHPUpdate_Struct *packet) {
@@ -488,7 +486,7 @@ FloatingDamage::FloatingDamage(ZealService *zeal) {
           Zeal::Game::print_chat("Usage: `/fcd font <fontname>` selects the zeal font <fontname>");
           Zeal::Game::print_chat("Usage: `/fcd bighit <threshold>` sets the big hit threshold");
         }
-
+        if (update_options_ui_callback) update_options_ui_callback();
         return true;
       });
 }

--- a/Zeal/floating_damage.h
+++ b/Zeal/floating_damage.h
@@ -53,10 +53,16 @@ class FloatingDamage {
   void clean_ui();
   void draw_icon(int index, float x, float y, float opacity);
   int get_active_damage_count(Zeal::GameStructures::Entity *ent);
+
+  void add_options_callback(std::function<void()> callback) { update_options_ui_callback = callback; };
+
+  void add_get_color_callback(std::function<unsigned int(int index)> callback) { get_color_callback = callback; };
+
   FloatingDamage(class ZealService *zeal);
   ~FloatingDamage();
 
  private:
+  D3DCOLOR get_color(bool is_my_damage, bool is_damage_to_me, bool is_damage_to_player, bool is_spell);
   bool is_visible() const;
   bool add_texture(std::string path);
   std::vector<IDirect3DTexture8 *> textures;
@@ -67,4 +73,6 @@ class FloatingDamage {
   std::unique_ptr<BitmapFont> bitmap_font = nullptr;
   int font_size = 5;
   std::unordered_map<Zeal::GameStructures::Entity *, std::vector<DamageData>> damage_numbers;
+  std::function<void()> update_options_ui_callback;
+  std::function<unsigned int(int)> get_color_callback;
 };

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1643,6 +1643,19 @@ GameStructures::Display *get_display() { return *reinterpret_cast<GameStructures
 
 const char *get_ui_skin() { return reinterpret_cast<const char *>(0x0063D3C0); }
 
+std::string get_ui_ini_filename() {
+  // First try to use client's function (GetUIIniFilename) to retrieve it.
+  const char *ui_ini_file = reinterpret_cast<const char *(__cdecl *)(void)>(0x00437481)();
+  if (ui_ini_file && ui_ini_file[0]) return ui_ini_file;
+
+  Zeal::GameStructures::GAMECHARINFO *c = Zeal::Game::get_char_info();
+  if (c) {
+    std::string char_name = c->Name;
+    return ".\\UI_" + char_name + "_pq.proj.ini";
+  }
+  return "";
+}
+
 std::filesystem::path get_default_ui_skin_path() {
   return std::filesystem::current_path() / std::filesystem::path("uifiles") / std::filesystem::path("default");
 }

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -175,6 +175,7 @@ void execute_cmd(UINT cmd, bool isdown, int unk2);
 GameStructures::GameClass *get_game();
 GameStructures::Display *get_display();
 const char *get_ui_skin();
+std::string get_ui_ini_filename();
 std::filesystem::path get_default_ui_skin_path();
 int get_gamestate();
 int get_channel_number(const char *name);  // Zero-based channel number.

--- a/Zeal/helm_manager.cpp
+++ b/Zeal/helm_manager.cpp
@@ -562,6 +562,25 @@ void HelmManager::DetectInstalledFixes() {
   return;
 }
 
+bool HelmManager::Handle_Showhelm(const std::vector<std::string> &args) {
+  if (args.size() == 1) {
+    ZealService::get_instance()->helm->ShowHelmEnabled.toggle();
+    return true;
+  }
+  if (args.size() == 2) {
+    if (Zeal::String::compare_insensitive(args[1], "on")) {
+      ZealService::get_instance()->helm->ShowHelmEnabled.set(true);
+      return true;
+    }
+    if (Zeal::String::compare_insensitive(args[1], "off")) {
+      ZealService::get_instance()->helm->ShowHelmEnabled.set(false);
+      return true;
+    }
+  }
+  Zeal::Game::print_chat("Usage: /showhelm or /showhelm <on|off>");
+  return true;
+}
+
 HelmManager::HelmManager(ZealService *zeal) {
   zeal->hooks->Add(SwapHeadHook, 0x004a1735, SwapHead_hk, hook_type_detour);
   zeal->hooks->Add("EntityChangeForm", 0x005074FA, EntityChangeForm_hk, hook_type_detour);
@@ -586,6 +605,9 @@ HelmManager::HelmManager(ZealService *zeal) {
         return false;  // continue processing
       },
       callback_type::WorldMessage);
+
+  zeal->commands_hook->Add("/showhelm", {"/helm"}, "Toggles your show helm setting on/off.",
+                           [this](const std::vector<std::string> &args) { return Handle_Showhelm(args); });
 
   if (HELM_MANAGER_LOG_DEBUG) {
     zeal->commands_hook->Add("/helmconfig", {}, "Prints/Toggles HelmManager configuration (for testing).",

--- a/Zeal/helm_manager.h
+++ b/Zeal/helm_manager.h
@@ -32,6 +32,7 @@ class HelmManager {
  private:
   bool Handle_In_OP_WearChange(Zeal::Packets::WearChange_Struct *data);
   bool Handle_Out_OP_WearChange(Zeal::Packets::WearChange_Struct *data);
+  bool Handle_Showhelm(const std::vector<std::string> &args);
 
   // Checks if this race/gender combination needs special handling for Velious helms
   bool IsHelmBuggedOldModel(WORD race, BYTE gender);

--- a/Zeal/io_ini.h
+++ b/Zeal/io_ini.h
@@ -17,8 +17,9 @@ class IO_ini {
 
  public:
   static constexpr char kClientFilename[] = ".\\eqclient.ini";
+  static constexpr char kZealIniFilename[] = ".\\zeal.ini";
 
-  IO_ini(const std::string &filename, bool import_check = false) : filename(filename){};
+  IO_ini(const std::string &filename) : filename(filename){};
 
   void set(std::string path) { filename = path; }
 

--- a/Zeal/looting.cpp
+++ b/Zeal/looting.cpp
@@ -9,7 +9,6 @@
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "string_util.h"
-#include "ui_manager.h"
 #include "zeal.h"
 
 // void __fastcall finalize_loot(int uk, int lootwnd_ptr)
@@ -96,7 +95,7 @@ void Looting::set_hide_looted(bool val) {
   hide_looted = val;
   auto zeal = ZealService::get_instance();
   zeal->ini->setValue<bool>("Zeal", "HideLooted", hide_looted);
-  if (zeal->ui && zeal->ui->options) ZealService::get_instance()->ui->options->UpdateOptions();
+  if (update_options_ui_callback) update_options_ui_callback();
   if (hide_looted)
     Zeal::Game::print_chat("Corpses will be hidden after looting.");
   else

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -29,6 +29,8 @@ class Looting {
   bool is_item_protected_from_selling(const Zeal::GameStructures::GAMEITEMINFO *item_info) const;
   bool is_trade_protected(struct Zeal::GameUI::TradeWnd *wnd) const;
 
+  void add_options_callback(std::function<void()> callback) { update_options_ui_callback = callback; };
+
  protected:
   ZealSetting<bool> setting_protect_enable = {false, "Protect", "Enabled", true};
   ZealSetting<int> setting_protect_value = {10, "Protect", "Value", true};
@@ -45,6 +47,7 @@ class Looting {
   void load_protected_items();
   void unhide_last_hidden();
 
+  std::function<void()> update_options_ui_callback;
   std::vector<ProtectedItem> protected_items;
   Zeal::GameStructures::Entity *last_hidden_entity = nullptr;
   int last_hidden_spawnid = 0;

--- a/Zeal/named_pipe.cpp
+++ b/Zeal/named_pipe.cpp
@@ -5,6 +5,7 @@
 
 #include <thread>
 
+#include "chat.h"
 #include "commands.h"
 #include "entity_manager.h"
 #include "game_addresses.h"
@@ -13,7 +14,10 @@
 #include "hook_wrapper.h"
 #include "labels.h"
 #include "string_util.h"
+#include "tick.h"
 #include "zeal.h"
+
+static constexpr const char *TICK_MESSAGE = "Tick";
 
 const std::map<int, std::string> LabelNames = {
     {1, "Name"},
@@ -424,6 +428,8 @@ void NamedPipe::update_pipe_handles() {
 }
 
 NamedPipe::NamedPipe(ZealService *zeal) {
+  zeal->tick->AddTickCallback([this]() { chat_msg(TICK_MESSAGE, 0); });
+  zeal->chat_hook->add_print_chat_callback([this](const char *data, int color_index) { chat_msg(data, color_index); });
   zeal->callbacks->AddGeneric([this]() { main_loop(); });
   zeal->commands_hook->Add("/pipedelay", {}, "delay between the pipe loop output in milliseconds",
                            [this](std::vector<std::string> &args) {

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <Windows.h>
 
+#include <functional>
+#include <string>
+#include <vector>
+
 #include "bitmap_font.h"
 #include "game_structures.h"
 #include "zeal_settings.h"
@@ -30,6 +34,10 @@ class NamePlate {
 
   NamePlate(class ZealService *zeal);
   ~NamePlate();
+
+  void add_options_callback(std::function<void()> callback) { update_options_ui_callback = callback; };
+
+  void add_get_color_callback(std::function<unsigned int(int index)> callback) { get_color_callback = callback; };
 
   // Tint (color) settings.
   ZealSetting<bool> setting_colors = {false, "Zeal", "NameplateColors", false};
@@ -119,4 +127,6 @@ class NamePlate {
 
   std::unique_ptr<SpriteFont> sprite_font;
   std::unordered_map<struct Zeal::GameStructures::Entity *, NamePlateInfo> nameplate_info_map;
+  std::function<void()> update_options_ui_callback;
+  std::function<unsigned int(int)> get_color_callback;
 };

--- a/Zeal/patches.cpp
+++ b/Zeal/patches.cpp
@@ -1,7 +1,6 @@
 #include "patches.h"
 
 #include "commands.h"
-#include "entity_manager.h"
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "string_util.h"
@@ -31,7 +30,7 @@ void __fastcall GetZoneInfoFromNetwork(int *t, int unused, char *p1) {
 // looks like a client bug to patch (impacts corpse nameplates and targeting).
 static void __fastcall ProcessDeath(uint32_t passthruECX, uint32_t unusedEDX,
                                     Zeal::Packets::Death_Struct *death_struct) {
-  auto *ent = ZealService::get_instance()->entity_manager->Get(death_struct->spawn_id);
+  auto *ent = Zeal::Game::get_entity_by_id(death_struct->spawn_id);
   bool player_death = (ent != nullptr && ent->Type == Zeal::GameEnums::Player);
   ZealService::get_instance()->hooks->hook_map["ProcessDeath"]->original(ProcessDeath)(passthruECX, unusedEDX,
                                                                                        death_struct);

--- a/Zeal/physics.cpp
+++ b/Zeal/physics.cpp
@@ -4,7 +4,6 @@
 #include "game_addresses.h"
 #include "game_functions.h"
 #include "game_structures.h"
-#include "game_ui.h"
 #include "hook_wrapper.h"
 #include "memory.h"
 #include "zeal.h"

--- a/Zeal/target_ring.h
+++ b/Zeal/target_ring.h
@@ -55,6 +55,11 @@ class TargetRing {
   std::vector<std::string> get_available_textures() const;
   void load_texture(const std::string &filename);
   void render_ring(Vec3 pos, float size, DWORD color, IDirect3DTexture8 *texture, float rotationAngle);
+
+  void add_options_callback(std::function<void()> callback) { update_options_ui_callback = callback; };
+
+  void add_get_color_callback(std::function<unsigned int(int index)> callback) { get_color_callback = callback; };
+
   TargetRing(class ZealService *zeal);
   ~TargetRing();
 
@@ -82,6 +87,11 @@ class TargetRing {
  private:
   void drawVertices(Vec3 pos, DWORD vertex_count, IDirect3DTexture8 *texture, D3DXMATRIX worldMatrix,
                     SolidVertex *solid_vertices, TexturedVertex *texture_vertices);
+  D3DCOLOR get_target_color() const;
+
   std::vector<RenderState> render_states;
   IDirect3DTexture8 *targetRingTexture = nullptr;
+
+  std::function<void()> update_options_ui_callback;
+  std::function<unsigned int(int)> get_color_callback;
 };

--- a/Zeal/tellwindows.h
+++ b/Zeal/tellwindows.h
@@ -10,8 +10,8 @@
 class TellWindows {
  public:
   bool HandleKeyPress(int key, bool down, int modifier);
-  bool HandleTell(std::string &cmd_data);
-  bool IsTellWindow(struct Zeal::GameUI::ChatWnd *wnd);
+  std::string GetTellWindowName() const;
+  bool IsTellWindow(struct Zeal::GameUI::ChatWnd *wnd) const;
   TellWindows(class ZealService *zeal);
   ~TellWindows();
   void SetEnabled(bool val);
@@ -19,6 +19,9 @@ class TellWindows {
   Zeal::GameUI::ChatWnd *FindTellWnd(std::string &name);
   void AddOutputText(Zeal::GameUI::ChatWnd *&wnd, std::string &msg, short channel);
   void CloseAllWindows();
+
+  void AddOptionsCallback(std::function<void()> callback) { update_options_ui_callback = callback; };
+
   bool enabled = false;
   bool hist_enabled = true;
 
@@ -26,6 +29,7 @@ class TellWindows {
   Zeal::GameUI::ChatWnd *FindPreviousTellWnd();
   Zeal::GameUI::ChatWnd *FindNextTellWnd();
   std::unordered_map<std::string, std::vector<std::pair<short, std::string>>> tell_cache;
+  std::function<void()> update_options_ui_callback;
   void CleanUI();
   void LoadUI();
 };

--- a/Zeal/tick.h
+++ b/Zeal/tick.h
@@ -1,16 +1,25 @@
 #pragma once
 #include <Windows.h>
 
+#include <functional>
+#include <vector>
+
 #include "zeal_settings.h"
 
 class Tick {
  public:
   DWORD GetTimeUntilTick();
   DWORD GetTickGauge(struct Zeal::GameUI::CXSTR *str);
+
+  void OnServerTick();
+
+  void AddTickCallback(std::function<void()> callback) { tick_callbacks.push_back(callback); }
+
   Tick(class ZealService *zeal);
   ~Tick();
 
   ZealSetting<bool> ReverseDirection = {false, "ServerTick", "ReverseDirection", false};
 
  private:
+  std::vector<std::function<void()>> tick_callbacks;
 };

--- a/Zeal/ui_manager.h
+++ b/Zeal/ui_manager.h
@@ -20,8 +20,6 @@
 
 class UIManager {
  public:
-  std::string GetUIIni();
-
   Zeal::GameUI::SliderWnd *GetSlider(std::string name);
   Zeal::GameUI::BasicWnd *GetCheckbox(std::string name);
   Zeal::GameUI::BasicWnd *GetButton(std::string name);
@@ -75,6 +73,8 @@ class UIManager {
   ZealSetting<bool> setting_show_ui_errors = {true, "Zeal", "ShowUIErrors", false};
 
  private:
+  bool handle_autobank(const std::vector<std::string> &args);
+  bool handle_uierrors(const std::vector<std::string> &args);
   bool handle_uilock(const std::vector<std::string> &args);
 
   std::unordered_map<std::string, Zeal::GameUI::BasicWnd *> checkbox_names;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -1369,6 +1369,15 @@ ui_options::ui_options(ZealService *zeal, UIManager *mgr) : ui(mgr) {
   zeal->callbacks->AddGeneric([this]() { InitUI(); }, callback_type::InitUI);
   zeal->callbacks->AddGeneric([this]() { RenderUI(); }, callback_type::RenderUI);
   zeal->callbacks->AddGeneric([this]() { Deactivate(); }, callback_type::DeactivateUI);
+  zeal->camera_mods->add_options_callback([this]() { UpdateOptionsCamera(); });
+  zeal->target_ring->add_options_callback([this]() { UpdateOptionsTargetRing(); });
+  zeal->nameplate->add_options_callback([this]() { UpdateOptionsNameplate(); });
+  zeal->floating_damage->add_options_callback([this]() { UpdateOptionsFloatingDamage(); });
+  zeal->looting_hook->add_options_callback([this]() { UpdateOptions(); });
+  zeal->tells->AddOptionsCallback([this]() { UpdateOptions(); });
+  zeal->target_ring->add_get_color_callback([this](int index) { return GetColor(index); });
+  zeal->nameplate->add_get_color_callback([this](int index) { return GetColor(index); });
+  zeal->floating_damage->add_get_color_callback([this](int index) { return GetColor(index); });
 
   zeal->hooks->Add("ContainerWndSetContainer", 0x0041717d, ContainerWndSetContainer, hook_type_detour);
   zeal->hooks->Add("SidlScreenWndHandleRButtonDown", 0x005703f0, SidlScreenWndHandleRButtonDown, hook_type_detour);

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -33,49 +33,57 @@ class ZealService {
   std::unique_ptr<class CrashHandler> crash_handler = nullptr;
   std::unique_ptr<class IO_ini> ini = nullptr;
   std::unique_ptr<class HookWrapper> hooks = nullptr;
-  std::unique_ptr<class NamedPipe> pipe = nullptr;
-  std::unique_ptr<class Looting> looting_hook = nullptr;
-  std::unique_ptr<class Labels> labels_hook = nullptr;
-  std::unique_ptr<class Binds> binds_hook = nullptr;
-  std::unique_ptr<class ChatCommands> commands_hook = nullptr;
   std::unique_ptr<class CallbackManager> callbacks = nullptr;
+  std::unique_ptr<class ChatCommands> commands_hook = nullptr;
+  std::unique_ptr<class EntityManager> entity_manager = nullptr;
+  std::unique_ptr<class Binds> binds_hook = nullptr;
+
+  std::unique_ptr<class Patches> game_patches = nullptr;
+  std::unique_ptr<class Physics> physics = nullptr;
+  std::unique_ptr<class DirectX> dx = nullptr;
+  std::unique_ptr<class GameStr> gamestr_hook = nullptr;
+  std::unique_ptr<class CycleTarget> cycle_target = nullptr;
   std::unique_ptr<class CameraMods> camera_mods = nullptr;
   std::unique_ptr<class Raid> raid_hook = nullptr;
-  std::unique_ptr<class GameStr> gamestr_hook = nullptr;
-  std::unique_ptr<class EquipItem> equip_item_hook = nullptr;
-  std::unique_ptr<class Chat> chat_hook = nullptr;
-  std::unique_ptr<class chatfilter> chatfilter_hook = nullptr;
-  std::unique_ptr<class SpellSets> spell_sets = nullptr;
-  std::unique_ptr<class ItemDisplay> item_displays = nullptr;
   std::unique_ptr<class Tooltip> tooltips = nullptr;
-  std::unique_ptr<class Physics> physics = nullptr;
-  std::unique_ptr<class FloatingDamage> floating_damage = nullptr;
-  std::unique_ptr<class DirectX> dx = nullptr;
-  std::unique_ptr<class NPCGive> give = nullptr;
-  std::unique_ptr<class NamePlate> nameplate = nullptr;
-  std::unique_ptr<class TellWindows> tells = nullptr;
-  std::unique_ptr<class HelmManager> helm = nullptr;
-  std::unique_ptr<class MusicManager> music = nullptr;
-  std::unique_ptr<class CharacterSelect> charselect = nullptr;
-  std::unique_ptr<class Tick> tick = nullptr;
-  std::unique_ptr<class Survey> survey = nullptr;
-  std::unique_ptr<class OutputFile> outputfile = nullptr;
-  std::unique_ptr<class Experience> experience = nullptr;
-  std::unique_ptr<class CycleTarget> cycle_target = nullptr;
   std::unique_ptr<class Assist> assist = nullptr;
-  std::unique_ptr<class BuffTimers> buff_timers = nullptr;
+  std::unique_ptr<class OutputFile> outputfile = nullptr;
   std::unique_ptr<class PlayerMovement> movement = nullptr;
+  std::unique_ptr<class MusicManager> music = nullptr;
   std::unique_ptr<class Alarm> alarm = nullptr;
-  std::unique_ptr<class Netstat> netstat = nullptr;
-  std::unique_ptr<class UIManager> ui = nullptr;
   std::unique_ptr<class Melody> melody = nullptr;
   std::unique_ptr<class AutoFire> autofire = nullptr;
+  std::unique_ptr<class Netstat> netstat = nullptr;
+  std::unique_ptr<class Tick> tick = nullptr;
+  std::unique_ptr<class BuffTimers> buff_timers = nullptr;
+  std::unique_ptr<class HelmManager> helm = nullptr;
+
   std::unique_ptr<class TargetRing> target_ring = nullptr;
+  std::unique_ptr<class FloatingDamage> floating_damage = nullptr;
+  std::unique_ptr<class NamePlate> nameplate = nullptr;
+
+  std::unique_ptr<class Experience> experience = nullptr;
+  std::unique_ptr<class Labels> labels_hook = nullptr;
+  std::unique_ptr<class ItemDisplay> item_displays = nullptr;
+  std::unique_ptr<class EquipItem> equip_item_hook = nullptr;
+  std::unique_ptr<class chatfilter> chatfilter_hook = nullptr;
+  std::unique_ptr<class Chat> chat_hook = nullptr;
+  std::unique_ptr<class TellWindows> tells = nullptr;
+  std::unique_ptr<class Looting> looting_hook = nullptr;
+  std::unique_ptr<class NPCGive> give = nullptr;
+
   std::unique_ptr<class ZoneMap> zone_map = nullptr;
-  std::unique_ptr<class Patches> game_patches = nullptr;
-  std::unique_ptr<class EntityManager> entity_manager = nullptr;
+  std::unique_ptr<class UIManager> ui = nullptr;
+  std::unique_ptr<class CharacterSelect> charselect = nullptr;
+  std::unique_ptr<class SpellSets> spell_sets = nullptr;
+  std::unique_ptr<class Survey> survey = nullptr;
+
+  std::unique_ptr<class NamedPipe> pipe = nullptr;
 
  private:
+  void AddCommands();  // Registers module dependent chat commands.
+  void AddBinds();     // Registers module dependent key binds.
+
   static ZealService *ptr_service;        // Pointer to this singleton-like object.
   std::vector<std::string> print_buffer;  // Queues/defers prints until UI is ready.
 };

--- a/Zeal/zeal_settings.h
+++ b/Zeal/zeal_settings.h
@@ -13,11 +13,9 @@ class ZealService;
 template <typename T>
 class ZealSetting {
  public:
-  static constexpr char kIniFilename[] = ".\\zeal.ini";
-
   void set(T val, bool store = true) {
     if (store && section.length() && key.length()) {
-      IO_ini ini(kIniFilename);
+      IO_ini ini(IO_ini::kZealIniFilename);
       ini.setValue<T>(get_section_name(), key, val);
     }
     value = val;
@@ -93,7 +91,7 @@ class ZealSetting {
 
   void init() {
     if (section.length() && key.length()) {
-      IO_ini ini(kIniFilename);
+      IO_ini ini(IO_ini::kZealIniFilename);
       std::string section_name = get_section_name();
       if (ini.exists(section_name, key)) value = ini.getValue<T>(section_name, key);
     }


### PR DESCRIPTION
- Cleaned up the initialization sequence to try and fix the persistent boot heap corruption check failures
  - Simplified core classes by removing dependencies on later initialized modules
  - Reviewed and updated the module initialization sequence in zeal.cpp to minimize the risk of a call to an uninitialized / partially initialized object
  - Moved the named pipe instantiation to the end so that thread spawn happens after everything else is initialized