### PR TITLE
Improve UI XML error dialog behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ ___
   - **Aliases:** `/opentrade`, `/ot`
   - **Description:** Opens a trade window with your current target.
 
+- `/uierrors`
+  - **Arguments:** `on`, `off`
+  - **Description:** Sets (on) or clears (off) the enable for showing dialog messages for unknown xml errors.
+ 
 - `/uilock`
   - **Arguments:** `on`, `off`
   - **Description:** Sets (on) or clears (off) the UI Lock value on primary game windows. Bag windows must be open to take effect.

--- a/Zeal/crash_handler.cpp
+++ b/Zeal/crash_handler.cpp
@@ -216,6 +216,8 @@ static std::string GetCrashMessage(EXCEPTION_POINTERS *pep, bool extra_data) {
     if (show_spell_effects) reasonStream << "ShowSpellEffects: " << show_spell_effects << std::endl;
     if (ZealService::get_heap_failed_line())
       reasonStream << "BootHeapCheck: " << ZealService::get_heap_failed_line() << std::endl;
+    int error_count = ZealService::get_instance()->crash_handler->get_xml_error_count();
+    if (error_count) reasonStream << "Unknown uierrors.txt error count: " << error_count << std::endl;
   }
   return reasonStream.str();
 }

--- a/Zeal/crash_handler.h
+++ b/Zeal/crash_handler.h
@@ -6,6 +6,11 @@ class CrashHandler {
   CrashHandler();
   ~CrashHandler();
 
+  void increment_xml_error_count() { xml_error_count++; };
+
+  int get_xml_error_count() const { return xml_error_count; };
+
  private:
   PVOID exception_handler;
+  int xml_error_count = 0;
 };

--- a/Zeal/spell_categories.h
+++ b/Zeal/spell_categories.h
@@ -1533,7 +1533,7 @@ static constexpr std::array<SpellCatEntry, 2151> spell_cat_lut = {{
     {2536, {69, 42}},                             // Transon's Elemental Infusion,
     {2537, {125, 51}},                            // Veil of Elements,
     {2538, {18, 109}},                            // Mass Mystical Transvergance,
-    {2539, {45, 44}},                             // Transon's Phantasmal Protection,
+    {2539, {79, 44}},                             // Transon's Phantasmal Protection,
     {2540, {25, 38}},                             // Shock of Fiery Blades,
     {2541, {69, 70}},                             // Focus Death,
     {2542, {126, 124}},                           // Shackle of Bone,


### PR DESCRIPTION
- Changed the LogUIError handler to:
  - Reduce 'normal' errors to 'Info' (fallback to default, song buffs)
  - Filter out common UI mods (optimized bags, tracking window)
  - Provide an option to disable with the dialog box cancel button
  - Made the dialogs properly go topmost
  - Increment an error count reported by a crash handler exception

- Also fixed Transon's Phantasmal Protection (2539) categorization to Regen from HP Buffs