### PR TITLE
Add pitch control to zeal autofollow

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ ___
   - **Example:** `/follow zeal on` turns on patched Zeal auto-follow mode (same as options tab)
   - **Example:** `/follow distance 5` sets the Zeal mode follow distance to 5 (default 15)
   - **Description:** adds /follow arguments that support enabling Zeal mode with adjustable distance. The
-    Zeal mode disables rapid toggling of run mode and slow turning to improve /follow reliability.
+    Zeal mode disables rapid toggling of run mode and slow turning to improve /follow reliability. It also
+    adds pitch control.
 
 - `/fov`
   - **Arguments:** `int`

--- a/Zeal/autofire.cpp
+++ b/Zeal/autofire.cpp
@@ -47,6 +47,17 @@
 //    return false;
 //}
 
+static void suppress_autofire_fault_messages(bool flag) {
+  ZealService::get_instance()->gamestr_hook->str_noprint[108] = flag;    // You cannot see your target.
+  ZealService::get_instance()->gamestr_hook->str_noprint[123] = flag;    // You can't hit them from here.
+  ZealService::get_instance()->gamestr_hook->str_noprint[124] = flag;    // Your target is too far away, get closer!
+  ZealService::get_instance()->gamestr_hook->str_noprint[125] = flag;    // You can't attack while stunned!
+  ZealService::get_instance()->gamestr_hook->str_noprint[12695] = flag;  // You can't attack while invulnerable!
+  ZealService::get_instance()->gamestr_hook->str_noprint[12696] = flag;  // Try attacking someone other...
+  ZealService::get_instance()->gamestr_hook->str_noprint[12698] = flag;  // Your target is too close...
+  ZealService::get_instance()->gamestr_hook->str_noprint[12699] = flag;  // Your target is too far above/below...
+}
+
 void AutoFire::Main() {
   if (!Zeal::Game::get_target() || *(BYTE *)0x7f6ffe) {
     SetAutoFire(false);
@@ -71,13 +82,7 @@ void AutoFire::Main() {
 
       // Suppress spam messages to only a 1 Hz rate.
       if (GetTickCount64() - last_print_time < 1000) {
-        ZealService::get_instance()->gamestr_hook->str_noprint[123] = true;
-        ZealService::get_instance()->gamestr_hook->str_noprint[124] = true;
-        ZealService::get_instance()->gamestr_hook->str_noprint[108] = true;
-        ZealService::get_instance()->gamestr_hook->str_noprint[12695] = true;
-        ZealService::get_instance()->gamestr_hook->str_noprint[12696] = true;
-        ZealService::get_instance()->gamestr_hook->str_noprint[12698] = true;
-        ZealService::get_instance()->gamestr_hook->str_noprint[12699] = true;
+        suppress_autofire_fault_messages(true);  // Disable fault reporting this cycle.
       } else {
         last_print_time = GetTickCount64();
       }
@@ -86,14 +91,7 @@ void AutoFire::Main() {
         *(BYTE *)0x7cd844 = 0;
         Zeal::Game::do_attack(11, 0);
       }
-
-      ZealService::get_instance()->gamestr_hook->str_noprint[123] = false;
-      ZealService::get_instance()->gamestr_hook->str_noprint[124] = false;
-      ZealService::get_instance()->gamestr_hook->str_noprint[108] = false;
-      ZealService::get_instance()->gamestr_hook->str_noprint[12695] = false;
-      ZealService::get_instance()->gamestr_hook->str_noprint[12696] = false;
-      ZealService::get_instance()->gamestr_hook->str_noprint[12698] = false;
-      ZealService::get_instance()->gamestr_hook->str_noprint[12699] = false;
+      suppress_autofire_fault_messages(false);  // Always re-enable before exiting.
     }
   }
 }

--- a/Zeal/camera_mods.cpp
+++ b/Zeal/camera_mods.cpp
@@ -124,7 +124,7 @@ void CameraMods::update_desired_zoom(float zoom) {
     desired_zoom = 0;
 
   if (desired_zoom == 0 && is_zeal_cam_active()) {
-    Zeal::Game::get_self()->Pitch = zeal_cam_pitch;
+    Zeal::Game::get_self()->Pitch = camera_math::pitch_to_game(zeal_cam_pitch);
     set_camera_view(Zeal::GameEnums::CameraView::FirstPerson);
   }
 

--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -672,6 +672,7 @@ struct LootWnd : public SidlWnd {
   /* 0x01B0 */ DWORD Timer;
   /* 0x01B4 */ PVOID Unknown01B4;
   /* 0x01B8 */ Zeal::GameStructures::_GAMEITEMINFO *Item[GAME_NUM_LOOT_WINDOW_ITEMS];
+  /* 0x0230 */ BYTE Unknown0230[0x84];  // Operator new of 0x2b4 bytes.
 };
 
 struct EditWnd : public BasicWnd  // Note: this definition has a truncated vtbl.

--- a/Zeal/patches.cpp
+++ b/Zeal/patches.cpp
@@ -52,76 +52,11 @@ static int32_t __fastcall CanIBreathe(Zeal::GameStructures::GAMECHARINFO *self_c
   return ZealService::get_instance()->hooks->hook_map["CanIBreathe"]->original(CanIBreathe)(self_char_info, unusedEDX);
 }
 
-void Patches::fonts()  // this was a test function and I later found out these aren't even used
-{
-  // const char* driverName = "DISPLAY";
-
-  //// Create the information context (IC) for the display device
-  // HDC hdc = CreateICA(driverName, NULL, NULL, NULL);
-
-  //// Check if the device context was created successfully
-  // if (hdc == NULL) return;
-
-  // HFONT fonts[6] = {};
-  // fonts[0] = reinterpret_cast<HFONT(__stdcall*)(int height, int weight, LPCSTR)>(0x55AE55)(10, 100, "Arial");
-  // fonts[1] = reinterpret_cast<HFONT(__stdcall*)(int height, int weight, LPCSTR)>(0x55AE55)(12, 100, "Arial");
-  // fonts[2] = reinterpret_cast<HFONT(__stdcall*)(int height, int weight, LPCSTR)>(0x55AE55)(14, 100, "Arial");
-  // fonts[3] = reinterpret_cast<HFONT(__stdcall*)(int height, int weight, LPCSTR)>(0x55AE55)(20, 100, "Arial");
-  // fonts[4] = reinterpret_cast<HFONT(__stdcall*)(int height, int weight, LPCSTR)>(0x55AE55)(24, 100, "Arial");
-  // fonts[5] = reinterpret_cast<HFONT(__stdcall*)(int height, int weight, LPCSTR)>(0x55AE55)(32, 100, "Arial");
-
-  // int** game_fonts = reinterpret_cast<int**>(0x809444);
-  // game_fonts[0] = reinterpret_cast<int*(__stdcall*)(HDC context, HGDIOBJ font, int size)>(0x55aed3)(hdc, fonts[0],
-  // 10); game_fonts[1] = reinterpret_cast<int* (__stdcall*)(HDC context, HGDIOBJ font, int size)>(0x55aed3)(hdc,
-  // fonts[1], 12); game_fonts[2] = reinterpret_cast<int* (__stdcall*)(HDC context, HGDIOBJ font, int
-  // size)>(0x55aed3)(hdc, fonts[2], 14); game_fonts[3] = reinterpret_cast<int* (__stdcall*)(HDC context, HGDIOBJ font,
-  // int size)>(0x55aed3)(hdc, fonts[3], 20); game_fonts[4] = reinterpret_cast<int* (__stdcall*)(HDC context, HGDIOBJ
-  // font, int size)>(0x55aed3)(hdc, fonts[4], 24); game_fonts[5] = reinterpret_cast<int* (__stdcall*)(HDC context,
-  // HGDIOBJ font, int size)>(0x55aed3)(hdc, fonts[5], 32); for (int i = 0; i < 6; i++) 	DeleteObject(fonts[i]);
-}
-
 void Patches::SetBrownSkeletons() {
   if (BrownSkeletons.get()) {
     mem::write<BYTE>(0x49f297, 0xEB);
   } else {
     mem::write<BYTE>(0x49f297, 0x75);
-  }
-}
-
-// These patches improve /follow reliability. There is logic in /follow to turn run mode on and off
-// and this actually makes your character crash out of the game if your framerate is high enough.
-// There is also a smooth turning function to circle around to the followed target which is
-// framerate dependent and causes follow failures.
-//
-// Both of these things are disabled by this mod, and it also adds an adjustable follow distance.
-void Patches::SyncAutoFollow(bool first_boot) {
-  // To patch the follow distance, we modify the pointer to a float in an instruction.
-  // We don't modify the value directly since that value is shared elsewhere in the code.
-  const DWORD follow_distance_address = (0x00507D92 + 2);                              // FADD dword ptr[addr]
-  const float *follow_distance_default = reinterpret_cast<const float *>(0x005e44d4);  // 15.0.
-  static float follow_distance_modified = 15.0f;  // Provides the static value to point to.
-
-  // Support disabling the rapid on/off toggling of run mode which can cause LDs or crashes.
-  const DWORD run_mode_address = 0x00507DB0;                    // FLD dword ptr[EBP + local_8]
-  const BYTE run_mode_toggle_default[3] = {0xd9, 0x45, 0xfc};   // Original client code.
-  const BYTE run_mode_toggle_disabled[3] = {0xeb, 0x43, 0x90};  // Patched to disable (jmp 0x45, nop).
-
-  // Support disabling the 'smoothing' where it only turns a little bit at a time if more than
-  // a quarter circle off course.
-  const DWORD turn_smoothing_address = 0x00507CB1;       // JNC LAB_00507cc1
-  const BYTE turn_smoothing_default[2] = {0x73, 0x0e};   // Original client code.
-  const BYTE turn_smoothing_disabled[2] = {0x90, 0x90};  // Patched to disable (nop, nop).
-
-  if (AutoFollowEnable.get()) {
-    follow_distance_modified = max(1.f, min(50.f, AutoFollowDistance.get()));
-    mem::write(follow_distance_address, &follow_distance_modified);
-    mem::write(run_mode_address, run_mode_toggle_disabled);
-    mem::write(turn_smoothing_address, turn_smoothing_disabled);
-  } else if (!first_boot)  // Do nothing at boot if Zeal mode is disabled.
-  {
-    mem::write(follow_distance_address, follow_distance_default);
-    mem::write(run_mode_address, run_mode_toggle_default);
-    mem::write(turn_smoothing_address, turn_smoothing_default);
   }
 }
 
@@ -136,7 +71,6 @@ Patches::Patches() {
   // disable client sided hp ticking
   // mem::set(0x4b9141, 0x90, 6);
   SetBrownSkeletons();
-  SyncAutoFollow(true);  // Sync only if non-default.
 
   // fix attack delay in DoPassageOfTime() for ItemTypeMartial (0x2d) by replacing unused type 0xd.
   mem::write<BYTE>(0x004c1d97 + 2, 0x2d);  // 004c1d97 80 f9 0d
@@ -167,37 +101,4 @@ Patches::Patches() {
 
   ZealService::get_instance()->hooks->Add("ProcessDeath", 0x00528E16, ProcessDeath, hook_type_detour);
   ZealService::get_instance()->hooks->Add("CanIBreathe", 0x004C0DAB, CanIBreathe, hook_type_detour);
-
-  // fonts();
-  //*(int*)0x809458 =
-
-  ZealService::get_instance()->commands_hook->Add(
-      "/follow", {}, "Additional /follow options to improve reliability.", [this](std::vector<std::string> &args) {
-        if (args.size() == 1) return false;  // No special flags, return false to let normal path handle.
-
-        float distance = 10;
-        if (args.size() == 3 && args[1] == "zeal") {
-          if (args[2] == "on") {
-            Zeal::Game::print_chat("Setting /follow mode to use Zeal patches");
-            AutoFollowEnable.set(true);
-            return true;  // Done
-          }
-          if (args[2] == "off") {
-            Zeal::Game::print_chat("Setting /follow mode to use default client behavior");
-            AutoFollowEnable.set(false);
-            return true;  // Done
-          }
-        } else if (args.size() == 3 && args[1] == "distance" && Zeal::String::tryParse(args[2], &distance)) {
-          distance = max(1.f, min(50.f, distance));
-          Zeal::Game::print_chat("Setting /follow distance in zeal mode to: %f", distance);
-          AutoFollowDistance.set(distance);
-          return true;  // Done
-        }
-
-        Zeal::Game::print_chat("Usage: /follow: Enable / disable auto-follow.");
-        Zeal::Game::print_chat("Usage: /follow zeal on, /follow zeal off: Enable / disable zeal follow mode.");
-        Zeal::Game::print_chat("Usage: /follow distance <value>: Sets the follow distance in zeal mode.");
-
-        return true;
-      });
 }

--- a/Zeal/patches.h
+++ b/Zeal/patches.h
@@ -5,13 +5,8 @@ class Patches {
  public:
   ZealSetting<bool> BrownSkeletons = {false, "Zeal", "BrownSkeletons", false,
                                       [this](bool val) { SetBrownSkeletons(); }};
-  ZealSetting<bool> AutoFollowEnable = {false, "AutoFollow", "Enable", false, [this](bool val) { SyncAutoFollow(); }};
-  ZealSetting<float> AutoFollowDistance = {15.f, "AutoFollow", "Distance", false,
-                                           [this](bool val) { SyncAutoFollow(); }};
   Patches();
-  void fonts();
 
  private:
   void SetBrownSkeletons();
-  void SyncAutoFollow(bool first_boot = false);
 };

--- a/Zeal/player_movement.h
+++ b/Zeal/player_movement.h
@@ -15,13 +15,20 @@ class PlayerMovement {
   ZealSetting<bool> CastAutoStand = {true, "Zeal", "CastAutoStand", false};
   ZealSetting<bool> SpellBookAutoStand = {true, "Zeal", "SpellBookAutoStand", false};
   ZealSetting<bool> EnhancedAutoRun = {false, "Zeal", "EnhancedAutoRun", false};
+  ZealSetting<bool> AutoFollowEnable = {false, "AutoFollow", "Enable", false,
+                                        [this](bool val) { sync_auto_follow_enable(); }};
+  ZealSetting<float> AutoFollowDistance = {15.f, "AutoFollow", "Distance", false,
+                                           [this](bool val) { sync_auto_follow_enable(); }};
   PlayerMovement(class ZealService *zeal);
 
  private:
   void set_strafe(strafe_direction dir);
+  void sync_auto_follow_enable(bool first_boot = false);  // Update when autofollow toggles.
+  void handle_autofollow();
   void callback_main();
   strafe_direction current_strafe = strafe_direction::None;
   bool current_strafe_key_down_state = false;  // A bound strafe key is currently pressed.
   bool current_strafe_lock = false;            // Current strafing direction is locked on.
   BYTE orig_reset_strafe[7] = {0};
+  DWORD last_follow_time_ms = 0;
 };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -480,7 +480,7 @@ void ui_options::InitGeneral() {
   ui->AddCheckboxCallback(wnd, "Zeal_InviteDialog",
                           [this](Zeal::GameUI::BasicWnd *wnd) { setting_invite_dialog.set(wnd->Checked); });
   ui->AddCheckboxCallback(wnd, "Zeal_AutoFollowEnable", [](Zeal::GameUI::BasicWnd *wnd) {
-    ZealService::get_instance()->game_patches->AutoFollowEnable.set(wnd->Checked);
+    ZealService::get_instance()->movement->AutoFollowEnable.set(wnd->Checked);
   });
 
   ui->AddCheckboxCallback(wnd, "Zeal_LinkAllAltDelimiter", [](Zeal::GameUI::BasicWnd *wnd) {
@@ -999,7 +999,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_EnhancedAutoRun", ZealService::get_instance()->movement->EnhancedAutoRun.get());
   ui->SetChecked("Zeal_SlashNotPoke", setting_slash_not_poke.get());
   ui->SetChecked("Zeal_InviteDialog", setting_invite_dialog.get());
-  ui->SetChecked("Zeal_AutoFollowEnable", ZealService::get_instance()->game_patches->AutoFollowEnable.get());
+  ui->SetChecked("Zeal_AutoFollowEnable", ZealService::get_instance()->movement->AutoFollowEnable.get());
 
   UpdateComboBox("Zeal_TellSound_Combobox", setting_tell_sound.get(), kDefaultSoundNone);
   UpdateComboBox("Zeal_InviteSound_Combobox", setting_invite_sound.get(), kDefaultSoundNone);


### PR DESCRIPTION
- Player pitch will now track the leader's position when zeal auto-follow is enabled (for use when following with lev)

- Also added the 'You are stunned!' message to the rate limiting filter in autofire