### PR TITLE
Refactor hook_wrapper

### DIFF
--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -113,9 +113,9 @@ UINT32 __fastcall GetRGBAFromIndex(int t, int u, USHORT index) {
     case CHANNEL_OTHERMELEESPECIAL:
       return c->get_color_callback(24);
     case CHANNEL_MYSTATS:
-      return 0xffffffff;  // Just hard-code to white.
-    case CHANNEL_ITEMSPEECH: // Just hard-code to spells.
-        index = 0x108;
+      return 0xffffffff;      // Just hard-code to white.
+    case CHANNEL_ITEMSPEECH:  // Just hard-code to spells.
+      index = 0x108;
   }
   return zeal->hooks->hook_map["GetRGBAFromIndex"]->original(GetRGBAFromIndex)(t, u, index);
 }
@@ -547,9 +547,9 @@ void __fastcall DoPercentConvert(int *t, int u, char *data, int u2) {
   }
 
   // Call original function using the stored hook
-  if (auto hook = ZealService::get_instance()->hooks->hook_map["DoPercentConvert"]) {
-    hook->original(DoPercentConvert)(t, u, data, u2);
-  }
+  auto hook = ZealService::get_instance()->hooks->hook_map.find("DoPercentConvert");
+  if (hook != ZealService::get_instance()->hooks->hook_map.end())
+    hook->second->original(DoPercentConvert)(t, u, data, u2);
 }
 
 void Chat::DoPercentReplacements(std::string &str_data) {

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -318,8 +318,8 @@ void __fastcall serverPrintChat(int t, int unused, const char *data, short color
     color_index = CHANNEL_MYPETSAY;
   else if (cf->isPetMessage)
     color_index = CHANNEL_OTHERPETSAY;
-  else if (cf->current_string_id == 422) 
-      color_index = CHANNEL_ITEMSPEECH;
+  else if (cf->current_string_id == 422)
+    color_index = CHANNEL_ITEMSPEECH;
 
   ZealService::get_instance()->hooks->hook_map["serverPrintChat"]->original(serverPrintChat)(t, unused, data,
                                                                                              color_index, u);
@@ -412,8 +412,6 @@ void chatfilter::callback_hit(Zeal::GameStructures::Entity *source, Zeal::GameSt
 
 chatfilter::chatfilter(ZealService *zeal) {
   if (!Zeal::Game::is_new_ui()) return;  // Old UI not supported.
-
-  zeal->hooks->Add("DamageOutputText", 0x52A8C1, CChatManager, hook_type_replace_call);
 
   zeal->callbacks->AddReportSuccessfulHit(
       [this](Zeal::GameStructures::Entity *source, Zeal::GameStructures::Entity *target, WORD type, short spell_id,

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -88,10 +88,8 @@ ChatCommands::~ChatCommands() {}
 
 // call interpret command without hitting the detour, useful for aliasing default commands
 void ForwardCommand(std::string cmd) {
-  reinterpret_cast<bool(__thiscall *)(Zeal::GameStructures::GameClass * game, Zeal::GameStructures::Entity * player,
-                                      const char *cmd)>(
-      ZealService::get_instance()->hooks->hook_map["commands"]->trampoline)(Zeal::Game::get_game(),
-                                                                            Zeal::Game::get_self(), cmd.c_str());
+  ZealService::get_instance()->hooks->hook_map["commands"]->original(InterpretCommand)(
+      (int)Zeal::Game::get_game(), 0, Zeal::Game::get_self(), cmd.c_str());
 }
 
 ChatCommands::ChatCommands(ZealService *zeal) {

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1606,6 +1606,9 @@ void print_chat(short color, const char *format, ...) {
   Zeal::Game::get_game()->dsp_chat(buffer, color, true);
 }
 
+// Kludge function definition hack for the cross-module hook original call.
+static void _fastcall AddOutputText(Zeal::GameUI::ChatWnd *wnd, int u, Zeal::GameUI::CXSTR msg, short channel){};
+
 void print_chat_wnd(Zeal::GameUI::ChatWnd *wnd, short color, const char *format, ...) {
   va_list argptr;
   char buffer[512];
@@ -1617,10 +1620,9 @@ void print_chat_wnd(Zeal::GameUI::ChatWnd *wnd, short color, const char *format,
     ZealService::get_instance()->queue_chat_message(buffer);
     return;
   }
-  // eal::GameUI::ChatWnd* wnd, int u, Zeal::GameUI::CXSTR msg, short channel)
+
   Zeal::GameUI::CXSTR cxBuff(buffer);  // Callers of AddOutputText() must FreeRep().
-  reinterpret_cast<void(__thiscall *)(Zeal::GameUI::ChatWnd *, Zeal::GameUI::CXSTR msg, short channel)>(
-      ZealService::get_instance()->hooks->hook_map["AddOutputText"]->trampoline)(wnd, cxBuff, color);
+  ZealService::get_instance()->hooks->hook_map["AddOutputText"]->original(AddOutputText)(wnd, 0, cxBuff, color);
   cxBuff.FreeRep();  // Required here to match client behavior calling AddOutputText.
 }
 

--- a/Zeal/hook_wrapper.cpp
+++ b/Zeal/hook_wrapper.cpp
@@ -1,113 +1,123 @@
 #include "hook_wrapper.h"
 
+#include <format>
+#include <string>
+
+#include "instruction_length.h"
+#include "memory.h"
+
 #pragma comment(lib, "Ws2_32.lib")
 #pragma comment(lib, "psapi.lib")
 
-namespace Zeal {
-namespace Memory {
-HookWrapper Hooks;
-}
-}  // namespace Zeal
-
-void hook::replace(int addr, int dest) {
-  if (*(BYTE *)addr == 0xE9 || *(BYTE *)addr == 0xE8) {
-    destination = (DWORD)dest;
-    address = (DWORD)addr;
-    trampoline = mem::instruction_to_absolute_address(addr);
-    DWORD old;
-    VirtualProtect((LPVOID)addr, 0x5, PAGE_EXECUTE_READWRITE, &old);
-    memcpy(original_bytes, (LPVOID)addr, 5);
-    *(DWORD *)(addr + 1) = dest - addr - 5;
-    VirtualProtect((LPVOID)addr, 0x5, old, NULL);
-    FlushInstructionCache(GetCurrentProcess(), (LPVOID)addr, 0x5);
-  }
+static void write_relative_jump(int jump_instr_addr, int relative_jump_size) {
+  *reinterpret_cast<uint8_t *>(jump_instr_addr) = 0xE9;
+  *reinterpret_cast<int *>(jump_instr_addr + 1) = relative_jump_size;
+  DWORD old_protect;
+  VirtualProtect((LPVOID)jump_instr_addr, 5, PAGE_EXECUTE_READWRITE, &old_protect);
+  FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<PVOID *>(jump_instr_addr), 5);
 }
 
-static void patch_relative_addresses(int trampoline, int addr, int byte_count) {
+// Fixes the relative address values of standard call and jump opcodes that were moved to the
+// trampoline buffer.
+void hook::patch_trampoline_relative_jumps() {
   int i = 0;
   unsigned char *opcodes = reinterpret_cast<unsigned char *>(trampoline);
-  while (i < byte_count) {
+  while (i < orig_byte_count) {
     if (opcodes[i] == 0xe8 || opcodes[i] == 0xe9) {
+      if (i + 5 > orig_byte_count) fatal_error();  // Must be mis-aligned.
       int32_t *relative_address = reinterpret_cast<int32_t *>(&opcodes[i + 1]);
-      *relative_address += addr - trampoline;  // Just modify with delta.
+      *relative_address += patch_address - trampoline;  // Just modify with delta.
     }
     i += Zeal::InstructionLength(&opcodes[i]);  // Stay opcode aligned.
   }
 }
 
-void hook::detour(int addr, int dest) {
-  int orig_to_dest_offset = dest - addr - 5;
-  DWORD old_protect;
-  if (*(BYTE *)addr == 0xE9)  // a jump (already hooked by something lets play nice)
-  {
-    orig_byte_count = 5;
-    trampoline = (int)malloc(orig_byte_count);
-    VirtualProtect((LPVOID)trampoline, orig_byte_count, PAGE_EXECUTE_READWRITE, &old_protect);
-    int jmp_absolute = mem::instruction_to_absolute_address(addr);
-    int trampoline_to_orig_offset = jmp_absolute - trampoline - 5;
-    mem::write<BYTE>(trampoline, 0xE9);
-    mem::write<int>(trampoline + 1, trampoline_to_orig_offset);
-    mem::write<BYTE>(addr, 0xE9);
-    mem::write<int>(addr + 1, orig_to_dest_offset);
-    // there is no need to write a jump back to the original since we are just going to jump to their hook
-  } else {
-    // Build a trampoline
-    trampoline = (int)malloc(orig_byte_count + 5);  // A jump is 5 bytes
-    VirtualProtect((LPVOID)trampoline, orig_byte_count + 5, PAGE_EXECUTE_READWRITE, &old_protect);
-    mem::copy(trampoline, original_bytes, orig_byte_count);
-    patch_relative_addresses(trampoline, addr, orig_byte_count);
-    // Calculate the relative offsets
-    int trampoline_to_orig_offset = addr - trampoline - orig_byte_count;
+// We hook everything at startup, so just use an obvious fatal error with the address to ID.
+void hook::fatal_error() {
+  std::string message = "Fatal Zeal hook wrapper patching: " + std::format("0x{:x}", patch_address);
+  int result_id = MessageBoxA(NULL, message.c_str(), "Internal Zeal error", MB_OK | MB_TOPMOST);
+  throw std::bad_alloc();  // Will crash out the program.
+}
 
-    // Write the relative jump instruction at the end of the trampoline
-    mem::write<BYTE>(trampoline + orig_byte_count, 0xE9);
-    mem::write<int>(trampoline + orig_byte_count + 1, trampoline_to_orig_offset);
+void hook::detour() {
+  // First determine how many aligned instruction bytes are required to move to our trampoline.
+  orig_byte_count = Zeal::InstructionLength((unsigned char *)patch_address);
+  while (orig_byte_count < 5)  // you need 5 bytes for a jmp
+    orig_byte_count += Zeal::InstructionLength((unsigned char *)(patch_address + orig_byte_count));
 
-    // Write the relative jump instruction at the original address
-    mem::write<BYTE>(addr, 0xE9);
-    mem::write<int>(addr + 1, orig_to_dest_offset);
-
-    // If there are more than 5 bytes of original instructions, fill the gap with NOPs
-    if (orig_byte_count > 5) mem::set(addr + 5, 0x90, orig_byte_count - 5);
+  // Save the original bytes for restoration upon deletion.
+  if (orig_byte_count > sizeof(original_bytes)) {
+    fatal_error();  // Will crash out the program.
+    return;
   }
+  memcpy(original_bytes, (void *)patch_address, orig_byte_count);
+
+  // Create the trampoline.
+  DWORD dummy_protect;
+  int trampoline_size = orig_byte_count + 5;
+  VirtualProtect(trampoline_bytes, trampoline_size, PAGE_EXECUTE_READWRITE, &dummy_protect);
+
+  // Copy the original bytes over to the trampoline start and patch their relative addresses.
+  // The address patching will play nice with already hooked functions or early jumps/calls.
+  // Note that if it is already hooked with a jump, our appended jump is redundant.
+  memcpy(trampoline_bytes, original_bytes, orig_byte_count);
+  patch_trampoline_relative_jumps();
+
+  // And append the jump back to the original function after the moved bytes.
+  int jump_instr_addr = trampoline + orig_byte_count;
+  int relative_jump_size = (patch_address + orig_byte_count) - (jump_instr_addr + 5);
+  *reinterpret_cast<uint8_t *>(jump_instr_addr) = 0xE9;
+  *reinterpret_cast<int *>(jump_instr_addr + 1) = relative_jump_size;
+  FlushInstructionCache(GetCurrentProcess(), trampoline_bytes, trampoline_size);
+
+  // And finally patch the original code location with the jump to the detour.
+  DWORD old_protect;
+  VirtualProtect((LPVOID)patch_address, orig_byte_count, PAGE_EXECUTE_READWRITE, &old_protect);
+  int relative_jump_to_callee = replacement_callee_addr - (patch_address + 5);
+  *reinterpret_cast<uint8_t *>(patch_address) = 0xE9;
+  *reinterpret_cast<int *>(patch_address + 1) = relative_jump_to_callee;
+
+  // If there are more than 5 bytes of original instructions, fill the gap with NOPs
+  if (orig_byte_count > 5) mem::set(patch_address + 5, 0x90, orig_byte_count - 5);
+
+  VirtualProtect((LPVOID)patch_address, orig_byte_count, old_protect, NULL);
+  FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<PVOID *>(patch_address), orig_byte_count);
 }
 
-void hook::replace_call(int addr, int dest) {
+void hook::replace_call() {
+  DWORD old;
+  VirtualProtect((LPVOID)patch_address, 0x5, PAGE_EXECUTE_READWRITE, &old);
+
+  if (*(BYTE *)patch_address != 0xE9 && *(BYTE *)patch_address != 0xE8) fatal_error();  // Will crash out the program.
+
+  // Create a trampoline in case an ->original() call is made.
+  int orig_jmp_dest_addr = mem::instruction_to_absolute_address(patch_address);
+  int trampoline_to_orig_jmp_dest = orig_jmp_dest_addr - (trampoline + 5);
+  write_relative_jump(trampoline, trampoline_to_orig_jmp_dest);
+
+  // Save the original destination for restoration at deletion
+  // and then update the relative jump size to the new target.
   orig_byte_count = 5;
-  replace(addr, dest);
-  // mem::copy((int)&original_bytes, (BYTE*)dest, 5);
+  memcpy(original_bytes, (LPVOID)patch_address, orig_byte_count);
+  int relative_jump_size = replacement_callee_addr - (patch_address + 5);
+  *(int *)(patch_address + 1) = relative_jump_size;
+
+  VirtualProtect((LPVOID)patch_address, 0x5, old, NULL);
+  FlushInstructionCache(GetCurrentProcess(), (LPVOID)patch_address, 0x5);
 }
 
-void hook::replace_vtable(int addr, int index, int dest) {
-  mem::copy((int)&original_bytes, (BYTE *)dest, 4);
-  int orig_addr = ((int *)addr)[index];
-  DWORD old_protect;
+void hook::replace_vtable() {
+  // Create a trampoline in case an ->original() call is made.
+  int orig_jmp_addr = *reinterpret_cast<int *>(patch_address);
+  int relative_jump_size = orig_jmp_addr - (trampoline + 5);
+  write_relative_jump(trampoline, relative_jump_size);
+
+  // Save the original destination for restoration at deletion.
   orig_byte_count = 4;
-  trampoline = (int)malloc(5);
-  VirtualProtect((LPVOID)trampoline, 5, PAGE_EXECUTE_READWRITE, &old_protect);
-  mem::write<BYTE>(trampoline, 0xE9);
-  mem::write<int>(trampoline + 1, orig_addr);
-  mem::write<int>(addr, dest);
+  memcpy(original_bytes, &patch_address, orig_byte_count);
+
+  // Finally replace the vtable entry.
+  mem::write<int>(patch_address, replacement_callee_addr);
 }
 
-void hook::replace_vtable(int addr, int dest) {
-  DWORD old_protect;
-  trampoline = (int)malloc(5);
-  VirtualProtect((LPVOID)trampoline, 5, PAGE_EXECUTE_READWRITE, &old_protect);
-  int trampoline_to_orig_offset = *(int *)addr - trampoline - 5;
-  mem::write<BYTE>(trampoline, 0xE9);
-  mem::write<int>(trampoline + 1, trampoline_to_orig_offset);
-  mem::write<int>(addr, dest);
-}
-
-void hook::rehook() {
-  if (hook_type == hook_type_detour)
-    detour(address, destination);
-  else
-    replace_call(address, destination);
-}
-
-void hook::remove() {
-  mem::copy(address, original_bytes, orig_byte_count);
-  free((void *)trampoline);
-}
+hook::~hook() { mem::copy(patch_address, original_bytes, orig_byte_count); }

--- a/Zeal/instruction_length.h
+++ b/Zeal/instruction_length.h
@@ -549,6 +549,7 @@ modrm_fetched:
   }
 
 error: {
+  throw std::bad_alloc();  // Will crash out the program.
   // printf("InstructionLength: unhandled opcode at %8x with opcode %2x\n", pc, opcode);
 }
   return 0;  // can't actually execute this


### PR DESCRIPTION
- Cleaned up hook_wrapper classes with no raw mallocs, smart unique pointers for memory management, encapsulation of internal details, fixes to some jump calcs, and ensured that the trampoline and original bytes were valid for all paths

- Also cleaned up some other hook calls, including one that had a potential map operator[] access bug and a deprecated one that was effectively a no-op