### PR TITLE
Add /locktogglebag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ ___
 - `/loc noprint`
   - **Description:** adds noprint argument to /loc, this just sends loc directly to your log.
 
+- `/locktogglebag`
+  - **Arguments:** `# (1 to 8 = inventory slot #, 0 = disable)`
+  - **Description:** Locks an inventory bag open (toggle containers keybind will not close).
+
 - `/log`
   - **Arguments:** `on`, `off`, `output text message with percent converts`
   - **Description:** if first argument is not `on` or `off`, it copies the rest of line to the log directly.

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -90,6 +90,7 @@
     <ClInclude Include="ui_inspect.h" />
     <ClInclude Include="ui_skin.h" />
     <ClInclude Include="ui_zoneselect.h" />
+    <ClInclude Include="utils.h" />
     <ClInclude Include="zeal_settings.h" />
     <ClInclude Include="zone_map.h" />
     <ClInclude Include="miniz.h" />
@@ -168,6 +169,7 @@
     <ClCompile Include="ui_inspect.cpp" />
     <ClCompile Include="ui_skin.cpp" />
     <ClCompile Include="ui_zoneselect.cpp" />
+    <ClCompile Include="utils.cpp" />
     <ClCompile Include="zone_map.cpp" />
     <ClCompile Include="miniz.c" />
     <ClCompile Include="named_pipe.cpp" />

--- a/Zeal/game_addresses.h
+++ b/Zeal/game_addresses.h
@@ -30,7 +30,7 @@ static GameStructures::GAMEZONEINFO *ZoneInfo = (GameStructures::GAMEZONEINFO *)
 // static GameStructures::SPELLMGR* SpellsMgr = (GameStructures::SPELLMGR*)0x805CB0;
 
 // static DWORD* ptr_LocalPC = (DWORD*)0x7F94E8;
-static int *ptr_ContainerMgr = (int *)0x63d6b8;
+static GameUI::ContainerMgr **ptr_ContainerMgr = reinterpret_cast<GameUI::ContainerMgr **>(0x0063d6b8);
 static int *ptr_COptionsWnd = (int *)0x63d634;
 static int *ptr_PrimaryKeyMap = (int *)0x7CD84C;
 static int *ptr_AlternateKeyMap = (int *)0x7CDC4C;

--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -739,6 +739,18 @@ class ContainerMgr {
   /*0x04c*/ DWORD Unknown0x04c;  // in the future this is ID of container in zone, starts at one (zero?) and goes up.
   /*0x050*/ DWORD dwTimeSpentWithWorldContainerOpen;  // Cumulative counter?
                                                       /*0x054*/
+
+  void OpenContainer(Zeal::GameStructures::GAMEITEMINFO *container, int index) {
+    reinterpret_cast<void(__thiscall *)(ContainerMgr *, Zeal::GameStructures::GAMEITEMINFO *, int)>(0x004168bd)(
+        this, container, index);
+  }
+
+  void CloseContainer(Zeal::GameStructures::GAMEITEMINFO *container, bool close_window) {
+    reinterpret_cast<void(__thiscall *)(ContainerMgr *, Zeal::GameStructures::GAMEITEMINFO *, bool)>(0x004169e5)(
+        this, container, close_window);
+  }
+
+  int CloseAllContainers() { return reinterpret_cast<int(__thiscall *)(ContainerMgr *)>(0x00416a43)(this); }
 };
 
 struct CInvSlotMgr {

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -26,6 +26,7 @@
 #include "tooltip.h"
 #include "ui_manager.h"
 #include "ui_skin.h"
+#include "utils.h"
 #include "zeal.h"
 #include "zone_map.h"
 
@@ -535,6 +536,9 @@ void ui_options::InitGeneral() {
         break;
     }
   });
+  ui->AddComboCallback(wnd, "Zeal_LockToggleBag_Combobox", [](Zeal::GameUI::BasicWnd *wnd, int value) {
+    ZealService::get_instance()->utils->setting_lock_toggle_bag_slot.set(value);
+  });
   ui->AddSliderCallback(wnd, "Zeal_HoverTimeout_Slider", [this](Zeal::GameUI::SliderWnd *wnd, int value) {
     int val = value * 5;
     ZealService::get_instance()->tooltips->set_timer(val);
@@ -958,6 +962,8 @@ void ui_options::UpdateOptionsGeneral() {
       break;
   }
   ui->SetComboValue("Zeal_FPS_Combobox", fps_limit_selection);
+  ui->SetComboValue("Zeal_LockToggleBag_Combobox",
+                    ZealService::get_instance()->utils->setting_lock_toggle_bag_slot.get());
   ui->SetComboValue("Zeal_Timestamps_Combobox", ZealService::get_instance()->chat_hook->TimeStampsStyle.get());
   ui->SetSliderValue("Zeal_HoverTimeout_Slider", ZealService::get_instance()->tooltips->hover_timeout.get() > 0
                                                      ? ZealService::get_instance()->tooltips->hover_timeout.get() / 5
@@ -1374,6 +1380,7 @@ ui_options::ui_options(ZealService *zeal, UIManager *mgr) : ui(mgr) {
   zeal->nameplate->add_options_callback([this]() { UpdateOptionsNameplate(); });
   zeal->floating_damage->add_options_callback([this]() { UpdateOptionsFloatingDamage(); });
   zeal->looting_hook->add_options_callback([this]() { UpdateOptions(); });
+  zeal->utils->add_options_callback([this]() { UpdateOptionsGeneral(); });
   zeal->tells->AddOptionsCallback([this]() { UpdateOptions(); });
   zeal->target_ring->add_get_color_callback([this](int index) { return GetColor(index); });
   zeal->nameplate->add_get_color_callback([this](int index) { return GetColor(index); });

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -844,6 +844,58 @@
     <Choices>240</Choices>
   </Combobox>
 
+  <Label item="Zeal_LockToggleBag_Label">
+    <ScreenID>Zeal_LockToggleBag_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>185</X>
+      <Y>275</Y>
+    </Location>
+    <Size>
+      <CX>145</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Lock open toggle bag slot #</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+
+  <Combobox item = "Zeal_LockToggleBag_Combobox">
+    <ScreenID>Zeal_LockToggleBag_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>185</X>
+      <Y>295</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>None</Choices>
+    <Choices>1</Choices>
+    <Choices>2</Choices>
+    <Choices>3</Choices>
+    <Choices>4</Choices>
+    <Choices>5</Choices>
+    <Choices>6</Choices>
+    <Choices>7</Choices>
+    <Choices>8</Choices>
+  </Combobox> 
+
   <!-- Third column -->
   <Button item="Zeal_EnhancedAutoRun">
     <ScreenID>Zeal_EnhancedAutoRun</ScreenID>
@@ -1423,7 +1475,9 @@
     <Pieces>Zeal_InviteSound_Label</Pieces>
     <Pieces>Zeal_TellSound_Label</Pieces>
     <Pieces>Zeal_FPS_Label</Pieces>
+    <Pieces>Zeal_LockToggleBag_Label</Pieces>
     <!-- Add comboboxes from bottom to top for z-ordering. -->
+    <Pieces>Zeal_LockToggleBag_Combobox</Pieces>
     <Pieces>Zeal_FPS_Combobox</Pieces>
     <Pieces>Zeal_TellSound_Combobox</Pieces>
     <Pieces>Zeal_InviteSound_Combobox</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -844,6 +844,58 @@
     <Choices>240</Choices>
   </Combobox>
 
+  <Label item="Zeal_LockToggleBag_Label">
+    <ScreenID>Zeal_LockToggleBag_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>370</X>
+      <Y>550</Y>
+    </Location>
+    <Size>
+      <CX>290</CX>
+      <CY>28</CY>
+    </Size>
+    <Text>Lock open toggle bag slot #</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+
+  <Combobox item="Zeal_LockToggleBag_Combobox">
+    <ScreenID>Zeal_LockToggleBag_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>370</X>
+      <Y>590</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>48</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>None</Choices>
+    <Choices>1</Choices>
+    <Choices>2</Choices>
+    <Choices>3</Choices>
+    <Choices>4</Choices>
+    <Choices>5</Choices>
+    <Choices>6</Choices>
+    <Choices>7</Choices>
+    <Choices>8</Choices>
+  </Combobox> 
+
   
   <Button item="Zeal_EnhancedAutoRun">
     <ScreenID>Zeal_EnhancedAutoRun</ScreenID>
@@ -1423,7 +1475,9 @@
     <Pieces>Zeal_InviteSound_Label</Pieces>
     <Pieces>Zeal_TellSound_Label</Pieces>
     <Pieces>Zeal_FPS_Label</Pieces>
+    <Pieces>Zeal_LockToggleBag_Label</Pieces>
     
+    <Pieces>Zeal_LockToggleBag_Combobox</Pieces>
     <Pieces>Zeal_FPS_Combobox</Pieces>
     <Pieces>Zeal_TellSound_Combobox</Pieces>
     <Pieces>Zeal_InviteSound_Combobox</Pieces>

--- a/Zeal/utils.cpp
+++ b/Zeal/utils.cpp
@@ -1,0 +1,68 @@
+#include "utils.h"
+
+#include <utility>
+#include <vector>
+
+#include "commands.h"
+#include "game_addresses.h"
+#include "game_structures.h"
+#include "game_ui.h"
+#include "string_util.h"
+#include "zeal.h"
+
+Utils::Utils(ZealService *zeal) {
+  zeal->commands_hook->Add(
+      "/locktogglebagslot", {}, "Sets the locked open bag slot (1 - 8, 0 = off).",
+      [this](const std::vector<std::string> &args) {
+        int slot = 0;
+        if (args.size() == 2 && Zeal::String::tryParse(args[1], &slot, true) && slot >= 0 && slot <= 8)
+          setting_lock_toggle_bag_slot.set(slot);
+        else
+          Zeal::Game::print_chat("Usage: /locktogglebagslot # (slot 1 to 8, 0 = off)");
+        Zeal::Game::print_chat("locktogglebagslot set to %d", setting_lock_toggle_bag_slot.get());
+        if (update_options_ui_callback) update_options_ui_callback();
+        return true;
+      });
+}
+
+void Utils::handle_toggle_all_containers() const {
+  auto *self = Zeal::Game::get_self();
+  auto char_info = self ? self->CharInfo : nullptr;
+  auto manager = *Zeal::Game::ptr_ContainerMgr;
+  if (!char_info || !manager) return;
+
+  bool is_a_bag_open = false;
+  bool is_a_bag_closed = false;
+  for (int i = 0; i < 8; i++)  // 8 inventory slots for containers
+  {
+    Zeal::GameStructures::GAMEITEMINFO *item = char_info->InventoryPackItem[i];
+    if (item && item->Type == 1 && item->Container.Capacity > 0) {
+      is_a_bag_open = is_a_bag_open || item->Container.IsOpen;
+      is_a_bag_closed = is_a_bag_closed || !item->Container.IsOpen;
+    }
+  }
+  if (is_a_bag_open && !is_a_bag_closed)  // All the containers are open, so toggle close.
+  {
+    int lock_slot = setting_lock_toggle_bag_slot.get();
+    if (lock_slot <= 0 || lock_slot > 8) {
+      manager->CloseAllContainers();
+    } else {
+      Zeal::GameStructures::GAMEITEMINFO *locked_slot = char_info->InventoryPackItem[lock_slot - 1];
+      for (int i = 0; i < 0x11; ++i) {
+        auto wnd = manager->pPCContainers[i];
+        auto container = wnd ? wnd->pContainerInfo : nullptr;
+        if (!container || container == locked_slot) continue;  // Locked so skip.
+        if (container->Type == 1 && container->Container.Capacity > 0 && container->Container.IsOpen)
+          manager->CloseContainer(container, true);
+      }
+    }
+  } else {
+    for (int i = 0; i < 8; ++i) {
+      Zeal::GameStructures::GAMEITEMINFO *item = char_info->InventoryPackItem[i];
+      if (item && item->Type == 1 && item->Container.Capacity > 0 && !item->Container.IsOpen)
+        manager->OpenContainer(item, 22 + i);
+    }
+  }
+}
+
+Utils::~Utils() {}

--- a/Zeal/utils.h
+++ b/Zeal/utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <functional>
+
+#include "zeal_settings.h"
+
+// Home for simple utility functions that extend the general game_functions and may require settings or hooks.
+class Utils {
+ public:
+  explicit Utils(class ZealService *zeal);
+  ~Utils();
+
+  ZealSetting<int> setting_lock_toggle_bag_slot = {0, "Zeal", "LockToggleBagSlot", true};
+
+  void handle_toggle_all_containers() const;
+
+  void add_options_callback(std::function<void()> callback) { update_options_ui_callback = callback; };
+
+ private:
+  std::function<void()> update_options_ui_callback;
+};

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -62,6 +62,7 @@ class ZealService {
   std::unique_ptr<class FloatingDamage> floating_damage = nullptr;
   std::unique_ptr<class NamePlate> nameplate = nullptr;
 
+  std::unique_ptr<class Utils> utils = nullptr;
   std::unique_ptr<class Experience> experience = nullptr;
   std::unique_ptr<class Labels> labels_hook = nullptr;
   std::unique_ptr<class ItemDisplay> item_displays = nullptr;


### PR DESCRIPTION
- Added a /locktogglebag command and linked Zeal general options tab combobox that can select a single inventory bag slot to lock open (ignores the toggle close)