### PR TITLE
Disables client-sided health tick

### DIFF
--- a/Zeal/patches.cpp
+++ b/Zeal/patches.cpp
@@ -86,6 +86,14 @@ Patches::Patches() {
   mem::set(0x4C3F93, 0x90, 7);
   mem::set(0x4C7642, 0x90, 7);
 
+  // disable client sided health ticking
+  mem::set(0x4C28B5, 0x90, 9);
+  mem::set(0x4C28EF, 0x90, 1);
+  mem::set(0x4C28EF + 1, 0xE9, 1);
+  mem::set(0x4C298B, 0x90, 2);
+  mem::set(0x4C2991, 0x90, 5);
+  mem::set(0x4C2BB4, 0x90, 9);
+
   mem::write<BYTE>(0x40f07a, 0);     // disable character select rotation by default
   mem::write<BYTE>(0x40f07d, 0xEB);  // uncheck rotate button defaultly
 


### PR DESCRIPTION
- Same feature as /cmt, but for health.
- Overall seems to improve client behavior as well.

Note: The server has a bug where it doesn't send HP updates after processing the most recent tick of DoT damage on the player, so the player view of their HP when dotted is one tick behind (or until damage taken by non-tick source). This is already an issue, independent of this feature, but just wanted to call that out as it's the only time the HP can feel a litlte bit desync'd. Will send a server PR to fix that. Since it's just more obvious now when we're trusting the server.