### PR TITLE
Protect against bad /load commands

### DIFF
--- a/Zeal/spell_categories.h
+++ b/Zeal/spell_categories.h
@@ -3027,7 +3027,7 @@ static inline std::string GetSpellSubCategoryName(DWORD subcategoryID) {
     case 165:
       return "Group";
     case 166:
-      return "Others";
+      return "Target";
     case 167:
       return "Area";
     default:


### PR DESCRIPTION
- Added Zeal blocking of the /load skin if the selected skin folder doesn't exist or the skin has contents known to be incompatible with Zeal or the server xml files

- Also renamed the spellset alt transport others to target