### PR TITLE
Add map broadcast (rsay, gsay) commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,6 +846,16 @@ up the map even in zoom. The keybind to toggle through the label modes is recomm
   - `/map butcherblock` shortcut for above (does not work for terms that match other commands)
   - `/map labels summary` enables the summary labels (other options are `off`, `all`, or `marker`)
 
+#### Map broadcast to rsay and gsay
+The map supports broadcasting map marker and line commands to the rsay or gsay channels which
+will trigger the zeal map on recipients to display those commands on their map. A message is
+put in the target channel with a Zeal map trigger header followed by the command.
+
+* Zeal options combobox to select from available fonts
+* Command examples:
+  - `/map rsay marker 1620 -240 Tunare` puts a marker for Tunare on raid members' maps
+  - `/map gsay line 10 20 30 40` puts a line from (10,20) to (30,40) on group members' maps
+
 #### Map data source
 The map has simple support for external map data files. The map data_mode can be set to `internal`,
 `both`, or `external`. In `both`, the internal maps are combined with any available data from an

--- a/Zeal/chat.h
+++ b/Zeal/chat.h
@@ -29,9 +29,21 @@ class Chat {
     print_chat_callbacks.push_back(callback);
   }
 
+  void add_incoming_gsay_callback(std::function<void(const char *data)> callback) {
+    gsay_callbacks.push_back(callback);
+  }
+
+  void add_incoming_rsay_callback(std::function<void(const char *data)> callback) {
+    rsay_callbacks.push_back(callback);
+  }
+
   void handle_print_chat(const char *data, int color_index);
 
   bool handle_key_press(int key, bool down, int modifier);
+
+  void handle_incoming_gsay(const char *msg);
+
+  void handle_incoming_rsay(const char *msg);
 
   void DoPercentReplacements(std::string &str_data);
   Chat(class ZealService *pHookWrapper);
@@ -41,5 +53,7 @@ class Chat {
   void InitPercentReplacements();
   std::vector<std::function<void(std::string &str_data)>> percent_replacements;
   std::vector<std::function<void(const char *data, int color_index)>> print_chat_callbacks;
+  std::vector<std::function<void(const char *data)>> gsay_callbacks;
+  std::vector<std::function<void(const char *data)>> rsay_callbacks;
   std::function<bool(int key, bool down, int modifier)> key_press_callback;
 };

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -193,8 +193,10 @@ class ZoneMap {
   void parse_rect(const std::vector<std::string> &args);
   void parse_size(const std::vector<std::string> &args);
   void parse_alignment(const std::vector<std::string> &args);
-  void parse_marker(const std::vector<std::string> &args);
-  void parse_line(const std::vector<std::string> &args);
+  bool parse_marker(const std::vector<std::string> &args);
+  bool parse_line(const std::vector<std::string> &args);
+  void parse_broadcast(const std::vector<std::string> &args);  // rsay or gsay.
+  bool check_message_for_broadcast(const char *message);
   void parse_background(const std::vector<std::string> &args);
   void parse_zoom(const std::vector<std::string> &args);
   void parse_labels(const std::vector<std::string> &args);


### PR DESCRIPTION
- Added new map commands to broadcast map marker or line commands to the rsay or gsay channels and the recipient Zeal will intercept a special zeal header and execute those commands