### PR TITLE
Add suppress lifetap filter

### DIFF
--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -346,13 +346,16 @@ void __fastcall serverPrintChat(int t, int unused, const char *data, short color
   } else if (cf->current_string_id == 1218 && cf->setting_suppress_other_fizzles.get() && is_non_group_fizzle(data)) {
     cf->current_string_id = 0;
     return;  // Just drop fizzles from others.
+  } else if (cf->current_string_id == 12117 && cf->settings_suppress_lifetap_feeling.get()) {
+    cf->current_string_id = 0;
+    return;  // Just drop Ahhh, I feel much better now...
   }
 
   if (cf->isMyPetSay)
     color_index = CHANNEL_MYPETSAY;
   else if (cf->isPetMessage)
     color_index = CHANNEL_OTHERPETSAY;
-  else if (color_index == USERCOLOR_MELEE_CRIT && !is_from_me(data))
+  else if (color_index == USERCOLOR_MELEE_CRIT && cf->current_string_id != 143 && !is_from_me(data))
     color_index = CHANNEL_OTHER_MELEE_CRIT;
   else if (is_item_speech(cf->current_string_id))
     color_index = CHANNEL_ITEMSPEECH;

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -51,6 +51,7 @@ class chatfilter {
                     short spell_id, short damage, char output_text);
   ZealSetting<bool> setting_suppress_missed_notes = {false, "Zeal", "SuppressMissedNotes", false};
   ZealSetting<bool> setting_suppress_other_fizzles = {false, "Zeal", "SupressOtherFizzles", false};
+  ZealSetting<bool> settings_suppress_lifetap_feeling = {false, "Zeal", "SuppressLifeTapFeeling", false};
   bool isExtendedCM(int channelMap, int applyOffset = 0);
   bool isStandardCM(int channelMap, int applyOffset = 0);
   int current_string_id = 0;

--- a/Zeal/ui_manager.cpp
+++ b/Zeal/ui_manager.cpp
@@ -357,7 +357,7 @@ static bool is_message_an_error(const std::string &message) {
 
   // Ignore some optional missing buttons in the XML that don't cause crashes. We could use some
   // regexp pattern matching here, but just brute force it for clarity.
-  static constexpr std::array<const char *, 13> optionals = {
+  static constexpr std::array<const char *, 14> optionals = {
       // Zeal extra buttons.
       "Error: Could not find child Zeal_ZoneSelect in window CharacterSelectWindow",
       "Error: Could not find child ChangeButton in window BankWnd",
@@ -367,6 +367,7 @@ static bool is_message_an_error(const std::string &message) {
       // UI skins with simplified bag windows.
       "Error: Could not find child Container_Icon in window ContainerWindow",
       "Error: Could not find child DoneButton in window ContainerWindow",
+      "Error: Could not find child Container_Label in window ContainerWindow",
 
       // UI skins with simplified druid / bard tracking window.
       "Error: Could not find child TRW_TrackSortCombobox in window TrackingWnd",

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -462,6 +462,9 @@ void ui_options::InitGeneral() {
   ui->AddCheckboxCallback(wnd, "Zeal_SuppressOtherFizzles", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_SuppressLifetapFeeling", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->chatfilter_hook->settings_suppress_lifetap_feeling.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_UseZealAssistOn", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->assist->setting_use_zeal_assist_on.set(wnd->Checked);
   });
@@ -1005,6 +1008,8 @@ void ui_options::UpdateOptionsGeneral() {
                  ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.get());
   ui->SetChecked("Zeal_SuppressOtherFizzles",
                  ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.get());
+  ui->SetChecked("Zeal_SuppressLifetapFeeling",
+                 ZealService::get_instance()->chatfilter_hook->settings_suppress_lifetap_feeling.get());
   ui->SetChecked("Zeal_UseZealAssistOn", ZealService::get_instance()->assist->setting_use_zeal_assist_on.get());
   ui->SetChecked("Zeal_DetectAssistFailure", ZealService::get_instance()->assist->setting_detect_assist_failure.get());
   ui->SetChecked("Zeal_SingleClickGiveEnable", ZealService::get_instance()->give->setting_enable_give.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -1453,7 +1453,38 @@
       <Disabled>A_BtnDisabled</Disabled>
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
-  </Button>  
+  </Button>
+
+  <Button item="Zeal_SuppressLifetapFeeling">
+    <ScreenID>Zeal_SuppressLifetapFeeling</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>420</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Suppress lifetap 'I feel better' message</TooltipReference>
+    <Text>Suppress lifetaps</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <!-- end -->
     
   <Page item="Tab_General">
@@ -1531,6 +1562,7 @@
     <Pieces>Zeal_DetectAssistFailure</Pieces>
     <Pieces>Zeal_SlashNotPoke</Pieces>
     <Pieces>Zeal_AltTransportCats</Pieces>
+    <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -1453,7 +1453,38 @@
       <Disabled>A_BtnDisabled</Disabled>
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
-  </Button>  
+  </Button>
+
+  <Button item="Zeal_SuppressLifetapFeeling">
+    <ScreenID>Zeal_SuppressLifetapFeeling</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>840</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Suppress lifetap 'I feel better' message</TooltipReference>
+    <Text>Suppress lifetaps</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   
     
   <Page item="Tab_General">
@@ -1531,6 +1562,7 @@
     <Pieces>Zeal_DetectAssistFailure</Pieces>
     <Pieces>Zeal_SlashNotPoke</Pieces>
     <Pieces>Zeal_AltTransportCats</Pieces>
+    <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
     <Location>
       <X>0</X>
       <Y>44</Y>


### PR DESCRIPTION
- New zeal option to suppress the Ahh, I feel better... messages

- Fixed bow double damage which counts as critical hits so it isn't routed to others' critical hits

- Added missing Container_Label from ContainerWindows to the ui errors whitelist