### PR TITLE
Do not re-route other pet dmg to self

### DIFF
--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -485,6 +485,7 @@ chatfilter::chatfilter(ZealService *zeal) {
       "Other Pet Say", 0x10005, [this, zeal](short &color, std::string data) { return color == CHANNEL_OTHERPETSAY; }));
   Extended_ChannelMaps.push_back(
       CustomFilter("Other Pet Damage", 0x10006, [this, zeal](short &color, std::string data) {
+        if (isDamage && damageData.target == Zeal::Game::get_self()) return false;  // Don't re-route damage to self.
         if (isDamage && damageData.source && damageData.source->PetOwnerSpawnId &&
             damageData.source->PetOwnerSpawnId != Zeal::Game::get_self()->SpawnId) {
           color = CHANNEL_OTHERPETDMG;

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -350,9 +350,12 @@ void ZealService::AddCommands() {
                              sizeof(Zeal::GameStructures::GAMECHARINFO));
       return true;
     }
-    if (args.size() == 2 && args[1] == "check")  // Report state and do basic debug integrity checks.
-    {
+    if (args.size() == 2 && args[1] == "entities") {
       ZealService::get_instance()->entity_manager.get()->Dump();
+      return true;
+    }
+    if (args.size() == 2 && args[1] == "check")  // Run a heap / memory check.
+    {
       int heap_valid1 = HeapValidate(GetProcessHeap(), 0, NULL);
       Zeal::Game::print_chat("Process HeapValidate: %s", heap_valid1 ? "Pass" : "Fail");
       int heap_valid2 = HeapValidate(*Zeal::Game::Heap, 0, NULL);
@@ -362,9 +365,8 @@ void ZealService::AddCommands() {
       memset(&heap_summary, 0, sizeof(heap_summary));
       heap_summary.cb = sizeof(heap_summary);
       HeapSummary(*Zeal::Game::Heap, 0, &heap_summary);
-      Zeal::Game::print_chat("Game Heap: Alloc: 0x%08x, Commit: 0x%08x", heap_summary.cbAllocated,
-                             heap_summary.cbCommitted);
-
+      Zeal::Game::print_chat("Game Heap: Alloc: %d MB, Commit: %d MB", heap_summary.cbAllocated / 1024 / 1024,
+                             heap_summary.cbCommitted / 1024 / 1024);
       return true;
     }
     if (args.size() == 3 && args[1] == "get_command") {


### PR DESCRIPTION
- Other pet dmg was getting routed to the other peg dmg filter channel even if the damage was to the player (self). Fixed.

- Also made it so `/zeal check` just does the memory check and reports current allocations in MB vs hex