### PR TITLE
Fix routing of other non-melee from DS channel

### DIFF
--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -435,7 +435,7 @@ void chatfilter::callback_hit(Zeal::GameStructures::Entity *source, Zeal::GameSt
     damageData = {source, target, type, spell_id, damage};
   }
 
-  if (!other_non_melee || (damage == 0)) return;
+  if (!other_non_melee || (damage == 0) || !setting_report_other_non_melee_dmg.get()) return;
 
   bool is_ds_damage_to_non_pet_npcs =
       (damage < 0 && type >= 244 && type <= 249 && target->Type == Zeal::GameEnums::EntityTypes::NPC &&
@@ -444,9 +444,11 @@ void chatfilter::callback_hit(Zeal::GameStructures::Entity *source, Zeal::GameSt
     if (damage < 0) damage = -damage;
     if ((source->Position.Dist2D(Zeal::Game::get_self()->Position) < 500 ||
          target->Position.Dist2D(Zeal::Game::get_self()->Position) < 500) &&
-        std::abs(source->Position.z - Zeal::Game::get_self()->Position.z) < 20)
-      Zeal::Game::print_chat(CHANNEL_OTHER_DAMAGE_SHIELD, "%s hit %s for %i points of non-melee damage.",
+        std::abs(source->Position.z - Zeal::Game::get_self()->Position.z) < 20) {
+      short channel = is_ds_damage_to_non_pet_npcs ? CHANNEL_OTHER_DAMAGE_SHIELD : USERCOLOR_NON_MELEE;
+      Zeal::Game::print_chat(channel, "%s hit %s for %i points of non-melee damage.",
                              Zeal::Game::strip_name(source->Name), Zeal::Game::strip_name(target->Name), damage);
+    }
   }
 }
 

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -52,6 +52,7 @@ class chatfilter {
   ZealSetting<bool> setting_suppress_missed_notes = {false, "Zeal", "SuppressMissedNotes", false};
   ZealSetting<bool> setting_suppress_other_fizzles = {false, "Zeal", "SupressOtherFizzles", false};
   ZealSetting<bool> settings_suppress_lifetap_feeling = {false, "Zeal", "SuppressLifeTapFeeling", false};
+  ZealSetting<bool> setting_report_other_non_melee_dmg = {true, "Zeal", "ReportOtherNonMeleeDmg", false};
   bool isExtendedCM(int channelMap, int applyOffset = 0);
   bool isStandardCM(int channelMap, int applyOffset = 0);
   int current_string_id = 0;

--- a/Zeal/target_ring.cpp
+++ b/Zeal/target_ring.cpp
@@ -459,9 +459,16 @@ std::vector<std::string> TargetRing::get_available_textures() const {
 
 void TargetRing::callback_initui() { load_texture(texture_name.get()); }
 
+void TargetRing::callback_cleanui() {
+  if (targetRingTexture) targetRingTexture->Release();
+  targetRingTexture = nullptr;
+}
+
 TargetRing::TargetRing(ZealService *zeal) {
   zeal->callbacks->AddGeneric([this]() { callback_render(); }, callback_type::RenderUI);
   zeal->callbacks->AddGeneric([this]() { callback_initui(); }, callback_type::InitUI);
+  zeal->callbacks->AddGeneric([this]() { callback_cleanui(); }, callback_type::CleanUI);
+  zeal->callbacks->AddGeneric([this]() { callback_cleanui(); }, callback_type::DXReset);  // Just release all resources.
 
   zeal->commands_hook->Add("/targetring", {}, "Toggles target ring", [this](std::vector<std::string> &args) {
     if (args.size() == 2) {
@@ -478,7 +485,4 @@ TargetRing::TargetRing(ZealService *zeal) {
   });
 }
 
-TargetRing::~TargetRing() {
-  if (targetRingTexture) targetRingTexture->Release();
-  targetRingTexture = nullptr;
-}
+TargetRing::~TargetRing() { callback_cleanui(); }

--- a/Zeal/target_ring.h
+++ b/Zeal/target_ring.h
@@ -49,9 +49,6 @@ struct SolidVertex : public BaseVertex {
 
 class TargetRing {
  public:
-  void callback_render();
-  void callback_initui();
-
   std::vector<std::string> get_available_textures() const;
   void load_texture(const std::string &filename);
   void render_ring(Vec3 pos, float size, DWORD color, IDirect3DTexture8 *texture, float rotationAngle);
@@ -85,6 +82,10 @@ class TargetRing {
   void reset_render_states();
 
  private:
+  void callback_render();
+  void callback_initui();
+  void callback_cleanui();
+
   void drawVertices(Vec3 pos, DWORD vertex_count, IDirect3DTexture8 *texture, D3DXMATRIX worldMatrix,
                     SolidVertex *solid_vertices, TexturedVertex *texture_vertices);
   D3DCOLOR get_target_color() const;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -465,6 +465,9 @@ void ui_options::InitGeneral() {
   ui->AddCheckboxCallback(wnd, "Zeal_SuppressLifetapFeeling", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->chatfilter_hook->settings_suppress_lifetap_feeling.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_ReportOtherNonMeleeDmg", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->chatfilter_hook->setting_report_other_non_melee_dmg.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_UseZealAssistOn", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->assist->setting_use_zeal_assist_on.set(wnd->Checked);
   });
@@ -1010,6 +1013,8 @@ void ui_options::UpdateOptionsGeneral() {
                  ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.get());
   ui->SetChecked("Zeal_SuppressLifetapFeeling",
                  ZealService::get_instance()->chatfilter_hook->settings_suppress_lifetap_feeling.get());
+  ui->SetChecked("Zeal_ReportOtherNonMeleeDmg",
+                 ZealService::get_instance()->chatfilter_hook->setting_report_other_non_melee_dmg.get());
   ui->SetChecked("Zeal_UseZealAssistOn", ZealService::get_instance()->assist->setting_use_zeal_assist_on.get());
   ui->SetChecked("Zeal_DetectAssistFailure", ZealService::get_instance()->assist->setting_detect_assist_failure.get());
   ui->SetChecked("Zeal_SingleClickGiveEnable", ZealService::get_instance()->give->setting_enable_give.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -1485,6 +1485,39 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+
+  <Button item="Zeal_ReportOtherNonMeleeDmg">
+    <ScreenID>Zeal_ReportOtherNonMeleeDmg</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>442</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Generate reports of non-melee dmg (spells, dmg shield) from others</TooltipReference>
+    <Text>Others non-melee</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
+
   <!-- end -->
     
   <Page item="Tab_General">
@@ -1563,6 +1596,7 @@
     <Pieces>Zeal_SlashNotPoke</Pieces>
     <Pieces>Zeal_AltTransportCats</Pieces>
     <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
+    <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -1485,6 +1485,39 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+
+  <Button item="Zeal_ReportOtherNonMeleeDmg">
+    <ScreenID>Zeal_ReportOtherNonMeleeDmg</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>884</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Generate reports of non-melee dmg (spells, dmg shield) from others</TooltipReference>
+    <Text>Others non-melee</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
+
   
     
   <Page item="Tab_General">
@@ -1563,6 +1596,7 @@
     <Pieces>Zeal_SlashNotPoke</Pieces>
     <Pieces>Zeal_AltTransportCats</Pieces>
     <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
+    <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
     <Location>
       <X>0</X>
       <Y>44</Y>


### PR DESCRIPTION
- Fixed the accidental routing of general other non-melee damage into the new other DS damage channel
- Also updated the target ring to release texture resources at directx reset or ui teardown