### PR TITLE
Fix IVU nameplates and zeal cam x-sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ ___
     give, trade, or crafting windows. It only activates when either ctrl or shift are held down.
     The `bag #` sets the target tradeskill inventory target if no world trade/tradeskill windows
     are open. Set # to zero to disable (default). The # is not a persistent setting (clears on camp).
+    Note: /singleclick will not work with `NO DROP` items to avoid unforeseen shenanigans
   - **Example:** `/singleclick bag 2` will set inventory slot bag 2 (1-8) as the target.
 
 - `/sit`

--- a/Zeal/floating_damage.cpp
+++ b/Zeal/floating_damage.cpp
@@ -228,12 +228,13 @@ void FloatingDamage::render_text() {
   }
 }
 
-D3DCOLOR FloatingDamage::get_color(bool is_my_damage, bool is_damage_to_me, bool is_damage_to_player, bool is_spell) {
+D3DCOLOR FloatingDamage::get_color(bool is_my_damage, bool is_damage_to_me, bool is_damage_to_player, bool is_spell,
+                                   bool is_highlight) {
   if (!get_color_callback) return 0xffffffff;  // Defaults to white.
 
   int color_index = 0;
   if (is_my_damage)
-    color_index = is_spell ? 33 : 32;  // Me creating damage.
+    color_index = is_highlight ? 40 : is_spell ? 33 : 32;  // Me creating damage.
   else if (is_damage_to_me)
     color_index = is_spell ? 35 : 34;  // Me getting hit.
   else if (is_damage_to_player)
@@ -314,9 +315,9 @@ void FloatingDamage::add_damage(Zeal::GameStructures::Entity *source, Zeal::Game
 
   bool is_damage_to_me = (target == Zeal::Game::get_controlled());
   bool is_damage_to_player = (target->Type == Zeal::GameEnums::Player);
-  auto color = get_color(is_my_damage, is_damage_to_me, is_damage_to_player, is_spell);
-  auto sp_data = is_spell ? Zeal::Game::get_spell_mgr()->Spells[spell_id] : nullptr;
   bool highlight = (damage >= big_hit_threshold.get()) || (type == 8);  // Backstab as starting point.
+  auto color = get_color(is_my_damage, is_damage_to_me, is_damage_to_player, is_spell, highlight);
+  auto sp_data = is_spell ? Zeal::Game::get_spell_mgr()->Spells[spell_id] : nullptr;
   damage_numbers[target].push_back(DamageData(damage, false, sp_data, color, highlight));
 }
 

--- a/Zeal/floating_damage.h
+++ b/Zeal/floating_damage.h
@@ -62,7 +62,7 @@ class FloatingDamage {
   ~FloatingDamage();
 
  private:
-  D3DCOLOR get_color(bool is_my_damage, bool is_damage_to_me, bool is_damage_to_player, bool is_spell);
+  D3DCOLOR get_color(bool is_my_damage, bool is_damage_to_me, bool is_damage_to_player, bool is_spell, bool highlight);
   bool is_visible() const;
   bool add_texture(std::string path);
   std::vector<IDirect3DTexture8 *> textures;

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1443,13 +1443,12 @@ int update_get_world_visible_actor_list(float max_distance) {
 // Identical logic to CDisplay::IsInvisible with the exception of providing the two boolean flags
 // instead of calculating can i see invis each call.
 static bool is_invisible_to_me(Zeal::GameStructures::Entity *target, bool can_i_see_invis, bool am_i_gm) {
-  bool invisible = false;
   if (!target) return false;
 
   if (target->Type >= Zeal::GameEnums::EntityTypes::NPCCorpse || target->HpCurrent <= 0) return false;
 
   if (target->TargetType > 0x40) return true;
-  if (!target->IsHidden) return false;
+  if (target->VisibilityState != 0x01) return false;
   if (!can_i_see_invis) return true;
   if (!target->IsGameMaster) return false;
   if (am_i_gm) return false;

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -1213,11 +1213,11 @@ struct Entity {
   /* 0x00AA */ WORD Race;    // RACE_x
   /* 0x00AC */ BYTE Gender;  // GENDER_x
   /* 0x00AD */ BYTE Level;
-  /* 0x00AE */ BYTE IsHidden;       // 0 = Visible, 1 = Invisible
-  /* 0x00AF */ BYTE IsSneaking;     // sneaking or snared ; 0 = Normal Movement Speed, 1 = Slow Movement Speed
-  /* 0x00B0 */ BYTE IsPlayerKill;   // PVP flagged with red name by Priest of Discord
-  /* 0x00B1 */ BYTE StandingState;  // STANDING_STATE_x
-  /* 0x00B2 */ BYTE LightType;      // LIGHT_TYPE_x
+  /* 0x00AE */ BYTE VisibilityState;  // 0 = Visible, 1 = Invisible, 2 = Invis to animal, 3 = IVU
+  /* 0x00AF */ BYTE IsSneaking;       // sneaking or snared ; 0 = Normal Movement Speed, 1 = Slow Movement Speed
+  /* 0x00B0 */ BYTE IsPlayerKill;     // PVP flagged with red name by Priest of Discord
+  /* 0x00B1 */ BYTE StandingState;    // STANDING_STATE_x
+  /* 0x00B2 */ BYTE LightType;        // LIGHT_TYPE_x
   /* 0x00B3 */ BYTE Face;
   /* 0x00B4 */ WORD EquipmentMaterialType[7];    // EQUIPMENT_MATERIAL_TYPE_x ; Head,Chest,Arms,Wrist,Hands,Legs,Feet
   /* 0x00C2 */ WORD EquipmentPrimaryItemType;    // EQUIPMENT_ITEM_TYPE_x ; Primary

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -539,7 +539,7 @@ std::string NamePlate::generate_nameplate_text(const Zeal::GameStructures::Entit
       ((is_self && setting_hide_self.get()) || (setting_hide_raid_pets.get() && Zeal::Game::is_raid_pet(entity))))
     return std::string();
 
-  if (is_self && setting_x.get()) return std::string((entity.IsHidden == 0x01) ? "(X)" : "X");
+  if (is_self && setting_x.get()) return std::string((entity.VisibilityState == 0x01) ? "(X)" : "X");
 
   if (entity.Race >= 0x8cd)  // Some sort of magic higher level races w/out name trimming.
     return std::string(entity.Name);
@@ -591,10 +591,10 @@ std::string NamePlate::generate_nameplate_text(const Zeal::GameStructures::Entit
   }
 
   // Finally work on the primary player name with embellishments.
-  if (entity.IsHidden == 0x01)  // Client code only does () on normal invisibility.
+  if (entity.VisibilityState == 0x01)  // Client code only does () on normal invisibility.
     text += "(";
   text += Zeal::Game::trim_name(entity.Name);
-  if (entity.IsHidden == 0x01) text += ")";
+  if (entity.VisibilityState == 0x01) text += ")";
 
   if (should_show_last_name(show_name) && entity.LastName[0]) {
     text += " ";

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -328,6 +328,11 @@ void ui_options::LoadColors() {
   {
     if (color_buttons.count(39)) color_buttons[39]->TextColor.ARGB = D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0);  // White
   }
+  if (!ini->exists("ZealColors", "Color40"))  // FCD: My big hits
+  {
+    if (color_buttons.count(40))
+      color_buttons[40]->TextColor.ARGB = D3DCOLOR_XRGB(0xf9, 0x9b, 0xff);  // Light purple/pink.
+  }
 
   for (auto &[index, btn] : color_buttons) {
     if (ini->exists("ZealColors", "Color" + std::to_string(index)))

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -1280,6 +1280,35 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_Color40">
+    <ScreenID>Zeal_Color40</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>580</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>41 - My big hit</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Page item="Tab_Colors">
     <ScreenID>Tab_Colors</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -1345,6 +1374,7 @@
     <Pieces>Zeal_Color37</Pieces>
     <Pieces>Zeal_Color38</Pieces>
     <Pieces>Zeal_Color39</Pieces>
+    <Pieces>Zeal_Color40</Pieces>
 
     <Location>
       <X>0</X>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Colors.xml
@@ -1280,6 +1280,35 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_Color40">
+    <ScreenID>Zeal_Color40</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>20</X>
+      <Y>1160</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>41 - My big hit</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
   <Page item="Tab_Colors">
     <ScreenID>Tab_Colors</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -1345,6 +1374,7 @@
     <Pieces>Zeal_Color37</Pieces>
     <Pieces>Zeal_Color38</Pieces>
     <Pieces>Zeal_Color39</Pieces>
+    <Pieces>Zeal_Color40</Pieces>
 
     <Location>
       <X>0</X>


### PR DESCRIPTION
- Fixed zeal font nameplate visibility for players with IVU
  - Changed field name to make this more obvious in future

- Zeal cam x sensitivity was effectively doubled when both LMB and RMB were held. Fixed it to be consistent with other minor cleanups.

- Added a new "My big hits" Zeal color (41) for setting the color of big hits (spells or melee above threshold, backstabs) in floating combat text