### PR TITLE
Use executable game path as root dir

### DIFF
--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -176,6 +176,8 @@ GameStructures::GameClass *get_game();
 GameStructures::Display *get_display();
 const char *get_ui_skin();
 std::string get_ui_ini_filename();
+std::string get_host_tag();  // Returns the short host description tag at end of ui filenames.
+std::filesystem::path get_game_path();
 std::filesystem::path get_default_ui_skin_path();
 int get_gamestate();
 int get_channel_number(const char *name);  // Zero-based channel number.

--- a/Zeal/looting.cpp
+++ b/Zeal/looting.cpp
@@ -442,13 +442,14 @@ bool Looting::is_trade_protected(Zeal::GameUI::TradeWnd *wnd) const {
   return false;
 }
 
-static std::string get_protected_items_filename() {
+static std::filesystem::path get_protected_items_filename() {
   if (!Zeal::Game::get_char_info()) return "";
-  return std::format(".\\{0}_protected.ini", Zeal::Game::get_char_info()->Name);
+  std::string filename = std::format("{0}_protected.ini", Zeal::Game::get_char_info()->Name);
+  return Zeal::Game::get_game_path() / std::filesystem::path(filename);
 }
 
 void Looting::load_protected_items() {
-  std::string filename = get_protected_items_filename();
+  std::filesystem::path filename = get_protected_items_filename();
   if (filename.empty() || !std::filesystem::exists(filename)) return;  // Game not initialized yet or no protected file.
 
   std::ifstream input_file(filename);

--- a/Zeal/outputfile.cpp
+++ b/Zeal/outputfile.cpp
@@ -14,8 +14,9 @@ using Zeal::GameEnums::EquipSlot::EquipSlot;
 static std::string IDToEquipSlot(int equipSlot) {
   switch (equipSlot) {
     case EquipSlot::LeftEar:
+      return "Ear1";
     case EquipSlot::RightEar:
-      return "Ear";
+      return "Ear2";
     case EquipSlot::Head:
       return "Head";
     case EquipSlot::Face:
@@ -29,8 +30,9 @@ static std::string IDToEquipSlot(int equipSlot) {
     case EquipSlot::Back:
       return "Back";
     case EquipSlot::LeftWrist:
+      return "Wrist1";
     case EquipSlot::RightWrist:
-      return "Wrist";
+      return "Wrist2";
     case EquipSlot::Range:
       return "Range";
     case EquipSlot::Hands:
@@ -40,8 +42,9 @@ static std::string IDToEquipSlot(int equipSlot) {
     case EquipSlot::Secondary:
       return "Secondary";
     case EquipSlot::LeftFinger:
+      return "Finger1";
     case EquipSlot::RightFinger:
-      return "Fingers";
+      return "Finger2";
     case EquipSlot::Chest:
       return "Chest";
     case EquipSlot::Legs:
@@ -71,14 +74,15 @@ void OutputFile::export_inventory(const std::vector<std::string> &args) {
 
   std::ostringstream oss;
   std::string t = "\t";  // output spacer
-  oss << "Location" << t << "Name" << t << "ID" << t << "Count" << t << "Slots" << std::endl;
+  oss << "Location" << t << "Name" << t << "ID" << t << "Count/Charges" << t << "Slots" << std::endl;
 
   // Processing Equipment
   for (size_t i = 0; i < GAME_NUM_INVENTORY_SLOTS; ++i) {
     Zeal::GameStructures::GAMEITEMINFO *item = self->CharInfo->InventoryItem[i];
     // GAMEITEMINFO->EquipSlot value only updates when a load happens. Don't use it for this.
     if (item) {
-      oss << IDToEquipSlot(i) << t << item->Name << t << item->ID << t << 1 << t << 0 << std::endl;
+      int count = item->Common.StackCount;  // Union with charges.
+      oss << IDToEquipSlot(i) << t << item->Name << t << item->ID << t << count << t << 0 << std::endl;
     } else {
       oss << IDToEquipSlot(i) << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
     }
@@ -94,16 +98,16 @@ void OutputFile::export_inventory(const std::vector<std::string> &args) {
           for (int j = 0; j < capacity; ++j) {
             Zeal::GameStructures::GAMEITEMINFO *bag_item = item->Container.Item[j];
             if (bag_item) {
-              int stack_count = ItemIsStackable(bag_item) ? static_cast<int>(bag_item->Common.StackCount) : 1;
-              oss << "General" << i + 1 << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->ID << t
-                  << stack_count << t << 0 << std::endl;
+              int count = bag_item->Common.StackCount;  // Union with charges.
+              oss << "General" << i + 1 << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->ID << t << count
+                  << t << 0 << std::endl;
             } else {
               oss << "General" << i + 1 << "-Slot" << j + 1 << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
             }
           }
         } else {
-          int stack_count = ItemIsStackable(item) ? static_cast<int>(item->Common.StackCount) : 1;
-          oss << "General" << i + 1 << t << item->Name << t << item->ID << t << stack_count << t << 0 << std::endl;
+          int count = item->Common.StackCount;  // Union with charges.
+          oss << "General" << i + 1 << t << item->Name << t << item->ID << t << count << t << 0 << std::endl;
         }
       } else {
         oss << "General" << i + 1 << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
@@ -126,9 +130,9 @@ void OutputFile::export_inventory(const std::vector<std::string> &args) {
         for (int i = 0; i < capacity; ++i) {
           Zeal::GameStructures::GAMEITEMINFO *bag_item = item->Container.Item[i];
           if (bag_item) {
-            int stack_count = ItemIsStackable(bag_item) ? static_cast<int>(bag_item->Common.StackCount) : 1;
+            int count = bag_item->Common.StackCount;  // Union with charges.
             oss << "Held"
-                << "-Slot" << i + 1 << t << bag_item->Name << t << bag_item->ID << t << stack_count << t << 0
+                << "-Slot" << i + 1 << t << bag_item->Name << t << bag_item->ID << t << count << t << 0
                 << std::endl;
           } else {
             oss << "Held"
@@ -136,8 +140,8 @@ void OutputFile::export_inventory(const std::vector<std::string> &args) {
           }
         }
       } else {
-        int stack_count = ItemIsStackable(item) ? static_cast<int>(item->Common.StackCount) : 1;
-        oss << "Held" << t << item->Name << t << item->ID << t << stack_count << t << 0 << std::endl;
+        int count = item->Common.StackCount;  // Union with charges.
+        oss << "Held" << t << item->Name << t << item->ID << t << count << t << 0 << std::endl;
       }
     } else {
       ULONGLONG coin = 0;
@@ -166,16 +170,16 @@ void OutputFile::export_inventory(const std::vector<std::string> &args) {
           for (int j = 0; j < capacity; ++j) {
             Zeal::GameStructures::GAMEITEMINFO *bag_item = item->Container.Item[j];
             if (bag_item) {
-              int stack_count = ItemIsStackable(bag_item) ? static_cast<int>(bag_item->Common.StackCount) : 1;
-              oss << label << slot << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->ID << t << stack_count
+		          int count = bag_item->Common.StackCount;  // Union with charges.
+              oss << label << slot << "-Slot" << j + 1 << t << bag_item->Name << t << bag_item->ID << t << count
                   << t << 0 << std::endl;
             } else {
               oss << label << slot << "-Slot" << j + 1 << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
             }
           }
         } else {
-          int stack_count = ItemIsStackable(item) ? static_cast<int>(item->Common.StackCount) : 1;
-          oss << label << slot << t << item->Name << t << item->ID << t << stack_count << t << 0 << std::endl;
+          int count = item->Common.StackCount;  // Union with charges.
+          oss << label << slot << t << item->Name << t << item->ID << t << count << t << 0 << std::endl;
         }
       } else {
         oss << label << slot << t << "Empty" << t << 0 << t << 0 << t << 0 << std::endl;
@@ -248,6 +252,7 @@ void OutputFile::write_to_file(std::string data, std::string file_arg, std::stri
   if (filename.empty()) {
     filename = Zeal::Game::get_self()->CharInfo->Name;
     filename += "-" + file_arg;
+    filename += Zeal::Game::get_host_tag();
   }
   filename += ".txt";
 

--- a/Zeal/spellsets.cpp
+++ b/Zeal/spellsets.cpp
@@ -257,7 +257,7 @@ void SpellSets::destroy_menus(std::vector<SpellSets::MenuPair> &menus) {
 void SpellSets::initialize_ini_filename() {
   const char *name = Zeal::Game::get_char_info() ? Zeal::Game::get_char_info()->Name : "unknown";
   std::string filename = std::string(name) + "_spellsets.ini";
-  std::filesystem::path file_path = std::filesystem::current_path() / std::filesystem::path(filename);
+  std::filesystem::path file_path = Zeal::Game::get_game_path() / std::filesystem::path(filename);
   ini.set(file_path.string());
 }
 

--- a/Zeal/ui_skin.cpp
+++ b/Zeal/ui_skin.cpp
@@ -226,7 +226,7 @@ bool UISkin::is_ui_skin_big_fonts_mode(const char *ui_skin) {
   std::filesystem::path ui_skin_path = std::filesystem::path(ui_skin);  // Drop uifiles if present.
   std::filesystem::path ui_skin_name = ui_skin_path.filename();
   if (ui_skin_name.empty()) ui_skin_name = ui_skin_path.parent_path().filename();
-  std::filesystem::path file_path = std::filesystem::current_path() / std::filesystem::path("uifiles") / ui_skin_name /
+  std::filesystem::path file_path = Zeal::Game::get_game_path() / std::filesystem::path("uifiles") / ui_skin_name /
                                     std::filesystem::path(kBigFontsTriggerFilename);
   return std::filesystem::exists(file_path);
 }
@@ -252,7 +252,7 @@ static void print_block_message(const std::string &skin_name, const std::string 
 static bool is_skin_valid(const std::string &skin_name) {
   // First reject it if the ui folder doesn't exist.
   std::filesystem::path ui_skin_path =
-      std::filesystem::current_path() / std::filesystem::path("uifiles") / std::filesystem::path(skin_name);
+      Zeal::Game::get_game_path() / std::filesystem::path("uifiles") / std::filesystem::path(skin_name);
   if (!std::filesystem::exists(ui_skin_path)) {
     print_block_message(skin_name, "Skin folder does not exist in uifiles");
     return false;
@@ -305,8 +305,8 @@ void UISkin::initialize_mode(ZealService *zeal) {
   auto ui_skin = get_global_default_ui_skin_name();
   is_big_fonts = is_ui_skin_big_fonts_mode(ui_skin.c_str()) && patch_big_fonts_mode(zeal);
 
-  zeal_resources_path = std::filesystem::current_path() / std::filesystem::path("uifiles") /
-                        std::filesystem::path(kDefaultZealFileSubfolder);
+  zeal_resources_path =
+      Zeal::Game::get_game_path() / std::filesystem::path("uifiles") / std::filesystem::path(kDefaultZealFileSubfolder);
   zeal_xml_path = zeal_resources_path;
   if (is_big_fonts) zeal_xml_path /= kBigFontsXmlSubfolder;
 }

--- a/Zeal/ui_zoneselect.cpp
+++ b/Zeal/ui_zoneselect.cpp
@@ -124,7 +124,9 @@ void ui_zoneselect::InitUI() {
     std::deque<std::vector<std::string>> zone_list;
     for (int i = 0; i < 225; i++) {
       if (world->Zones[i]) {
-        if (!std::filesystem::exists(std::string(world->Zones[i]->name_short) + ".s3d")) continue;
+        std::string filename = std::string(world->Zones[i]->name_short) + ".s3d";
+        std::filesystem::path filepath = Zeal::Game::get_game_path() / std::filesystem::path(filename);
+        if (!std::filesystem::exists(filepath)) continue;
         zones[world->Zones[i]->name_long] = world->Zones[i]->zone_id;
         if (world->Zones[i]->zone_id == ZealService::get_instance()->charselect->ZoneIndex.get()) {
           lst->SelectedIndex = i;


### PR DESCRIPTION
- Swapped the use of filesystem::current_path() for a new function that retrieves the executable file folder (with a fallback to the current_path)

- Also tweaked outputfile inventory and spellbooks to add the host suffix before the ini to reduce collisions when sharing a game install between hosts

- The outputfile inventory was also updated to:
  - separate ear, wrists, and fingers
  - export either charges or stack count in the third column