### PR TITLE
Add mystats support for PE, LR AAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ ___
   - **Description:** specifies an item ID that will be left as the last item when using /lootall on your corpse 
 
 - `/map`
-  - **Arguments:** `on`, `off`, `size`, `alignment`, `marker`, `background`, `zoom`, `poi`, `labels`, `level`, `ring`, `grid`
+  - **Arguments:** `on`, `off`, `size`, `alignment`, `marker`, `background`, `zoom`, `poi`, `labels`, `level`, `ring`, `grid`, `loc`
   - **Example:** See In-game map section below
   - **Description:** controls map enable, size, labels, zoom, and markers
 
@@ -760,7 +760,9 @@ are colored orange.
 #### Map ring
 A simple distance ring around the current position is available. The distance can be auto-set
 based on the tracking skill for rangers, druids, and bards, so they can simply toggle the ring
-on and off with `/map ring` (or explicitly on or off with `ring on` or `ring off`).
+on and off with `/map ring` (or explicitly on or off with `ring on` or `ring off`). The
+`/map ring heading` command toggles on and off a setting to add a line from your position to
+the ring radius in the direction of your heading.
 
 * Command examples:
   - `/map ring` if visible or a non-tracker, turns ring off
@@ -813,6 +815,7 @@ markers have a label centered above them, with the default set to the marker loc
 is no set limit to the number of markers. See how to clear them below.
 
 * Zeal options slider to adjust the marker size
+* The `/map loc` command will drop a marker at your current position
 * Command examples:
   - `/map marker 1100 -500` adds a map marker at /loc of 1100, -500 labeled "(1100, -500)"
   - `/map 1100 -500` is a shortcut for the command above to set a marker at 1100, -500

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -2474,8 +2474,13 @@ int get_avoidance(bool include_combat_agility) {
   auto actor_info = self ? self->ActorInfo : nullptr;
   if (!actor_info) return avoidance;
 
-  UINT combat_agility = actor_info->AAAbilities[0x22];  // Combat Agility AA skill = 0x22.
+  // The server is summing CombatAgility, PhysicalEnhancement, and LightningReflexes as effect 172.
+  BYTE combat_agility = actor_info->AAAbilities[0x22];  // Combat Agility AA skill = 0x22.
   int boost_percent = (combat_agility == 3) ? 10 : (combat_agility == 2) ? 5 : (combat_agility == 1) ? 2 : 0;
+  if (actor_info->AAAbilities[120])                                      // Physical Enhancement AA skill.
+    boost_percent += 2;                                                  // Extra 2%.
+  BYTE lightning_reflexes = actor_info->AAAbilities[151];                // Lightning reflexes AA skill.
+  if (lightning_reflexes <= 5) boost_percent += 3 * lightning_reflexes;  // 3% / level.
   int extra_avoidance = avoidance * boost_percent / 100;
 
   // The server code adds the extra avoidance before the drunk derating, so we have to

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -354,6 +354,17 @@ void ZealService::AddCommands() {
       ZealService::get_instance()->entity_manager.get()->Dump();
       return true;
     }
+    if (args.size() == 3 && args[1] == "aa") {
+      int index = 0;
+      if (Zeal::String::tryParse(args[2], &index) && index <= 227)
+        Zeal::Game::print_chat("AA[%d] = %d", index, Zeal::Game::get_self()->ActorInfo->AAAbilities[index]);
+      else
+        for (int i = 0; i <= 227; ++i) {
+          BYTE value = Zeal::Game::get_self()->ActorInfo->AAAbilities[i];
+          if (value) Zeal::Game::print_chat("AA[%d] = %d", i, value);
+        }
+      return true;
+    }
     if (args.size() == 2 && args[1] == "check")  // Run a heap / memory check.
     {
       int heap_valid1 = HeapValidate(GetProcessHeap(), 0, NULL);
@@ -427,7 +438,7 @@ void ZealService::AddCommands() {
   });
 
   commands_hook->Add(
-      "/mystats", {}, "Calculate and report your current stats.", [this](std::vector<std::string> &args) {
+      "/mystats", {"/mystat"}, "Calculate and report your current stats.", [this](std::vector<std::string> &args) {
         using Zeal::Game::print_chat;
         const char kMarker = 0x12;  // Link marker.
         int item_id = 0;


### PR DESCRIPTION
- Mystats now includes the bonuses from physical enhancement and lightning reflex in the avoidance calculation (in addition to combat agility)