### PR TITLE
Block loading multiple zeals

### DIFF
--- a/Zeal/dllmain.cpp
+++ b/Zeal/dllmain.cpp
@@ -2,6 +2,15 @@
 
 #include "zeal.h"
 
+// Returns true if it detects that a version of Zeal has already been loaded.
+static bool is_zeal_already_loaded() {
+  // Simple hack check is to see if client sided mana ticking was disabled (since before 0.3.0).
+  // The patch performs: mem::set(0x4C3F93, 0x90, 7);
+  const uint8_t *ptr = reinterpret_cast<uint8_t *>(0x004C3F93);
+  bool already_patched = (*ptr == 0x90);  // Already loaded if set to a nop.
+  return already_patched;
+}
+
 // The zeal.asi is loaded by the mss which happens in-between the login screen and character select.
 // This is unlike most other libraries that are loaded only once.  In order to avoid
 // loading / unloading with multiple patching cycles, the zeal.asi dll pins itself into memory.
@@ -19,16 +28,20 @@ static void __fastcall initialize_zeal(void *this_game, int unused_edx) {
                      (LPCSTR)&initialize_zeal,  // An address within this module.
                      &hModule);
 
-  // Create the zeal super-class that installs patches, hooks, callbacks, and things like
-  // the named pipe thread.
-  ZealService::create();
+  // Do not load Zeal if a version has already been loaded. This can happen normally on
+  // subsequent world logins or it can happen if the user has multiple zeal asi files.
+  if (!is_zeal_already_loaded()) {
+    // Create the zeal super-class that installs patches, hooks, callbacks, and things like
+    // the named pipe thread.
+    ZealService::create();
+  }
 
   // Call the original loadOptions.
   reinterpret_cast<void(_fastcall *)(void *, int)>(0x00536ce0)(this_game, unused_edx);
 }
 
 static void handle_process_attach() {
-  // Bail out if already patched.
+  // Bail out if already patched (either a previous login cycle or another zeal asi file).
   if (*ptr_load_options_call_jump_value != load_options_call_addr_jump_value_unpatched) return;
 
   // Install the patch by replacing the relative jump in a call to loadOptions with a jump


### PR DESCRIPTION
- Checks if some version of Zeal has already performed a core patch and if so it skips loading Zeal