### PR TITLE
Chat filter cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,9 +293,9 @@ ___
   - **Description:** sorts your current group members in the ui  using /sq 1 2 will swap players 1 and 2 in your group on your ui.
 
 - `/spellset`
-  - **Arguments:** `save`, `load`, `delete`
-  - **Example:** `/spellset save buffs`
-  - **Example:** `/spellset load buffs`
+  - **Arguments:** `save <name>`, `load <name>`, `delete <name>`, `list`
+  - **Example:** `/spellset save heals`
+  - **Example:** `/spellset load nukes`
   - **Example:** `/spellset delete buffs`
   - **Description:** allows you to save and load spellsets
 

--- a/Zeal/chatfilter.h
+++ b/Zeal/chatfilter.h
@@ -50,16 +50,18 @@ class chatfilter {
   void callback_clean_ui();
   void callback_hit(Zeal::GameStructures::Entity *source, Zeal::GameStructures::Entity *target, WORD type,
                     short spell_id, short damage, char output_text);
+  void handle_suppress_lifetaps(bool value);
+
   ZealSetting<bool> setting_suppress_missed_notes = {false, "Zeal", "SuppressMissedNotes", false};
   ZealSetting<bool> setting_suppress_other_fizzles = {false, "Zeal", "SupressOtherFizzles", false};
-  ZealSetting<bool> settings_suppress_lifetap_feeling = {false, "Zeal", "SuppressLifeTapFeeling", false};
+  ZealSetting<bool> setting_suppress_other_pets = {false, "Zeal", "SuppressOtherPets", false};
+  ZealSetting<bool> settings_suppress_lifetap_feeling = {false, "Zeal", "SuppressLifeTapFeeling", false,
+                                                         [this](bool val) { handle_suppress_lifetaps(val); }};
   ZealSetting<bool> setting_report_other_non_melee_dmg = {true, "Zeal", "ReportOtherNonMeleeDmg", false};
   bool isExtendedCM(int channelMap, int applyOffset = 0);
   bool isStandardCM(int channelMap, int applyOffset = 0);
   int current_string_id = 0;
   bool isDamage = false;
-  bool isMyPetSay = false;
-  bool isPetMessage = false;
   int menuIndex = -1;
   damage_data damageData;
   ~chatfilter();

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1889,6 +1889,22 @@ const char *get_spell_name(int spell_id) {
   return spell->Name;
 }
 
+void dump_spell_info(int spell_id) {
+  const auto *spell_mgr = Zeal::Game::get_spell_mgr();
+  if (spell_id < 1 || spell_id >= GAME_NUM_SPELLS || !spell_mgr) {
+    print_chat("Invalid spell id: %d", spell_id);
+    return;
+  };
+
+  const auto *spell = spell_mgr->Spells[spell_id];
+  if (!spell) {
+    print_chat("Null spell at id: %d", spell_id);
+    return;
+  };
+
+  print_chat("[%d]: %s:, SpellType: %d, TargetType: %d", spell_id, spell->Name, spell->SpellType, spell->TargetType);
+}
+
 Zeal::GameStructures::Entity *get_self() { return *(Zeal::GameStructures::Entity **)Zeal::Game::Self; }
 
 Zeal::GameStructures::Entity *get_pet() {

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -226,6 +226,7 @@ Zeal::GameStructures::Entity *get_pet();
 Zeal::GameStructures::SPELLMGR *get_spell_mgr();
 int get_spell_level(int spell_id);
 const char *get_spell_name(int spell_id);
+void dump_spell_info(int spell_id);
 Zeal::GameStructures::Entity *get_controlled();
 Zeal::GameStructures::ViewActor *get_view_actor();
 Zeal::GameStructures::CameraInfo *get_camera();

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -1480,8 +1480,8 @@ struct SPELL {
   /*0x088*/ BYTE Unknown0x088;
   /*0x089**/ BYTE Resist;  // 0=un 1=mr 2=fr 3=cr 4=pr 5=dr 6=chromatic
   /*0x08a**/ BYTE Attrib[0xc];
-  /*0x096**/ BYTE
-      TargetType;  // 03=Group v1, 04=PB AE, 05=Single, 06=Self, 08=Targeted AE, 0e=Pet, 28=AE PC v2, 29=Group v2
+  /*0x096**/ BYTE TargetType;  // 3=Groupv1, 4=PBAoE, 5=Single, 6=Self, 8=TargetAoE, 9=Animal, 10=Undead, 11=Summoned,
+                               // 13=Tap, 14=Pet, 15=Corpse, 16=Plant, 20=TargetAoETap 28=AE PC v2, 29=Group v2
   /*0x097**/ BYTE FizzleAdj;
   /*0x098**/ BYTE Skill;
   /*0x099*/ BYTE Location;  // 01=Outdoors, 02=dungeons, ff=Any

--- a/Zeal/spellsets.cpp
+++ b/Zeal/spellsets.cpp
@@ -508,33 +508,37 @@ SpellSets::SpellSets(ZealService *zeal) {
 
   zeal->commands_hook->Add("/spellset", {"/ss"}, "Load, save, delete or list your spellsets.",
                            [this, zeal](std::vector<std::string> &args) {
-                             if (args.size() < 3 || !Zeal::Game::get_self() || !Zeal::Game::get_char_info()) {
-                               Zeal::Game::print_chat("usage: /spellset save/load/list [name]");
-                             } else {
+                             if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "list")) {
+                               initialize_ini_filename();
+                               std::vector<std::string> sets = ini.getSectionNames();
+                               Zeal::Game::print_chat("--- spell sets (%i) ---", sets.size());
+                               for (auto &set : sets) {
+                                 Zeal::Game::print_chat(set);
+                               }
+                               Zeal::Game::print_chat("--- end of spell sets ---", sets.size());
+                               return true;
+                             }
+                             if (args.size() == 3 && Zeal::Game::get_self() && Zeal::Game::get_char_info()) {
                                if (Zeal::String::compare_insensitive(args[1], "test")) {
                                  create_spells_menus();
                                  create_spellsets_menus();
+                                 return true;
                                }
                                if (Zeal::String::compare_insensitive(args[1], "save")) {
                                  save(args[2]);
+                                 return true;
                                }
                                if (Zeal::String::compare_insensitive(args[1], "delete") ||
                                    Zeal::String::compare_insensitive(args[1], "remove")) {
                                  remove(args[2]);
+                                 return true;
                                }
                                if (Zeal::String::compare_insensitive(args[1], "load")) {
                                  load(args[2]);
-                               }
-                               if (Zeal::String::compare_insensitive(args[1], "list")) {
-                                 initialize_ini_filename();
-                                 std::vector<std::string> sets = ini.getSectionNames();
-                                 Zeal::Game::print_chat("--- spell sets (%i) ---", sets.size());
-                                 for (auto &set : sets) {
-                                   Zeal::Game::print_chat(set);
-                                 }
-                                 Zeal::Game::print_chat("--- end of spell sets ---", sets.size());
+                                 return true;
                                }
                              }
+                             Zeal::Game::print_chat("usage: /spellset save/load/delete [name], /spellset list");
                              return true;
                            });
 }

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -369,6 +369,9 @@ void ui_options::InitGeneral() {
   ui->AddCheckboxCallback(wnd, "Zeal_SuppressOtherFizzles", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_SuppressOtherPets", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->chatfilter_hook->setting_suppress_other_pets.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_SuppressLifetapFeeling", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->chatfilter_hook->settings_suppress_lifetap_feeling.set(wnd->Checked);
   });
@@ -919,6 +922,8 @@ void ui_options::UpdateOptionsGeneral() {
                  ZealService::get_instance()->chatfilter_hook->setting_suppress_missed_notes.get());
   ui->SetChecked("Zeal_SuppressOtherFizzles",
                  ZealService::get_instance()->chatfilter_hook->setting_suppress_other_fizzles.get());
+  ui->SetChecked("Zeal_SuppressOtherPets",
+                 ZealService::get_instance()->chatfilter_hook->setting_suppress_other_pets.get());
   ui->SetChecked("Zeal_SuppressLifetapFeeling",
                  ZealService::get_instance()->chatfilter_hook->settings_suppress_lifetap_feeling.get());
   ui->SetChecked("Zeal_ReportOtherNonMeleeDmg",

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -1486,12 +1486,43 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_SuppressOtherPets">
+    <ScreenID>Zeal_SuppressOtherPets</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>442</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Suppress messages from other's pets</TooltipReference>
+    <Text>Suppress other pets</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <Button item="Zeal_ReportOtherNonMeleeDmg">
     <ScreenID>Zeal_ReportOtherNonMeleeDmg</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>360</X>
-      <Y>442</Y>
+      <Y>464</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -1596,6 +1627,7 @@
     <Pieces>Zeal_SlashNotPoke</Pieces>
     <Pieces>Zeal_AltTransportCats</Pieces>
     <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
+    <Pieces>Zeal_SuppressOtherPets</Pieces>
     <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
     <Location>
       <X>0</X>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -1486,12 +1486,43 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_SuppressOtherPets">
+    <ScreenID>Zeal_SuppressOtherPets</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>884</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Suppress messages from other's pets</TooltipReference>
+    <Text>Suppress other pets</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <Button item="Zeal_ReportOtherNonMeleeDmg">
     <ScreenID>Zeal_ReportOtherNonMeleeDmg</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>720</X>
-      <Y>884</Y>
+      <Y>928</Y>
     </Location>
     <Size>
       <CX>300</CX>
@@ -1596,6 +1627,7 @@
     <Pieces>Zeal_SlashNotPoke</Pieces>
     <Pieces>Zeal_AltTransportCats</Pieces>
     <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
+    <Pieces>Zeal_SuppressOtherPets</Pieces>
     <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
     <Location>
       <X>0</X>

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -380,6 +380,11 @@ void ZealService::AddCommands() {
                              heap_summary.cbCommitted / 1024 / 1024);
       return true;
     }
+    if (args.size() == 3 && args[1] == "spell") {
+      int spell_id = -1;
+      if (Zeal::String::tryParse(args[2], &spell_id)) Zeal::Game::dump_spell_info(spell_id);
+      return true;
+    }
     if (args.size() == 3 && args[1] == "get_command") {
       auto command = Zeal::Game::get_command_struct(args[2]);
       if (command)


### PR DESCRIPTION
* Chat filter cleanups
  - Fixed suppress_lifetaps to properly suppress both the feel better and beam smile messages
  - Updated pet message filtering to be more reliable (includes taunting, waiting for your order) for my vs other pet filtering
  - Added a suppress other pets option that snuffs messages from other player's pets (except for leader ID messages)

* Cleaned up /spellset parser (list doesn't need a dummy argument, etc)