### PR TITLE
Add /outputfile format setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,11 +206,13 @@ ___
 
 - `/outputfile`
   - **Aliases:** `/output`, `/out`
-  - **Arguments:** `inventory | spellbook` `[optional_name]`
+  - **Arguments:** `inventory | spellbook | raidlist` `[optional_filename]`, `format [0 | 1]`
   - **Example:** `/outputfile inventory my_inventory`
   - **Description:**
     - `inventory` outputs information about your equipment, inventory bag slots, held item, and bank slots to a file.
     - `spellbook` outputs a list of all spell ids current scribed in your spellbook.
+    - `raidlist` outputs a raid 'tick' with a list of players in the raid.
+    - `format` sets the format of the export files (0 = default, 1 = new style with host tag)
 
 - `/pandelay`
   - **Arguments:** `ms delay`, `none`

--- a/Zeal/outputfile.h
+++ b/Zeal/outputfile.h
@@ -12,8 +12,9 @@ class OutputFile {
   void export_spellbook(const std::vector<std::string> &args = {});
 
   ZealSetting<bool> setting_export_on_camp = {false, "Zeal", "ExportOnCamp", false};
+  ZealSetting<int> setting_export_format = {0, "Zeal", "ExportFormat", false};
 
  private:
   void export_raidlist(std::vector<std::string> &args);
-  void write_to_file(std::string data, std::string filename, std::string optional_name);
+  void write_to_file(std::string data, std::string filename, std::string optional_name, bool add_host_tag = false);
 };


### PR DESCRIPTION
- Added the /outputfile format [0 | 1] command and setting to toggle the legacy (0) or updated (1) export format of the inventory and spellbook files