### PR TITLE
Add some /consent enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ ___
   - **Aliases:** `/autoba`, `/ab`
   - **Description:** Drops whatever is on your cursor into your bank. [requires you to be at a banker] (not fully functional atm)
 
+- `/autoconsent`
+  - **Description:** Toggles the enable of auto-consenting from a /tc sent by a group or raid member.
+
 - `/autoinventory`
   - **Aliases:** `/autoinv`, `/ai`
   - **Description:** Drops whatever is on your cursor into your inventory.
@@ -110,6 +113,9 @@ ___
 
 - `/cls`
   - **Description:** Adds cls alias for clearchat.
+
+- `/consentmonks` or `/consentrogues`
+  - **Description:** Executes a /consent on all monks or rogues in the raid.
 
 - `/corpsedrag`
   - **Aliases:** `/drag`
@@ -253,6 +259,10 @@ ___
           enable, value, and protected list are stored per character with the list stored in the
           `./<character_name>_protected.ini` file.
 
+- `/replyconsent`
+  - **Aliases:** `/rc`
+  - **Description:** Executes a /consent on the last player to send you a tell.
+
 - `/reloadskin`
   - **Description:** reloads your current skin using ini.
 
@@ -319,6 +329,11 @@ ___
   - **Example:** `/targetring 0.25`
   - **Example:** `/targetring indicator` toggles auto attack indicator.
   - **Description:** toggles targetring on/off.
+
+- `/tellconsent`
+  - **Aliases:** `/tc`
+  - **Description:** Sends a 'Consent me' tell to the owner of the currently targeted corpse. Will automatically
+                     target the nearest player corpse within a distance of 50 if no active target.
 
 - `/tellwindows`
   - **Description:** Toggle tell windows. 

--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -25,17 +25,17 @@
 #include "zeal.h"
 
 std::map<std::string, std::string> channelPrefixes = {
-  {"guild", "G"},             // Guild
-  {"party", "P"},             // Group (Received)
-  {"group", "P"},             // Group (Sent)
-  {"shout", "Sh"},            // Shout
-  {"auction", "A"},           // Auction
-  {"out of character", "O"},  // OOC
-  {"BROADCAST", "B"},         // Broadcast
-  {"tell", "Fr"},             // Tell (Received)
-  {"say", "S"},               // Say
-  {"told", "To"},             // TellEcho (Sent)
-  {"raid", "R"},              // Raid
+    {"guild", "G"},             // Guild
+    {"party", "P"},             // Group (Received)
+    {"group", "P"},             // Group (Sent)
+    {"shout", "Sh"},            // Shout
+    {"auction", "A"},           // Auction
+    {"out of character", "O"},  // OOC
+    {"BROADCAST", "B"},         // Broadcast
+    {"tell", "Fr"},             // Tell (Received)
+    {"say", "S"},               // Say
+    {"told", "To"},             // TellEcho (Sent)
+    {"raid", "R"},              // Raid
 };
 
 std::string playerRolling;
@@ -89,11 +89,11 @@ std::string StripSpecialCharacters(const std::string &input) {
 std::string abbreviateChat(const std::string &original_message) {
   // Pattern to look for chat messages
   static const std::regex chat_pattern(
-    R"(^([\w ]+) (?:(?:say to your |says? |tells the |tell your |(told|tell)s? )(say)?(?:\w+:)?([\w\d: ]+)|(auction|say|shout|BROADCAST)[sS]?),?[^']+'(.*)'\s*$)");
+      R"(^([\w ]+) (?:(?:say to your |says? |tells the |tell your |(told|tell)s? )(say)?(?:\w+:)?([\w\d: ]+)|(auction|say|shout|BROADCAST)[sS]?),?[^']+'(.*)'\s*$)");
 
   static const std::regex roll_player_pattern(R"(^\*\*A Magic Die is rolled by (\w+)\.$)");
   static const std::regex roll_result_pattern(
-    R"(^\*\*It could have been any number from (\d+) to (\d+), but this time it turned up a (\d+)\.$)");
+      R"(^\*\*It could have been any number from (\d+) to (\d+), but this time it turned up a (\d+)\.$)");
 
   std::smatch match;
 
@@ -174,36 +174,18 @@ std::string abbreviateChat(const std::string &original_message) {
 
 DWORD get_class_color(std::string character_name, short channel) {
   static const std::unordered_set<int> valid_channels_you = {
-    USERCOLOR_SPELLS,
-    USERCOLOR_YOU_HIT_OTHER,
-    USERCOLOR_OTHER_HIT_YOU,
-    USERCOLOR_YOU_MISS_OTHER,
-    USERCOLOR_OTHER_MISS_YOU,
-    USERCOLOR_DISCIPLINES,
-    USERCOLOR_YOUR_DEATH,
-    USERCOLOR_OTHER_DEATH,
-    USERCOLOR_NON_MELEE,
-    USERCOLOR_MONEY_SPLIT,
-    USERCOLOR_LOOT,
-    USERCOLOR_OTHERS_SPELLS,
-    USERCOLOR_SPELL_FAILURE,
-    USERCOLOR_MELEE_CRIT,
-    USERCOLOR_SPELL_CRIT,
-    USERCOLOR_NPC_RAMAGE,
-    USERCOLOR_NPC_FURRY,
-    USERCOLOR_NPC_ENRAGE,
-    CHANNEL_OTHERPETDMG,
-    CHANNEL_MYPETSAY,
-    CHANNEL_MYMELEESPECIAL,
-    CHANNEL_OTHERMELEESPECIAL,
-    CHANNEL_OTHER_MELEE_CRIT,
-    CHANNEL_OTHER_DAMAGE_SHIELD,
+      USERCOLOR_SPELLS,         USERCOLOR_YOU_HIT_OTHER,   USERCOLOR_OTHER_HIT_YOU,  USERCOLOR_YOU_MISS_OTHER,
+      USERCOLOR_OTHER_MISS_YOU, USERCOLOR_DISCIPLINES,     USERCOLOR_YOUR_DEATH,     USERCOLOR_OTHER_DEATH,
+      USERCOLOR_NON_MELEE,      USERCOLOR_MONEY_SPLIT,     USERCOLOR_LOOT,           USERCOLOR_OTHERS_SPELLS,
+      USERCOLOR_SPELL_FAILURE,  USERCOLOR_MELEE_CRIT,      USERCOLOR_SPELL_CRIT,     USERCOLOR_NPC_RAMAGE,
+      USERCOLOR_NPC_FURRY,      USERCOLOR_NPC_ENRAGE,      CHANNEL_OTHERPETDMG,      CHANNEL_MYPETSAY,
+      CHANNEL_MYMELEESPECIAL,   CHANNEL_OTHERMELEESPECIAL, CHANNEL_OTHER_MELEE_CRIT, CHANNEL_OTHER_DAMAGE_SHIELD,
   };
 
   // Set class color for self
   Zeal::GameStructures::GAMECHARINFO *char_info = Zeal::Game::get_char_info();
-  if ((character_name == "You" || character_name == "Your")
-      && valid_channels_you.count(channel) && char_info != nullptr)
+  if ((character_name == "You" || character_name == "Your") && valid_channels_you.count(channel) &&
+      char_info != nullptr)
     return Zeal::Game::get_raid_class_color(char_info->Class);
 
   // Check Zone Entities for a match
@@ -355,10 +337,10 @@ static void __fastcall PrintChat(int t, int unused, char *data, short color_inde
   } else {
     strncpy_s(buffer, chat_buffer, sizeof(buffer));
   }
-  
+
   if (std::strlen(chat_buffer) > 0)
     ZealService::get_instance()->hooks->hook_map["PrintChat"]->original(PrintChat)(t, unused, buffer, color_index,
-                                                                                         add_log && !log_is_different);
+                                                                                   add_log && !log_is_different);
 
   if (add_log && log_is_different && std::strlen(log_buffer) > 0 && *Zeal::Game::is_logging_enabled) {
     strncpy_s(buffer, log_buffer, sizeof(buffer));
@@ -768,7 +750,37 @@ void Chat::DoPercentReplacements(std::string &str_data) {
   for (auto &fn : percent_replacements) fn(str_data);
 }
 
+std::string GetConsentMeTellName(const std::string &data) {
+  static const char consent_ending[] = " tells you, 'Consent me'";
+  if (!data.ends_with(consent_ending)) return "";
+
+  // Extract the name. Normally it is the first word but we go backwards just in case.
+  std::string truncated = data.substr(0, data.length() - strlen(consent_ending));
+  size_t last_space = truncated.find_last_of(" ");
+  std::string name = (last_space == std::string::npos) ? truncated : truncated.substr(last_space + 1);
+
+  // And then check if the name is a raid or group member to authorize the auto consent.
+  Zeal::GameStructures::RaidInfo *raid_info = Zeal::Game::RaidInfo;
+  if (raid_info->is_in_raid()) {
+    for (int i = 0; i < Zeal::GameStructures::RaidInfo::kRaidMaxMembers; ++i) {
+      const auto &member = raid_info->MemberList[i];
+      if (member.Name == name) return name;
+    }
+  }
+
+  const auto *group_info = Zeal::Game::GroupInfo;
+  for (int i = 0; i < GAME_NUM_GROUP_MEMBERS; ++i) {
+    if (group_info->IsValidList[i] && group_info->Names[i] == name) return name;
+  }
+  return "";
+}
+
 void Chat::AddOutputText(Zeal::GameUI::ChatWnd *wnd, std::string &msg, short channel) {
+  if (channel == USERCOLOR_TELL && EnableAutoConsent.get()) {
+    std::string name = GetConsentMeTellName(msg);
+    if (!name.empty()) Zeal::Game::do_consent(name.c_str());
+  }
+
   if (UseClassChatColors.get() && !msg.empty()) {
     msg = add_class_colors(msg, channel);
   }
@@ -842,27 +854,27 @@ Chat::Chat(ZealService *zeal) {
   //
   // return false;
   //}, callback_type::WorldMessage);
-  zeal->commands_hook->Add("/abbreviatedchat", {"/abc"},"Abbreviates chat messages.",
-                           [this](std::vector<std::string> &args) {
-                              // 0 = Off
-                              // 1 = Chat Only
-                              // 2 = Chat and Log
-                              if (args.size() > 1) {
-                                int abbreviated_option;
-                                if (Zeal::String::tryParse(args[1], &abbreviated_option)) {
-                                  abbreviated_option = std::clamp(abbreviated_option, 0, 2);
-                                  UseAbbreviatedChat.set(abbreviated_option);
-                                }
+  zeal->commands_hook->Add(
+      "/abbreviatedchat", {"/abc"}, "Abbreviates chat messages.", [this](std::vector<std::string> &args) {
+        // 0 = Off
+        // 1 = Chat Only
+        // 2 = Chat and Log
+        if (args.size() > 1) {
+          int abbreviated_option;
+          if (Zeal::String::tryParse(args[1], &abbreviated_option)) {
+            abbreviated_option = std::clamp(abbreviated_option, 0, 2);
+            UseAbbreviatedChat.set(abbreviated_option);
+          }
 
-                              } else {
-                                UseAbbreviatedChat.set(UseAbbreviatedChat.get() > 0 ? 0 : 1);
-                              }
-                              Zeal::Game::print_chat(
-                                  "Abbreviated chat set to %d (%s)", UseAbbreviatedChat.get(),
-                                  UseAbbreviatedChat.get() == 0 ? "Off" : (UseAbbreviatedChat.get() == 1 ? "Chat only" : "Chat and Log"));
-                              return true;  // return true to stop the game from processing any further on this command,
-                                            // false if you want to just add features to an existing cmd
-                          });
+        } else {
+          UseAbbreviatedChat.set(UseAbbreviatedChat.get() > 0 ? 0 : 1);
+        }
+        Zeal::Game::print_chat(
+            "Abbreviated chat set to %d (%s)", UseAbbreviatedChat.get(),
+            UseAbbreviatedChat.get() == 0 ? "Off" : (UseAbbreviatedChat.get() == 1 ? "Chat only" : "Chat and Log"));
+        return true;  // return true to stop the game from processing any further on this command,
+                      // false if you want to just add features to an existing cmd
+      });
   zeal->commands_hook->Add("/timestamp", {"/tms"}, "Toggles timestamps on chat windows.",
                            [this](std::vector<std::string> &args) {
                              if (args.size() > 1 && args[1] == "2") {
@@ -944,6 +956,12 @@ Chat::Chat(ZealService *zeal) {
                              }
                              return false;
                            });
+  zeal->commands_hook->Add(
+      "/autoconsent", {}, "Toggles autoconsent response on/off", [this](std::vector<std::string> &args) {
+        EnableAutoConsent.toggle();
+        Zeal::Game::print_chat("Auto-consent response is %s", EnableAutoConsent.get() ? "ON" : "OFF");
+        return true;
+      });
 
   /*  zeal->commands_hook->Add("/uniquenaming", {}, "Toggles off the stripping of mob id and other identifiers from name
      of npc's (log only)", [this, ini](std::vector<std::string>& args) { uniquenames = !uniquenames;
@@ -997,7 +1015,7 @@ Chat::Chat(ZealService *zeal) {
 
   // Callbacks
   zeal->callbacks->AddOutputText([this](Zeal::GameUI::ChatWnd *&wnd, std::string &msg, short &channel) {
-      this->AddOutputText(wnd, msg, channel);
+    this->AddOutputText(wnd, msg, channel);
   });
 }
 

--- a/Zeal/chat.h
+++ b/Zeal/chat.h
@@ -9,13 +9,13 @@
 
 class Chat {
  public:
-  ZealSetting<bool> UseClassChatColors = {false, "Zeal", "ClassChatColors", false,
-                                          [this](bool val) { set_classes(); }};
+  ZealSetting<bool> UseClassChatColors = {false, "Zeal", "ClassChatColors", false, [this](bool val) { set_classes(); }};
   ZealSetting<bool> UseClassicClassNames = {false, "Zeal", "ClassicClasses", false,
                                             [this](bool val) { set_classes(); }};
   ZealSetting<bool> UseBlueCon = {true, "Zeal", "Bluecon", false};
   ZealSetting<bool> UseZealInput = {true, "Zeal", "ZealInput", false};
   ZealSetting<bool> UseUniqueNames = {false, "Zeal", "UniqueNames", false};
+  ZealSetting<bool> EnableAutoConsent = {false, "Zeal", "AutoConsent", false};
   ZealSetting<int> UseAbbreviatedChat = {0, "Zeal", "AbbreviatedChat", false};
   ZealSetting<int> TimeStampsStyle = {0, "Zeal", "ChatTimestamps", false};
 

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1600,6 +1600,11 @@ std::vector<std::string> splitStringByNewLine(const std::string &str) {
   return tokens;
 }
 
+void do_consent(const char *name) {
+  auto do_consent_fn = reinterpret_cast<void(__cdecl *)(Zeal::GameStructures::Entity *, const char *)>(0x004fb39e);
+  do_consent_fn(get_self(), name);
+}
+
 void do_say(bool hide_local, const char *format, ...) {
   BYTE orig[13] = {0};
   if (hide_local) mem::set(0x538672, 0x90, 13, orig);
@@ -1628,6 +1633,8 @@ void do_say(bool hide_local, std::string data) {
     mem::copy(0x538672, orig, 13);
   }
 }
+
+void do_tell(const char *target_name_and_message) { GameInternal::do_tell(get_self(), target_name_and_message); }
 
 void do_gsay(std::string data) { GameInternal::do_gsay(get_self(), data.c_str()); }
 

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -66,6 +66,7 @@ static mem::function<bool __cdecl()> IsPlayerABardAndSingingASong = 0x0040a74a; 
 static mem::function<int __fastcall(void *this_raid, int unused_edx, const char *)> send_raid_chat =
     0x0049e2e8;  // CRaid::SendRaidChat()
 static mem::function<int __cdecl(Zeal::GameStructures::Entity *, const char *)> do_say = 0x4f8172;
+static mem::function<int __cdecl(Zeal::GameStructures::Entity *, const char *)> do_tell = 0x004f8367;
 static mem::function<int __cdecl(Zeal::GameStructures::Entity *, const char *)> do_guildsay = 0x004f4bd1;
 static mem::function<int __cdecl(Zeal::GameStructures::Entity *, const char *)> do_gsay = 0x004f82a8;
 static mem::function<int __cdecl(Zeal::GameStructures::Entity *, const char *)> do_auction = 0x004f8325;
@@ -259,8 +260,10 @@ bool is_game_ui_window_hovered();
 bool is_targetable(Zeal::GameStructures::Entity *ent);
 bool is_in_game();
 bool is_in_char_select();
+void do_consent(const char *name);
 void do_say(bool hide_local, const char *format, ...);
 void do_say(bool hide_local, std::string data);
+void do_tell(const char *target_name_and_message);
 void do_gsay(std::string data);
 void do_guildsay(std::string data);
 void do_auction(std::string data);

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -403,6 +403,9 @@ void ui_options::InitGeneral() {
   ui->AddCheckboxCallback(wnd, "Zeal_AddGroupColors", [this](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->ui->group->setting_add_group_colors.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_AutoConsent", [this](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->chat_hook->EnableAutoConsent.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_AutoFollowEnable", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->movement->AutoFollowEnable.set(wnd->Checked);
   });
@@ -942,6 +945,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_AltTransportCats",
                  ZealService::get_instance()->spell_sets->setting_alternate_transport_categories.get());
   ui->SetChecked("Zeal_AddGroupColors", ZealService::get_instance()->ui->group->setting_add_group_colors.get());
+  ui->SetChecked("Zeal_AutoConsent", ZealService::get_instance()->chat_hook->EnableAutoConsent.get());
   ui->SetChecked("Zeal_AutoFollowEnable", ZealService::get_instance()->movement->AutoFollowEnable.get());
 
   UpdateComboBox("Zeal_TellSound_Combobox", setting_tell_sound.get(), kDefaultSoundNone);

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -634,6 +634,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_AutoConsent">
+    <ScreenID>Zeal_AutoConsent</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>442</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables auto-consent to any /tc sent by a group or raid member</TooltipReference>
+    <Text>Auto-consent</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- Second column -->
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1624,6 +1655,7 @@
     <Pieces>Zeal_RecastTimersLeftAlign</Pieces>
     <Pieces>Zeal_InviteDialog</Pieces>
     <Pieces>Zeal_AddGroupColors</Pieces>
+    <Pieces>Zeal_AutoConsent</Pieces>
     <!-- Second column. -->
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -634,6 +634,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_AutoConsent">
+    <ScreenID>Zeal_AutoConsent</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>20</X>
+      <Y>884</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables auto-consent to any /tc sent by a group or raid member</TooltipReference>
+    <Text>Auto-consent</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1624,6 +1655,7 @@
     <Pieces>Zeal_RecastTimersLeftAlign</Pieces>
     <Pieces>Zeal_InviteDialog</Pieces>
     <Pieces>Zeal_AddGroupColors</Pieces>
+    <Pieces>Zeal_AutoConsent</Pieces>
     
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>


### PR DESCRIPTION
- Added new commands and an auto-consent response option
  /tellconsent, /tc: Sends a "Consent me" to a targeted corpse
 /replyconsent, /rc: Does a /consent to the sender of most recent tell
 /autoconsent: Toggles an enable to do a /rc in response to a /tc from a raid or group member (also new general option)
 /consentmonks, /consentrogues: Consents all monks or rogues in a raid.