### PR TITLE
Fixed left mouse pan jump in full screen legacy

### DIFF
--- a/Zeal/binds.h
+++ b/Zeal/binds.h
@@ -38,4 +38,5 @@ class Binds {
                 std::function<void(int state)> callback);
   void replace_cmd(int cmd, std::function<bool(int state)> callback);
   bool execute_cmd(unsigned int opcode, int state);
+  void print_keybinds() const;
 };

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -466,8 +466,7 @@ void ZealService::AddCommands() {
     }
     if (args.size() == 2 && args[1] == "list_keybinds")  // Just a utility to check native keybind mapping.
     {
-      const char **cmd = reinterpret_cast<const char **>(0x00611220);
-      for (int i = 0; cmd[i] != nullptr; ++i) Zeal::Game::print_chat("[%d]: %s", i, cmd[i]);
+      binds_hook->print_keybinds();
       return true;
     }
     if (args.size() == 2 && args[1] == "target_name")  // Report name parsing of current target.


### PR DESCRIPTION
- Added an explicit check for eqw version to control whether the lmb restore cursor position logic tries to accurately sync up with the win32 position

- Also expanded a utility function for listing in-use keybind codes