### PR TITLE
Add autofire on and off arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ ___
 - `/autoconsent`
   - **Description:** Toggles the enable of auto-consenting from a /tc sent by a group or raid member.
 
+- `/autofire`
+  - **Aliases:** `/af`
+  - **Arguments:** none (toggles), `on`, `off`
+  - **Description:** Enables/disables ranged autofire mode.
+
 - `/autoinventory`
   - **Aliases:** `/autoinv`, `/ai`
   - **Description:** Drops whatever is on your cursor into your inventory.

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1574,8 +1574,8 @@ std::vector<Zeal::GameStructures::Entity *> get_world_visible_actor_list(float m
 }
 
 float get_target_blink_fade_factor(float speed_factor, bool auto_attack_only) {
-  if (auto_attack_only && !(bool)(*(BYTE *)0x7f6ffe))  // Auto attack disabled.
-    return 1.0f;                                       // No fading.
+  if (auto_attack_only && !is_autoattacking())  // Auto attack disabled.
+    return 1.0f;                                // No fading.
 
   // Calculate a fraction of the cycle time. Phase alignment doesn't matter, so just
   // do a modulo off of the current time in millseconds.
@@ -1879,6 +1879,8 @@ bool use_item(int item_index, bool quiet) {
   chr->cast(0xA, 0, (int *)&item, item_index < 21 ? item_index + 1 : item_index);
   return true;
 }
+
+bool is_autoattacking() { return *reinterpret_cast<BYTE *>(0x007f6ffe); }
 
 Zeal::GameStructures::Entity *get_active_corpse() {
   return *(Zeal::GameStructures::Entity **)Zeal::Game::Active_Corpse;

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -218,6 +218,7 @@ bool can_move();
 bool is_on_ground(Zeal::GameStructures::Entity *ent);
 void log(const char *data);
 void log(std::string &data);
+bool is_autoattacking();
 Zeal::GameStructures::GAMECHARINFO *get_char_info();
 Zeal::GameStructures::Entity *get_active_corpse();
 Zeal::GameStructures::Entity *get_target();


### PR DESCRIPTION
- /autofire now supports explict on and off parameters in addition to the toggle w/out any
- Also added some more warnings when it won't enable properly due to a lack of target or auto-attack is on