### PR TITLE
Add /dampenlev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ ___
   - **Arguments:** none, `all` (drops all corpses)
   - **Description:** Stop dragging your currently targeted corpse. To drop all use `/corpsedrop all`.
 
+- `/dampenlev`
+  - **Arguments:** `on`, `off`
+  - **Description:** Selects dampened (on) or normal (off) levitation motion.
+
 - `/fcd` (floating combat damage)
   - **Arguments:** none, `client font size #`, `font`
   - **Example:** `/fcd` toggles on and off

--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -26,7 +26,8 @@ class CameraMods {
   ZealSetting<bool> setting_toggle_zeal_view = {true, "Camera", "ToggleZealView", false};
   ZealSetting<bool> setting_toggle_free1_view = {true, "Camera", "ToggleFree1View", false};
   ZealSetting<bool> setting_toggle_free2_view = {true, "Camera", "ToggleFree2View", false};
-
+  ZealSetting<bool> setting_dampen_levitation = {false, "Zeal", "DampenLevitation", false,
+                                                 [this](float val) { synchronize_lev(); }};
   const float max_zoom_out = 100;
   const float min_zoom_in = 5.f;  // Transitions to first person below this.
   const float zoom_speed = 5.f;
@@ -65,6 +66,7 @@ class CameraMods {
   bool callback_packet(UINT opcode, char *buffer, UINT len);
   void update_desired_zoom(float zoom);
   void synchronize_fov();
+  void synchronize_lev();
   void set_zeal_cam_active(bool activate);
   bool is_zeal_cam_active() const;
   bool calc_camera_positions(Vec3 &head_pos, Vec3 &wanted_pos) const;

--- a/Zeal/commands.cpp
+++ b/Zeal/commands.cpp
@@ -16,8 +16,17 @@ void ChatCommands::print_commands() {
   std::stringstream ss;
   ss << "List of commands" << std::endl;
   ss << "-----------------------------------------------------" << std::endl;
-  for (auto &[name, c] : CommandFunctions) {
-    ss << name;
+  // Create a sorted vector of commands w/out copying.
+  std::vector<std::pair<std::reference_wrapper<const std::string>, std::reference_wrapper<const ZealCommand>>>
+      sorted_references;
+  for (const auto &pair : CommandFunctions) {
+    sorted_references.emplace_back(std::cref(pair.first), std::cref(pair.second));
+  }
+  std::sort(sorted_references.begin(), sorted_references.end(),
+            [](const auto &a, const auto &b) { return a.first.get() < b.first.get(); });
+  for (auto &pair : sorted_references) {
+    ss << pair.first.get();
+    const ZealCommand &c = pair.second.get();
     if (c.aliases.size() > 0) ss << " [";
     for (auto it = c.aliases.begin(); it != c.aliases.end(); ++it) {
       auto &a = *it;


### PR DESCRIPTION
- Added a new /dampenlev command that selects (on) dampened levitation motion
  - Reduces frequency by 8x and amplitude by 10x
  - Affects only the player (not other PCs)

- Also added a alphabetical command name sort to `/zeal help`