### PR TITLE
Add pet hold & assist binds and /targetprevious

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,9 @@ ___
   - **Aliases:** `/cleartarget`
   - **Description:** acts as normal /target unless you provide no argument in which case it will clear your target.
 
+- `/targetprevious`
+  - **Description:** Switches to previous target (can toggle last two like keybind).
+
 - `/targetring`
   - **Arguments:** `size`, `indicator`
   - **Example:** `/targetring 0.25`
@@ -404,6 +407,7 @@ ___
 ### Key Binds (Added to Options->Keyboard)
 - Cycle through nearest NPCs
 - Cycle through nearest PCs
+- Assist
 - Strafe Right
 - Strafe Left
 - Auto Inventory
@@ -416,6 +420,7 @@ ___
 - Pet Back
 - Pet Sit
 - Pet Health
+- Pet Hold
 - Do /loot (targeted corpse)
 - Slow turn left
 - Slow turn right

--- a/Zeal/cycle_target.cpp
+++ b/Zeal/cycle_target.cpp
@@ -17,8 +17,8 @@ void CycleTarget::handle_next_target(int key_down, Zeal::GameEnums::EntityTypes 
   }
 }
 
-void CycleTarget::handle_toggle_last_two(int key_down) {
-  if (!key_down || Zeal::Game::GameInternal::UI_ChatInputCheck()) return;
+void CycleTarget::handle_toggle_last_two(int key_down, bool skip_input_check) {
+  if (!key_down || (!skip_input_check && Zeal::Game::GameInternal::UI_ChatInputCheck())) return;
 
   Zeal::GameStructures::Entity *target = Zeal::Game::get_target();
   if (target) {

--- a/Zeal/cycle_target.h
+++ b/Zeal/cycle_target.h
@@ -11,7 +11,7 @@ class CycleTarget {
   Zeal::GameStructures::Entity *get_next_ent(float dist, BYTE type);
   Zeal::GameStructures::Entity *get_nearest_ent(float dist, BYTE type);
   void handle_next_target(int key_down, Zeal::GameEnums::EntityTypes type);
-  void handle_toggle_last_two(int key_down);
+  void handle_toggle_last_two(int key_down, bool skip_input_check = false);
 
  private:
   void main_loop();

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -150,7 +150,13 @@ enum PetCommand {
   Follow = 8,
   Sit = 9,
   Stand = 10,
-  Taunt = 11
+  Taunt = 11,
+  Hold = 12,
+  TauntOn = 13,
+  TauntOff = 14,
+  PetTarget = 15,
+  WhoLeader = 16,
+  Buy = 17,
 };
 
 enum SpellTargetType {

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -602,6 +602,11 @@ void ZealService::AddCommands() {
                      [](std::vector<std::string> &args) { return handle_tell_consent(); });
   commands_hook->Add("/replyconsent", {"/rc"}, "Does a /consent to the sender of most recent tell.",
                      [](std::vector<std::string> &args) { return handle_reply_consent(); });
+  commands_hook->Add("/targetprevious", {}, "Switches to previous target (can toggle last two).",
+                     [this](std::vector<std::string> &args) {
+                       cycle_target->handle_toggle_last_two(true, true);
+                       return true;
+                     });
 }
 
 void ZealService::AddBinds() {
@@ -880,6 +885,18 @@ void ZealService::AddBinds() {
                          if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck())
                            ZealService::get_instance()->tells->CloseMostRecentWindow();
                        });
+  binds_hook->add_bind(249, "Pet Hold", "PetHold", key_category::Commands, [this](int key_down) {
+    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
+      Zeal::Game::pet_command(Zeal::GameEnums::PetCommand::Hold, 0);
+    }
+  });
+  binds_hook->add_bind(250, "Assist", "Assist", key_category::Target, [this](int key_down) {
+    if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) {
+      auto do_assist_fn = reinterpret_cast<void (*)(Zeal::GameStructures::Entity *, const char *)>(0x004fd7dc);
+      do_assist_fn(Zeal::Game::get_self(), "");
+    }
+  });
+
   binds_hook->add_bind(255, "Auto Inventory", "AutoInventory", key_category::Commands | key_category::Macros,
                        [](int key_down) {
                          if (key_down) {


### PR DESCRIPTION
- Added two new keybinds
 - PetHold: does /pet hold (AA command)
 - Assist: does /assist

- Added a /targetprevious command that acts like the toggle last two keybind