### PR TITLE
Add bazaar qol items

### DIFF
--- a/Zeal/game_addresses.h
+++ b/Zeal/game_addresses.h
@@ -21,7 +21,7 @@ static GameStructures::RaidInfo *RaidInfo = (GameStructures::RaidInfo *)0x7914D0
 static GameStructures::ViewActor *ViewActor = (GameStructures::ViewActor *)0x63D6C0;
 static GameStructures::KeyboardModifiers *KeyMods = (GameStructures::KeyboardModifiers *)0x799738;
 static GameUI::pInstWindows *Windows = (GameUI::pInstWindows *)0x63D5CC;
-static GameUI::CXWndManager *WndManager = (GameUI::CXWndManager *)0x809DB4;
+static GameUI::CXWndManager **WndManager = (GameUI::CXWndManager **)0x809DB4;
 
 // The client maintains a 5000 entry spawn_id to entity (GamePlayer) LUT for faster access to the linked list.
 static constexpr int kEntityIdArraySize = 5000;

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -367,18 +367,18 @@ Zeal::GameStructures::ActorLocation get_actor_location(int actor) {
 }
 
 bool show_context_menu() {
-  int ctx = GameInternal::CXWndShowContextMenu(*(int *)0x809db4, 0, *(int *)0x8092e8, *(int *)0x8092ec);
+  int ctx = GameInternal::CXWndShowContextMenu(*(int *)Game::WndManager, 0, *(int *)0x8092e8, *(int *)0x8092ec);
   return ctx;
 }
 
-GameUI::CXWndManager *get_wnd_manager() { return *(GameUI::CXWndManager **)0x809db4; }
+GameUI::CXWndManager *get_wnd_manager() { return *Game::WndManager; }
 
 bool is_gui_visible() {
   return *(reinterpret_cast<int *>(0x0063b918)) != 3;  // ScreenMode == 3 when F10 is pressed.
 }
 
 bool is_game_ui_window_hovered() {
-  GameUI::CXWndManager *mgr = *(GameUI::CXWndManager **)0x809db4;
+  GameUI::CXWndManager *mgr = *Game::WndManager;
   if (mgr)
     return mgr->Hovered != 0;
   else
@@ -389,7 +389,7 @@ bool game_wants_input() {
   int chat_input = GameInternal::UI_ChatInputCheck();
   bool focused_window_needs_input = false;
   if (is_new_ui()) {
-    int focused_wnd = GameInternal::GetFocusWnd(*(int *)0x809db4, 0);
+    int focused_wnd = GameInternal::GetFocusWnd(*(int *)Game::WndManager, 0);
     if (focused_wnd) focused_window_needs_input = GameInternal::CXWndIsType(focused_wnd, 0, 2);
   }
   return chat_input != 0 || focused_window_needs_input;

--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -1191,6 +1191,52 @@ class CastSpellWnd : public SidlWnd  // Aka CastSpellWnd in client.
   /*0x15C*/ SidlWnd *SpellBook;
 };
 
+class QuantityWnd : public SidlWnd {
+ public:
+  /*0x134*/ BYTE Activated;  // Set to 1 when activated and 0 in Deactivate().
+  /*0x135*/ BYTE Unknown0x135[3];
+  /*0x138*/ DWORD Unknown0x138;
+  /*0x13C*/ DWORD Unknown0x13C;
+  /*0x140*/ DWORD Unknown0x140;  // Set to 0 in constructor.
+  /*0x144*/ DWORD Unknown0x144;  // Quantity slider.
+  /*0x148*/ DWORD Unknonw0x148;  // Quantity slider input.
+  /*0x14C*/ DWORD Unknown0x14c;  // Quantity accept button.
+};
+
+class BazaarSearchWnd : public SidlWnd {
+ public:
+  void doQuery() { reinterpret_cast<void(__thiscall *)(BazaarSearchWnd *)>(0x0040614c)(this); }
+
+  /*0x0134*/ BYTE Activated;  // Set to 1 when activated and 0 in Deactivate().
+  /*0x0135*/ BYTE Unknown0x135[3];
+  /*0x0138*/ BYTE Unknown0x138[0x3854];
+  /*0x398c*/ DWORD ItemList;               // BZR_ItemList.
+  /*0x3990*/ DWORD QueryButton;            // BZR_QueryButton.
+  /*0x3994*/ DWORD WelcomeButton;          // BZR_WelcomeButton.
+  /*0x3998*/ DWORD UpdatePlayerButton;     // BZR_UpdatePlayerButton.
+  /*0x399c*/ DWORD RequestItemButton;      // BZR_RequestItemButton.
+  /*0x39a0*/ DWORD Default;                // BZR_Default.
+  /*0x39a4*/ DWORD ItemNameLabel;          // BZR_ItemNameLabel.
+  /*0x39a8*/ DWORD PlayersLabel;           // BZR_PlayersLabel.
+  /*0x39ac*/ DWORD ItemSlotLabel;          // BZR_ItemSlotLabel.
+  /*0x39b0*/ DWORD StatSlotLabel;          // BZR_StatSlotLabel.
+  /*0x39b4*/ DWORD RaceSlotLabel;          // BZR_RaceSlotLabel.
+  /*0x39b8*/ DWORD CLassSlotLabel;         // BZR_CLassSlotLabel.
+  /*0x39bc*/ DWORD ItemTypeLabel;          // BZR_ItemTypeLabel.
+  /*0x39c0*/ DWORD SearchResultLabel;      // BZR_SearchResultLabel.
+  /*0x39c4*/ DWORD MaxPriceLabel;          // BZR_MaxPriceLabel.
+  /*0x39c8*/ DWORD MinPriceLabel;          // BZR_MinPriceLabel.
+  /*0x39cc*/ ComboWnd *ItemSlotCombobox;   // BZR_ItemSlotCombobox.
+  /*0x39d0*/ ComboWnd *StatSlotCombobox;   // BZR_StatSlotCombobox.
+  /*0x39d4*/ ComboWnd *RaceSlotCombobox;   // BZR_RaceSlotCombobox.
+  /*0x39d8*/ ComboWnd *ClassSlotCombobox;  // BZR_ClassSlotCombobox.
+  /*0x39dc*/ ComboWnd *ItemTypeCombobox;   // BZR_ItemTypeCombobox.
+  /*0x39e0*/ ComboWnd *PlayersCombobox;    // BZR_PlayersCombobox.
+  /*0x39e4*/ EditWnd *ItemNameInput;       // BZR_ItemNameInput.
+  /*0x39e8*/ EditWnd *MaxPriceInput;       // BZR_MaxPriceInput.
+  /*0x39ec*/ EditWnd *MinPriceInput;       // BZR_MinPriceInput.
+};
+
 struct pInstWindows {
   CContextMenuManager *ContextMenuManager;  // 0x63D5CC
   CChatManager *ChatManager;                // 0x63D5D0
@@ -1227,14 +1273,14 @@ struct pInstWindows {
   SpellBookWnd *SpellBook;                  // 0x63D64C
   SidlWnd *Inventory;                       // 0x63D650
   SidlWnd *Bank;                            // 0x63D654
-  SidlWnd *Quantity;                        // 0x63D658
+  QuantityWnd *Quantity;                    // 0x63D658
   LootWnd *Loot;                            // 0x63D65C
   SidlWnd *Actions;                         // 0x63D660
   MerchantWnd *Merchant;                    // 0x63D664
   TradeWnd *Trade;                          // 0x63D668
   SidlWnd *Selector;                        // 0x63D66C
   SidlWnd *Bazaar;                          // 0x63D670
-  SidlWnd *BazaarSearch;                    // 0x63D674
+  BazaarSearchWnd *BazaarSearch;            // 0x63D674
   SidlWnd *Give;                            // 0x63D678
   SidlWnd *Tracking;                        // 0x63D67C
   SidlWnd *Inspect;                         // 0x63D680

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -2164,6 +2164,11 @@ bool ZoneMap::set_marker_size(int new_size_percent, bool update_default) {
   return true;  // Just clamp and report success.
 }
 
+void ZoneMap::add_marker(int y, int x, const char *label, bool clear_others) {
+  if (clear_others) clear_markers();
+  set_marker(y, x, label);
+}
+
 void ZoneMap::clear_markers(bool erase_list) {
   if (erase_list) markers_list.clear();
   if (marker_vertex_buffer) {

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -140,6 +140,9 @@ class ZoneMap {
   void add_dynamic_label(const std::string &label, int loc_y, int loc_x, unsigned int duration_ms = 0,
                          D3DCOLOR font_color = D3DCOLOR_XRGB(250, 250, 51));
 
+  // Public interface for adding markers programmatically.
+  void add_marker(int y, int x, const char *label = nullptr, bool clear_others = true);
+
   Zeal::GameUI::SidlWnd *get_internal_window() { return wnd; }  // For short-term use only.
 
   // Private methods exposed for callback use only.


### PR DESCRIPTION
- Updated the right click on trader name in bazaar search window to also both target the player and add them as a map marker to make it easier to find traders

- Performing a ctrl + shift + left click on a non-empty inv slot while the bazaar search window is open will automatically perform a bazaar search for that slot's item