### PR TITLE
Add /tag command for nameplate text tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## [Download instructions](#installation)
+
 ### Description
 Zeal adds quality of life functionality to legacy TAKP game clients. It aims to make the experience
 more enjoyable and accessible while not fundamentally changing the game's difficulty, but it should
@@ -7,7 +9,8 @@ Zeal custom code is entirely open source. The releases are built by github serve
 from the repo source, providing full transparency on the release contents.
 
 ### Installation
-- Download [latest official release](https://github.com/coastalredwood/Zeal/releases/latest)
+- Download [latest official release](https://github.com/coastalredwood/Zeal/releases/latest) zip
+  (not the repo source code zip)
 - Unzip contents to root game directory (not the uifiles/ subfolder).
 - Test Zeal installation in game by typing "/zeal version" and "/help zeal".
 - Configure Zeal by assigning new key binds and using the new Zeal options window.
@@ -338,6 +341,15 @@ ___
 - `/survey`
   - **Arguments:** `on`, `off`, `channel`, `new`, `response`, `results`, `share`
   - **Description:** Survey helper for polling raid groups. See /survey section below.
+
+- `/tag`
+  - **Description:** sets a unique color and a text tag to the top of a target NPC's nameplate
+    (requires Zeal fonts nameplate mode)
+  - **Arguments:** `clear`: clears all tags, `on`, `off`: Used to enable/disable
+  - **Arguments:** `<rsay | gsay | local> <tag_text | clear>`
+  - **Example:** `/tag rsay Assist me` broadcasts to trigger a raid-wide tag with 'Assist Me'
+  - **Example:** `/tag gsay clear` broadcasts a special message to clear all group members' tags
+  - **Example:** `/tag clear` clears all tags on local client
 
 - `/target`
   - **Aliases:** `/cleartarget`

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -29,6 +29,7 @@ class NamePlate {
     NpcCorpse = 10,
     PlayerCorpse = 11,
     Target = 18,
+    Tagged = 29,
     GuildLFG = 30,
     PvpAlly = 31,
   };
@@ -45,6 +46,7 @@ class NamePlate {
   ZealSetting<bool> setting_con_colors = {false, "Zeal", "NameplateConColors", false};
   ZealSetting<bool> setting_target_color = {false, "Zeal", "NameplateTargetColor", false};
   ZealSetting<bool> setting_char_select = {false, "Zeal", "NameplateCharSelect", false};
+  ZealSetting<bool> setting_tag_enable = {false, "Zeal", "NameplateTagEnable", false};
 
   // Text settings.
   ZealSetting<bool> setting_hide_self = {false, "Zeal", "NameplateHideSelf", false};
@@ -98,6 +100,7 @@ class NamePlate {
  private:
   struct NamePlateInfo {
     std::string text;
+    std::string tag_text;
     DWORD color;
   };
 
@@ -117,6 +120,10 @@ class NamePlate {
   bool is_group_member(const Zeal::GameStructures::Entity &entity) const;
   bool is_raid_member(const Zeal::GameStructures::Entity &entity) const;
   bool handle_shownames_command(const std::vector<std::string> &args);
+  bool handle_tag_command(const std::vector<std::string> &args);
+  void enable_tags(bool enable);
+  void clear_tags();
+  bool check_message_for_broadcast(const char *message);
 
   void clean_ui();
   void render_ui();

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -200,7 +200,7 @@ static constexpr std::array<ColorButtonEntry, num_color_buttons> color_button_de
     {"OtherDmgShld", D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0)},   // 26: White
     {nullptr, D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0)},          // 27: Unused
     {nullptr, D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0)},          // 28: Unused
-    {nullptr, D3DCOLOR_XRGB(0xf0, 0xf0, 0xf0)},          // 29: Unused
+    {"Tagged", D3DCOLOR_XRGB(0xff, 0x80, 0xf0)},         // 29: Orange
     {"GuildLFG", D3DCOLOR_XRGB(0xcf, 0xff, 0x00)},       // 30: Yellow
     {"PVPAlly", D3DCOLOR_XRGB(0x3d, 0x6b, 0xdc)},        // 31: Default blue
     {"MyMelee", D3DCOLOR_XRGB(0x00, 0xf0, 0xf0)},        // 32: Light blue

--- a/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Colors.xml
@@ -713,7 +713,35 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-
+  <Button item="Zeal_Color29">
+    <ScreenID>Zeal_Color29</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>200</X>
+      <Y>304</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>30 - Tagged</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 	<Label item="Section_ChatColors">
 		<ScreenID>Section_ChatColors</ScreenID>
 		<RelativePosition>true</RelativePosition>
@@ -1354,6 +1382,7 @@
     <Pieces>Zeal_BtnDividerNPC</Pieces>
     <Pieces>Zeal_BtnDividerCC</Pieces>
     <Pieces>Zeal_Color18</Pieces>
+    <Pieces>Zeal_Color29</Pieces>
     <Pieces>Zeal_Color19</Pieces>
     <Pieces>Zeal_Color20</Pieces>
     <Pieces>Zeal_Color21</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Colors.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Colors.xml
@@ -713,7 +713,35 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-
+  <Button item="Zeal_Color29">
+    <ScreenID>Zeal_Color29</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>400</X>
+      <Y>608</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>30 - Tagged</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 	<Label item="Section_ChatColors">
 		<ScreenID>Section_ChatColors</ScreenID>
 		<RelativePosition>true</RelativePosition>
@@ -1354,6 +1382,7 @@
     <Pieces>Zeal_BtnDividerNPC</Pieces>
     <Pieces>Zeal_BtnDividerCC</Pieces>
     <Pieces>Zeal_Color18</Pieces>
+    <Pieces>Zeal_Color29</Pieces>
     <Pieces>Zeal_Color19</Pieces>
     <Pieces>Zeal_Color20</Pieces>
     <Pieces>Zeal_Color21</Pieces>

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -142,7 +142,6 @@ ZealService::ZealService() {
 
   // Adds DirectX (and UISkin for resource file paths) dependencies.
   target_ring = MakeCheckedUnique(TargetRing);
-  nameplate = MakeCheckedUnique(NamePlate);             // Uses target ring blink rate setting.
   floating_damage = MakeCheckedUnique(FloatingDamage);  // Uses target ring method.
 
   // Classes that add more explicit dependencies on the new UI.
@@ -153,6 +152,7 @@ ZealService::ZealService() {
   equip_item_hook = MakeCheckedUnique(EquipItem);   // Uses new UI InvSlotWnd.
   chatfilter_hook = MakeCheckedUnique(chatfilter);  // Uses new UI ChatWnd
   chat_hook = MakeCheckedUnique(Chat);              // Uses chatfilter.
+  nameplate = MakeCheckedUnique(NamePlate);         // Uses target ring blink rate setting and Chat.
   tells = MakeCheckedUnique(TellWindows);           // Uses new UI ChatManager.
   looting_hook = MakeCheckedUnique(Looting);        // Uses new UI Loot window (and ChatManager).
   give = MakeCheckedUnique(NPCGive);                // Uses new Ui Trade & Give and also looting.

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -67,7 +67,6 @@ class ZealService {
 
   std::unique_ptr<class TargetRing> target_ring = nullptr;
   std::unique_ptr<class FloatingDamage> floating_damage = nullptr;
-  std::unique_ptr<class NamePlate> nameplate = nullptr;
 
   std::unique_ptr<class Utils> utils = nullptr;
   std::unique_ptr<class Experience> experience = nullptr;
@@ -76,6 +75,7 @@ class ZealService {
   std::unique_ptr<class EquipItem> equip_item_hook = nullptr;
   std::unique_ptr<class chatfilter> chatfilter_hook = nullptr;
   std::unique_ptr<class Chat> chat_hook = nullptr;
+  std::unique_ptr<class NamePlate> nameplate = nullptr;
   std::unique_ptr<class TellWindows> tells = nullptr;
   std::unique_ptr<class Looting> looting_hook = nullptr;
   std::unique_ptr<class NPCGive> give = nullptr;


### PR DESCRIPTION
- New /tag command allows adding a text tag to the top of a npc nameplate (zeal fonts mode only)
  - Supports local only or broadcasts through rsay and gsay
  - Can clear tags locally or broadcast a clear all tags
  - Must be enabled to receive broadcasts (/tag on)
- Tagged nameplaces have a new Zeal color: Tagged - 30
  - The tag color overrides the con color but the target color will override the tag color