### PR TITLE
Add buff window click thru

### DIFF
--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -298,8 +298,9 @@ struct BasicWnd  // Equivalent to CXWnd in client.
   /* 0x0010 */ BYTE FadedAlpha;  // Alpha transparency value when faded
   /* 0x0011 */ BYTE IsNotFaded;  // Set to 0 when faded, 1 when not faded
   /* 0x0012 */ BYTE IsLocked;
-  /* 0x0013 */ BYTE LockEnable;  // Enable Lock option in CContextMenuManager::WarnDefaultMenu.
-  /* 0x0014 */ PVOID Unknown0014;
+  /* 0x0013 */ BYTE LockEnable;         // Enable Lock option in CContextMenuManager::WarnDefaultMenu.
+  /* 0x0014 */ BYTE DisableRightClick;  // Set to 1 to ignore RMB down (like in CChatWindow() for CW_ChatOutput).
+  /* 0x0015 */ BYTE Unknown0015[0x3];
   /* 0x0018 */ DWORD Unknown0018;
   /* 0x001C */ struct SidlWnd *ParentWnd;
   /* 0x0020 */ struct SidlWnd *FirstChildWnd;
@@ -711,8 +712,10 @@ struct EditWnd : public BasicWnd  // Note: this definition has a truncated vtbl.
 };
 
 struct ChatWnd : public SidlWnd {
-  /*0x134*/ EditWnd *unk;
-  /*0x138*/ EditWnd *edit;
+  /*0x134*/ class CChatManager *ChatManager;  // Points back so Deactivate can release itself.
+  /*0x138*/ EditWnd *edit;                    // CW_ChatInput
+  /*0x13C*/ EditWnd *ChatOutput;              // CW_ChatOutput
+  /*0x140*/ BYTE Uknown0x140[0x240 - 0x140];
 };
 
 // onetimehero 09-17-03

--- a/Zeal/ui_buff.h
+++ b/Zeal/ui_buff.h
@@ -15,6 +15,7 @@ class ui_buff {
   ZealSetting<bool> BuffTimers = {true, "Zeal", "Bufftimers", false};
   ZealSetting<bool> RecastTimers = {false, "Zeal", "Recasttimers", false};
   ZealSetting<bool> RecastTimersLeftAlign = {false, "Zeal", "RecasttimersLeftAlign", false};
+  ZealSetting<bool> BuffClickThru = {false, "Zeal", "BuffClickThru", false};
 
  private:
   UIManager *ui;

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -360,6 +360,9 @@ void ui_options::InitGeneral() {
   ui->AddCheckboxCallback(wnd, "Zeal_RecastTimersLeftAlign", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->ui->buffs->RecastTimersLeftAlign.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_BuffClickThru", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->ui->buffs->BuffClickThru.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_BrownSkeletons", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->game_patches->BrownSkeletons.set(wnd->Checked);
   });
@@ -929,6 +932,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_BuffTimers", ZealService::get_instance()->ui->buffs->BuffTimers.get());
   ui->SetChecked("Zeal_RecastTimers", ZealService::get_instance()->ui->buffs->RecastTimers.get());
   ui->SetChecked("Zeal_RecastTimersLeftAlign", ZealService::get_instance()->ui->buffs->RecastTimersLeftAlign.get());
+  ui->SetChecked("Zeal_BuffClickThru", ZealService::get_instance()->ui->buffs->BuffClickThru.get());
   ui->SetChecked("Zeal_BrownSkeletons", ZealService::get_instance()->game_patches->BrownSkeletons.get());
   ui->SetChecked("Zeal_ClassicMusic", ZealService::get_instance()->music->ClassicMusic.get());
   ui->SetChecked("Zeal_SuppressMissedNotes",

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -1641,6 +1641,36 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_BuffClickThru">
+    <ScreenID>Zeal_BuffClickThru</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>486</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Makes buff non-button area click thru when locked (use ctrl+click to unlock)</TooltipReference>
+    <Text>Buff click thru</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 
   <!-- end -->
     
@@ -1725,6 +1755,7 @@
     <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
     <Pieces>Zeal_SuppressOtherPets</Pieces>
     <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
+    <Pieces>Zeal_BuffClickThru</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -1641,6 +1641,36 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_BuffClickThru">
+    <ScreenID>Zeal_BuffClickThru</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>972</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Makes buff non-button area click thru when locked (use ctrl+click to unlock)</TooltipReference>
+    <Text>Buff click thru</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 
   
     
@@ -1725,6 +1755,7 @@
     <Pieces>Zeal_SuppressLifetapFeeling</Pieces>
     <Pieces>Zeal_SuppressOtherPets</Pieces>
     <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
+    <Pieces>Zeal_BuffClickThru</Pieces>
     <Location>
       <X>0</X>
       <Y>44</Y>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Map.xml
@@ -967,6 +967,7 @@
     <Choices>Internal only</Choices>
     <Choices>Both</Choices>
     <Choices>External</Choices>
+	<Choices>Both - No Internal POI</Choices>
   </Combobox>
   <Button item="Zeal_MapAddLocText">
     <ScreenID>Zeal_MapAddLocText</ScreenID>


### PR DESCRIPTION
- Added a new Zeal options Buff Click Thru that will make the non-button area of a locked Buff window transparent to mouse clicks
  - Unlock the window to move it around with left click
  - Use control + right click to access the context menu (to unlock)

- Also refine /tag to clear tag_text on corpses, warn about fonts disabled, and sanitize the display text a bit