### PR TITLE
Add arrows to npc's when tagging mobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ ___
 - `/loc noprint`
   - **Description:** adds noprint argument to /loc, this just sends loc directly to your log.
 
-- `/locktogglebag`
+- `/locktogglebagslot`
   - **Arguments:** `# (1 to 8 = inventory slot #, 0 = disable)`
   - **Description:** Locks an inventory bag open (toggle containers keybind will not close).
 
@@ -352,10 +352,12 @@ ___
 
 - `/tag`
   - **Description:** sets a unique color and a text tag to the top of a target NPC's nameplate
-    (requires Zeal fonts nameplate mode)
+    (requires Zeal fonts nameplate mode) and an arrow above it
   - **Arguments:** `clear`: clears all tags, `on`, `off`: Used to enable/disable
   - **Arguments:** `<rsay | gsay | local> <tag_text | clear>`
+    - <tag_text> prefixes: `+` to append, `^R^`: to color arrow (R, O, Y, G, B, W)
   - **Example:** `/tag rsay Assist me` broadcasts to trigger a raid-wide tag with 'Assist Me'
+  - **Example:** `/tag rsay +^Y^OFFTANK` appends 'OFFTANK' to the tag text and sets the arrow to yellow
   - **Example:** `/tag gsay clear` broadcasts a special message to clear all group members' tags
   - **Example:** `/tag clear` clears all tags on local client
 

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -83,6 +83,7 @@
     <ClInclude Include="helm_manager.h" />
     <ClInclude Include="music.h" />
     <ClInclude Include="survey.h" />
+    <ClInclude Include="tag_arrows.h" />
     <ClInclude Include="tick.h" />
     <ClInclude Include="ui_buff.h" />
     <ClInclude Include="ui_group.h" />
@@ -162,6 +163,7 @@
     <ClCompile Include="items.cpp" />
     <ClCompile Include="music.cpp" />
     <ClCompile Include="survey.cpp" />
+    <ClCompile Include="tag_arrows.cpp" />
     <ClCompile Include="tick.cpp" />
     <ClCompile Include="ui_buff.cpp" />
     <ClCompile Include="ui_group.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -288,6 +288,9 @@
     <ClInclude Include="utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="tag_arrows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -499,6 +502,9 @@
     </ClCompile>
     <ClCompile Include="zeal_settings.cpp">
       <Filter>Source Files\helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="tag_arrows.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Zeal/autofire.cpp
+++ b/Zeal/autofire.cpp
@@ -74,7 +74,7 @@ void AutoFire::SetAutoFire(bool enabled, bool do_print) {
 
   if (autofire && !enabled) {
     if (do_print) Zeal::Game::print_chat(USERCOLOR_ECHO_SHOUT, "Autofire disabled");
-    Zeal::Game::SetMusicSelection(2, false);
+    if (!Zeal::Game::is_autoattacking()) Zeal::Game::SetMusicSelection(2, false);
   } else if (enabled) {
     Zeal::Game::do_autoattack(false);  // Automatically disable auto-attack when enabling.
     if (do_print) Zeal::Game::print_chat(USERCOLOR_ECHO_SHOUT, "Autofire enabled.");

--- a/Zeal/bitmap_font.cpp
+++ b/Zeal/bitmap_font.cpp
@@ -741,7 +741,6 @@ void SpriteFont::render_queue() {
   device.GetTransform(D3DTS_VIEW, &viewMatrix);
 
   // Need to scale the bitmap font to roughly the right size in world data.
-  const float scale_factor = 0.025f;  // Empirically set so arial_24_bold roughly matches client.
   D3DXMATRIX scaleMatrix, rotationMatrix, translationMatrix;
   D3DXMatrixScaling(&scaleMatrix, scale_factor, scale_factor, scale_factor);
   // And we need to rotate it so that it faces the camera.
@@ -864,4 +863,18 @@ void SpriteFont::calculate_glyph_vertices(const GlyphQueueEntry &entry, Glyph3DV
     glyph_vertices[i].z = z;
     glyph_vertices[i].color = color;
   }
+}
+
+float SpriteFont::get_text_height(const std::string &text) const {
+  auto text_lines = Zeal::String::split_text(text);
+  float y_height = 0;
+  float y_advance = 0;
+  for (const auto &line : text_lines) {
+    y_height += y_advance;
+    Vec3 size = measure_string(line.c_str());
+    y_height += size.y;
+    y_advance = std::max(0.f, size.z - size.y);  // Save if needed for next line.
+  }
+
+  return y_height * scale_factor;
 }

--- a/Zeal/bitmap_font.h
+++ b/Zeal/bitmap_font.h
@@ -206,7 +206,13 @@ class SpriteFont : public BitmapFontBase {
   void flush_queue_to_screen() override;
   void release() override;
 
+  // Note: The measure_string() and other bases do not include the internal scale factor. This method does
+  // return the height in corrected screen dimensions.
+  float get_text_height(const std::string &text) const;
+
  protected:
+  const float scale_factor = 0.025f;  // Empirically set so arial_24_bold roughly matches client.
+
   struct GlyphString {
     Vec3 position;  // Origin anchor point for a string of glyphs.
     int start_index;

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -102,6 +102,7 @@ class NamePlate {
     std::string text;
     std::string tag_text;
     DWORD color;
+    DWORD tag_color;
   };
 
   struct RenderInfo {
@@ -130,6 +131,7 @@ class NamePlate {
   void load_sprite_font();
 
   std::unique_ptr<SpriteFont> sprite_font;
+  std::unique_ptr<class TagArrows> tag_arrows;
   std::unordered_map<struct Zeal::GameStructures::Entity *, NamePlateInfo> nameplate_info_map;
   std::function<void()> update_options_ui_callback;
   std::function<unsigned int(int)> get_color_callback;

--- a/Zeal/tag_arrows.cpp
+++ b/Zeal/tag_arrows.cpp
@@ -1,0 +1,224 @@
+#include "tag_arrows.h"
+
+#include "game_functions.h"
+
+TagArrows::TagArrows(IDirect3DDevice8 &device) : device(device) {
+  CalculateVertices();  // Precalculate the arrow shape.
+}
+
+TagArrows::~TagArrows() { Release(); }
+
+// DirectX resources need to be manually released at Reset or other cleanup.
+void TagArrows::Release() {
+  if (vertex_buffer) vertex_buffer->Release();
+  vertex_buffer = nullptr;
+  vertex_buffer_wr_index = 0;
+  if (index_buffer) index_buffer->Release();
+  index_buffer = nullptr;
+  num_indices = 0;
+  arrow_queue.clear();
+  memset(vertices, 0, sizeof(vertices));
+}
+
+void TagArrows::Dump() const {
+  Zeal::Game::print_chat("vertex: %d, index: %d, num_indices: %d, vertex_buffer_wr_index: %d", vertex_buffer != nullptr,
+                         index_buffer != nullptr, num_indices, vertex_buffer_wr_index);
+}
+
+void TagArrows::QueueArrow(const Vec3 &position, const D3DCOLOR color) {
+  arrow_queue.emplace_back(Arrow{.position = position, .color = color});
+}
+
+void TagArrows::FlushQueueToScreen() {
+  if (arrow_queue.empty()) return;
+
+  if (!vertex_buffer) {
+    vertex_buffer_wr_index = 0;
+    if (FAILED(device.CreateVertexBuffer(kVertexBufferMaxArrowsCount * kNumArrowVertices * sizeof(ArrowVertex),
+                                         D3DUSAGE_WRITEONLY | D3DUSAGE_DYNAMIC, ArrowVertex::kFvfCode, D3DPOOL_DEFAULT,
+                                         &vertex_buffer))) {
+      vertex_buffer = nullptr;  // Ensure nullptr.
+      Release();                // Do a full cleanup.
+      return;
+    }
+  }
+
+  if (!index_buffer && !CreateIndexBuffer()) {
+    Release();  // Do a full cleanup.
+    return;
+  }
+
+  RenderQueue();
+  arrow_queue.clear();
+}
+
+// Submits arrows to the D3D renderer one at a time.
+void TagArrows::RenderQueue() {
+  // Configure for 3D rendering. Could possibly enhance this by enabling light and adding
+  // diffuse, specular, and ambient lighting but keep it simple for now.
+  D3DRenderStateStash render_state(device);
+  render_state.store_and_modify({D3DRS_CULLMODE, D3DCULL_NONE});  // Future optimization.
+  render_state.store_and_modify({D3DRS_ALPHABLENDENABLE, FALSE});
+  render_state.store_and_modify({D3DRS_ZENABLE, TRUE});
+  render_state.store_and_modify({D3DRS_ZWRITEENABLE, TRUE});
+  render_state.store_and_modify({D3DRS_LIGHTING, FALSE});
+
+  // Note: Not preserving shader, texture, source, or indices to avoid reference counting.
+  device.SetVertexShader(ArrowVertex::kFvfCode);
+  device.SetTexture(0, NULL);  // Ensure no texture is bound
+  device.SetStreamSource(0, vertex_buffer, sizeof(ArrowVertex));
+
+  D3DXMATRIX worldMatrix, originalWorldMatrix;
+  device.GetTransform(D3DTS_WORLD, &originalWorldMatrix);  // Stashing this for restoration.
+
+  D3DXMATRIX translationMatrix;
+  for (const auto &entry : arrow_queue) {
+    // Per arrow translation from model space to world space.
+    D3DXMatrixTranslation(&translationMatrix, entry.position.x, entry.position.y, entry.position.z);
+    device.SetTransform(D3DTS_WORLD, &translationMatrix);
+
+    // Retrieve the color dependent set of arrow model vertices.
+    int start_vertex_index = GetStartVertexIndex(entry);
+    if (start_vertex_index < 0) {
+      Release();
+      return;
+    }
+
+    device.SetIndices(index_buffer, start_vertex_index);
+    device.DrawIndexedPrimitive(D3DPT_TRIANGLESTRIP, 0, kNumArrowVertices, 0, num_indices - 2);
+  }
+
+  // Restore D3D state.
+  device.SetStreamSource(0, NULL, 0);  // Unbind vertex buffer.
+  device.SetIndices(NULL, 0);          // Ensure index_buffer is no longer bound.
+  device.SetTransform(D3DTS_WORLD, &originalWorldMatrix);
+  render_state.restore_state();
+}
+
+int TagArrows::GetStartVertexIndex(const Arrow &arrow) {
+  // First check for the presence of a matching cached color.
+  for (int i = 0; i < vertex_buffer_wr_index; ++i) {
+    if (vertex_cache_colors[i] == arrow.color) return i * kNumArrowVertices;
+  }
+
+  if (vertex_buffer_wr_index >= kVertexBufferMaxArrowsCount) vertex_buffer_wr_index = 0;
+  vertex_cache_colors[vertex_buffer_wr_index] = arrow.color;
+
+  // No cache hit so need to update the vertex colors of our pre-calculated vertex model and then
+  // copy it over to the next vertex buffer slot.
+  auto color = arrow.color;
+  int entry_red = (color >> 16) & 0xFF;
+  int entry_green = (color >> 8) & 0xFF;
+  int entry_blue = color & 0xFF;
+  int grey = 192;
+  auto top_color =
+      D3DCOLOR_XRGB(grey + (entry_red - grey) / 8, grey + (entry_green - grey) / 8, grey + (entry_blue - grey) / 8);
+  auto inner_color = D3DCOLOR_XRGB(entry_red + (grey - entry_red) / 4, entry_green + (grey - entry_green) / 4,
+                                   entry_blue + (grey - entry_blue) / 4);
+  auto outer_color = D3DCOLOR_XRGB(entry_red + (grey - entry_red) / 2, entry_green + (grey - entry_green) / 2,
+                                   entry_blue + (grey - entry_blue) / 2);
+  for (int i = 0; i < kNumCircleVertices; ++i) vertices[i].color = top_color;
+  for (int i = kNumCircleVertices; i < 2 * kNumCircleVertices; ++i) vertices[i].color = inner_color;
+  for (int i = 2 * kNumCircleVertices; i < 3 * kNumCircleVertices; ++i) vertices[i].color = outer_color;
+  vertices[3 * kNumCircleVertices].color = arrow.color;
+  vertices[3 * kNumCircleVertices + 1].color = arrow.color;
+
+  // The cache is effectively flushed when the wr_index rolls around otherwise we are appending.
+  auto lock_type = (vertex_buffer_wr_index == 0) ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE;
+  const int start_vertex_index = vertex_buffer_wr_index * kNumArrowVertices;
+  const int start_offset_bytes = start_vertex_index * sizeof(ArrowVertex);
+  const int copy_size = sizeof(vertices);
+  BYTE *buffer = nullptr;
+  if (FAILED(vertex_buffer->Lock(start_offset_bytes, copy_size, &buffer, lock_type))) {
+    Release();
+    return -1;
+  }
+  memcpy(buffer, vertices, copy_size);
+  vertex_buffer->Unlock();
+  vertex_buffer_wr_index++;
+
+  return start_vertex_index;
+}
+
+// Calculate the fixed relative locations of the vertices with a default color that is updated later.
+void TagArrows::CalculateVertices() {
+  // The arrow consists of the top circle, the bottom circle base of the cylinder, the wider bottom circle for
+  // the arrow head, and then the point at the bottom which is set at the origin.
+  const auto color = D3DCOLOR_XRGB(0xff, 0xff, 0xff);
+  const float top_height = 4;
+  const float mid_height = 2;
+  const float inner_radius = 0.75;
+  const float outer_radius = 1.5;
+  const float angle_step = 2.0f * static_cast<float>(M_PI) / kNumCircleVertices;  // Fixed truncation warning
+  for (int i = 0; i < kNumCircleVertices; ++i) {
+    float angle = (i * angle_step);
+    float cos_angle = cosf(angle);
+    float sin_angle = sinf(angle);
+    vertices[i] = {.x = inner_radius * cos_angle, .y = inner_radius * sin_angle, .z = top_height, .color = color};
+    vertices[i + kNumCircleVertices] = vertices[i];
+    vertices[i + kNumCircleVertices].z = mid_height;
+    vertices[i + 2 * kNumCircleVertices] = {
+        .x = outer_radius * cos_angle, .y = outer_radius * sin_angle, .z = mid_height, .color = color};
+  }
+  vertices[3 * kNumCircleVertices + 0] = {.x = 0, .y = 0, .z = 0, .color = color};
+  vertices[3 * kNumCircleVertices + 1] = {.x = 0, .y = 0, .z = top_height, .color = color};
+}
+
+// Define the fixed index lookup map that accesses the Arrow vertices in the required strip order.
+bool TagArrows::CreateIndexBuffer() {
+  if (index_buffer) return true;
+
+  // Calculate the fixed pattern that maps the pre-calculated vertices to the form the
+  // the cylinder and cone shapes.
+  std::vector<int16_t> indices;
+  const int16_t bottom_center_vertex_index = 3 * kNumCircleVertices;
+  const int16_t top_center_vertex_index = 3 * kNumCircleVertices + 1;
+
+  // Draw top filled circle.
+  for (size_t i = 0; i < kNumCircleVertices; ++i) {
+    indices.push_back(i);                        // Top radius.
+    indices.push_back(top_center_vertex_index);  // To center.
+  }
+  indices.push_back(0);  // Back to starting top radius to close out circle.
+
+  // Draw the cylinder walls (the repeat at 0 breaks the strip).
+  for (size_t i = 0; i < kNumCircleVertices; ++i) {
+    indices.push_back(i);
+    indices.push_back(kNumCircleVertices + i);
+  }
+  indices.push_back(0);  // Close off with final triangle set.
+  indices.push_back(kNumCircleVertices);
+
+  // Draw the ring at bottom (inner to outer, repeat from above breaks strip).
+  for (size_t i = 0; i < kNumCircleVertices; ++i) {
+    indices.push_back(kNumCircleVertices + i);
+    indices.push_back(2 * kNumCircleVertices + i);
+  }
+  indices.push_back(kNumCircleVertices);  // Repeat to close off final and end up at outside.
+  indices.push_back(2 * kNumCircleVertices);
+
+  // Draw the cone (and repeat from above breaks strip).
+  for (size_t i = 0; i < kNumCircleVertices; ++i) {
+    indices.push_back(2 * kNumCircleVertices + i);
+    indices.push_back(bottom_center_vertex_index);  // To center.
+  }
+  indices.push_back(2 * kNumCircleVertices);  // Back to starting outer radius to close out cone.
+  indices.push_back(2 * kNumCircleVertices);  // And repeat to terminate strip.
+
+  int buffer_size = indices.size() * sizeof(indices[0]);
+  if (FAILED(device.CreateIndexBuffer(buffer_size, 0, D3DFMT_INDEX16, D3DPOOL_DEFAULT, &index_buffer))) {
+    index_buffer = nullptr;  // Ensure nullptr.
+    return false;
+  }
+
+  uint8_t *locked_buffer = nullptr;
+  if (FAILED(index_buffer->Lock(0, 0, &locked_buffer, D3DLOCK_DISCARD))) {
+    Release();
+    return false;
+  }
+
+  memcpy(locked_buffer, indices.data(), buffer_size);
+  index_buffer->Unlock();
+  num_indices = indices.size();
+  return true;
+}

--- a/Zeal/tag_arrows.h
+++ b/Zeal/tag_arrows.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "directx.h"
+#include "vectors.h"
+
+// Directx 8 compatible classe for rendering a 3-D arrow pointing down at a 3D screen location.
+class TagArrows {
+ public:
+  explicit TagArrows(IDirect3DDevice8 &device);
+  ~TagArrows();
+
+  // Disable copy.
+  TagArrows(TagArrows const &) = delete;
+  TagArrows &operator=(TagArrows const &) = delete;
+
+  // Primary interface for adding arrows each render. The position is in screen pixel coordinates
+  // and specifies the bottom tip of the arrow pointing down.
+  void QueueArrow(const Vec3 &position, const D3DCOLOR color);
+
+  // Renders queued arrows to the screen and clears the queue.
+  // Note that the D3D stream source, indices, vertex shader, and texture states
+  // are not preserved across this call.
+  void FlushQueueToScreen();
+
+  // Releases resources including DirectX. Must call on a DirectX reset / lost device.
+  void Release();  // Note: No longer usable after this call (delete object).
+
+  // Print debug information.
+  void Dump() const;
+
+ private:
+  // Properties of each active Arrow stored in the queue.
+  struct Arrow {
+    Vec3 position;   // In screen coordinates.
+    D3DCOLOR color;  // Color of all vertices.
+  };
+
+  // Vertices allow texturing and color modulation.
+  struct ArrowVertex {
+    static constexpr DWORD kFvfCode = (D3DFVF_XYZ | D3DFVF_DIFFUSE);
+
+    float x, y, z;   // Transformed position coordinates.
+    D3DCOLOR color;  // Color of surfaces.
+  };
+
+  // Arrow consists of 3 circles with a vertex at the tip.
+  static constexpr int kNumCircleVertices = 60;                         // Spaced every 6 degrees.
+  static constexpr int kNumArrowVertices = 3 * kNumCircleVertices + 2;  // Three circles + top and bottom centers.
+  static constexpr int kVertexBufferMaxArrowsCount = 8;                 // Cache up to 8 arrow colors.
+
+  void CalculateVertices();                     // Calculates the cached, fixed 3D shape stored in vertices.
+  bool CreateIndexBuffer();                     // Populates the index_buffer LUT for mapping triangles across vertices.
+  void RenderQueue();                           // Performs the render of all arrows in queue.
+  int GetStartVertexIndex(const Arrow &arrow);  // Returns the starting vertex index for the arrow.
+
+  IDirect3DDevice8 &device;
+  std::vector<Arrow> arrow_queue;  // Loaded to batch up processing in each render pass.
+  IDirect3DVertexBuffer8 *vertex_buffer = nullptr;
+  IDirect3DIndexBuffer8 *index_buffer = nullptr;
+  int vertex_buffer_wr_index = 0;  // Used for pipelining writes.
+  D3DCOLOR vertex_cache_colors[kVertexBufferMaxArrowsCount] = {0};
+  int num_indices = 0;                      // Set when index buffer is populated.
+  ArrowVertex vertices[kNumArrowVertices];  // CPU memory calculation buffer cache.
+};


### PR DESCRIPTION
- The /tag command now renders an arrow above tagged mobs
  - The arrow color defaults to the nameplate color but can be explicity set using a special `^r^` prefix in the tag_text, where R or r = red, O or o = orange, Y or y = yellow, G or g = green, B or b = blue, W or w = white

- The /tag command now supports a special `+` prefix to append text to an existing tag instead of fully replacing it

- Fixed a bug in /autofire where it was disabling combat music when going directly from autofire to autoattack