### PR TITLE
Tag arrow refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,10 +356,13 @@ ___
   - **Arguments:** `clear`: clears all tags, `on`, `off`: Used to enable/disable
   - **Arguments:** `<rsay | gsay | local> <tag_text | clear>`
     - <tag_text> prefixes: `+` to append, `^R^`: to color arrow (R, O, Y, G, B, W)
+    - <tag_text> prefixes: `-` to delete existing text, `^-^`: to disable arrow
   - **Example:** `/tag rsay Assist me` broadcasts to trigger a raid-wide tag with 'Assist Me'
-  - **Example:** `/tag rsay +^Y^OFFTANK` appends 'OFFTANK' to the tag text and sets the arrow to yellow
+  - **Example:** `/tag rsay +^Y^OFFTANK` appends ' | OFFTANK' to the tag text and sets the arrow to yellow
+  - **Example:** `/tag rsay -` clears text but leaves arrow if explicitly colored
+  - **Example:** `/tag rsay ^-^` leaves text but clears the arrow
   - **Example:** `/tag gsay clear` broadcasts a special message to clear all group members' tags
-  - **Example:** `/tag clear` clears all tags on local client
+  - **Example:** `/tag clear` clears target tag if target else all tags on local client
 
 - `/target`
   - **Aliases:** `/cleartarget`


### PR DESCRIPTION
- Added support / docs for a new prefix `-` that erases the existing tag text. Can be sent by itself to delete the tag text and the tag arrow if it is using the default (non-specified) nameplate color.

- Unlinked tag arrow color to allow separately enabling / disabling the tag arrows. Sending ^-^ by itself or as a prefix will disable the tag arrow.

- Added a separator (" | ") when appending tag text

- `/tag clear` now will clear just your target if there is one else it will clear all tags