### PR TITLE
Add /optchat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ ___
   - **Arguments:** `colors`, `concolors`, `targetcolor`, `charselect`, `hideself`, `x`, `hideraidpets`, `showpetownername`, `targetmarker`, `targethealth`, `inlineguild`
   - **Description:** toggles nameplate modes for adjusting colors (tints) and text
 
+- `/optchat`
+  - **Arguments:** `rs`, `gs`, `rsgs` (sends to raid if in raid else group if in group)
+  - **Description:** optionally broadcasts to raid or group if in one
+  - **Example:** `/optchat rsgs CH on %t`
+
 - `/outputfile`
   - **Aliases:** `/output`, `/out`
   - **Arguments:** `inventory | spellbook | raidlist` `[optional_filename]`, `format [0 | 1]`

--- a/Zeal/chat.h
+++ b/Zeal/chat.h
@@ -62,6 +62,8 @@ class Chat {
 
   bool handle_incoming_chat(const char *msg, int color_index);
 
+  void handle_opt_chat(std::vector<std::string> &args);
+
   void DoPercentReplacements(std::string &str_data);
   Chat(class ZealService *pHookWrapper);
   ~Chat();

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -376,6 +376,9 @@ static PetSpeech is_pet_speech(int string_id, short color_index, const char *dat
   const auto *pet = Zeal::Game::get_pet();
   if (!pet) return PetSpeech::OtherPetSay;  // If we don't have a pet, not ours.
 
+  if (string_id == 488)        // /pet health: I have %1 percent of my hit points left.
+    return PetSpeech::NotPet;  // Do not route to keep with buffs on Chat::White.
+
   // Next check the explicit string IDs that only come from "my pet".
   for (const int &i : my_pet_string_ids) {
     if (string_id == i) return PetSpeech::MyPetSay;
@@ -388,9 +391,9 @@ static PetSpeech is_pet_speech(int string_id, short color_index, const char *dat
   // We have a %T2 pet message. Now sort out if the %1 is equal to the client's pet name.
   const char *pet_name = Zeal::Game::strip_name(pet->Name);
   std::string message = std::string(data);
-  size_t first_space = message.find(' ');
-  if (first_space == std::string::npos) return PetSpeech::NotPet;
-  auto name = message.substr(0, first_space);
+  size_t end_of_name_space = message.find(" says");
+  if (end_of_name_space == std::string::npos) return PetSpeech::NotPet;
+  auto name = message.substr(0, end_of_name_space);
   return strcmp(name.c_str(), pet_name) ? PetSpeech::OtherPetSay : PetSpeech::MyPetSay;
 }
 

--- a/Zeal/crash_handler.cpp
+++ b/Zeal/crash_handler.cpp
@@ -212,7 +212,11 @@ static std::string GetCrashMessage(EXCEPTION_POINTERS *pep, bool extra_data) {
       reasonStream << "Self: 0x" << std::hex << (uint32_t)(self) << std::dec << std::endl;
     }
     int show_spell_effects = *reinterpret_cast<unsigned int *>(0x007cf290);
-    if (show_spell_effects) reasonStream << "ShowSpellEffects: " << show_spell_effects << std::endl;
+    const BYTE kOpcodeNop = 0x90;
+    const int kDoSpriteEffectAddr = 0x0052cbb1;
+    bool sprites_disabled = (*reinterpret_cast<BYTE *>(kDoSpriteEffectAddr) == kOpcodeNop);
+    if (show_spell_effects)
+      reasonStream << "ShowSpellEffects: " << show_spell_effects << " NoSprites: " << sprites_disabled << std::endl;
     if (ZealService::get_heap_failed_line())
       reasonStream << "BootHeapCheck: " << ZealService::get_heap_failed_line() << std::endl;
     int error_count = ZealService::get_instance()->crash_handler->get_xml_error_count();


### PR DESCRIPTION
* Added new /optchat command to optionally broadcast to raid or group without error messages
  - /optchat <rs | gs | rsgs> <message>

* Adding crash logging of nosprites state if showspelleffects is on

* Pet chat fixes:
  - Moved /pet health summary line routing from My pet channel to default routing so it gets clustered with the buff report lines
  - Fixed an issue where a pet name with a space (NPC) was going to other instead of my pet