### PR TITLE
Add tradewnd logging

### DIFF
--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -1186,7 +1186,9 @@ struct Display {
   /* 0x0008 */ float *ActiveCamera;  // Pointer to camera position (source used to update CameraLocation).
   /* 0x000C */ BYTE Unknown000C[0x10];
   /* 0x001C */ float CameraLocation[7];  // Updated in RenderWorld with t3dGetCameraLocation.
-  /* 0x0038 */ BYTE Unknown0038[0x90];
+  /* 0x0038 */ BYTE Unknown0038[0x41 - 0x38];
+  /* 0x0041 */ BYTE CursorMoneyType;  // 0 = None, 1 = plat, 2 = gold, 3 = silver, 4 = copper.
+  /* 0x0042 */ BYTE Unknown0042[0xc8 - 0x42];
   /* 0x00C8 */ DWORD GameTimeMs;  // Millisecond timestamp updated at start of RealRender_World.
   /* 0x00CC */ BYTE Unknown00CC[0x2bd8];
   /* 0x2CA4 */ DWORD WorldDisplayStarted;  // Set in CDisplay::StartWorldDisplay().

--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -657,8 +657,11 @@ struct TradeWnd : public SidlWnd {
   /* 0x0168 */ SidlWnd *HisNameLabel;
   /* 0x016C */ SidlWnd *MyNameLabel;
   /* 0x0170 */ InvSlotWnd *TradeSlots[0x10];
-  /* 0x01B0 */ DWORD Unknown01b0[0x4];                                // Probably My or Their Money slots.
-  /* 0x01C0 */ DWORD Unknown01c0[0x4];                                // Probably My or Their money slots.
+  /* 0x01B0 */ DWORD Unknown01b0[0x4];  // Probably Their Money slots.
+  /* 0x01C0 */ int MyPlatinum;
+  /* 0x01C4 */ int MyGold;
+  /* 0x01C8 */ int MySilver;
+  /* 0x01CC */ int MyCopper;
   /* 0x01D0 */ Zeal::GameStructures::_GAMEITEMINFO *GiveItems[8];     // My item giving array.
   /* 0x01F0 */ Zeal::GameStructures::_GAMEITEMINFO *ReceiveItems[8];  // Probably their item array.
   /* 0x0210 */ BYTE Unknown0210;     // Set to 0 in constructor. Possibly accept status.

--- a/Zeal/npc_give.h
+++ b/Zeal/npc_give.h
@@ -11,6 +11,7 @@ class NPCGive {
   void ClearItem();                      // Reset the waiting for item flag.
 
   ZealSetting<bool> setting_enable_give = {false, "SingleClick", "EnableGive", false};
+  ZealSetting<bool> setting_log_add_to_trade = {false, "Zeal", "LogAddToTrade", false};
 
  private:
   Zeal::GameStructures::GAMEITEMINFOBASE *wait_cursor_item = nullptr;  // Auto-move item on cursor.

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -327,6 +327,9 @@ void ui_options::InitGeneral() {
                           [this](Zeal::GameUI::BasicWnd *wnd) { setting_escape_raid_lock.set(wnd->Checked); });
   ui->AddCheckboxCallback(wnd, "Zeal_DialogPosition",
                           [this](Zeal::GameUI::BasicWnd *wnd) { setting_dialog_position.set(wnd->Checked); });
+  ui->AddCheckboxCallback(wnd, "Zeal_LogAddToTrade", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->give->setting_log_add_to_trade.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_ShowHelm", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->helm->ShowHelmEnabled.set(wnd->Checked);
   });
@@ -948,6 +951,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_Escape", setting_escape.get());
   ui->SetChecked("Zeal_RaidEscapeLock", setting_escape_raid_lock.get());
   ui->SetChecked("Zeal_DialogPosition", setting_dialog_position.get());
+  ui->SetChecked("Zeal_LogAddToTrade", ZealService::get_instance()->give->setting_log_add_to_trade.get());
   ui->SetChecked("Zeal_ShowHelm", ZealService::get_instance()->helm->ShowHelmEnabled.get());
   ui->SetChecked("Zeal_AltContainerTooltips", ZealService::get_instance()->tooltips->all_containers.get());
   ui->SetChecked("Zeal_SpellbookAutoStand", ZealService::get_instance()->movement->SpellBookAutoStand.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -696,6 +696,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_LogAddToTrade">
+    <ScreenID>Zeal_LogAddToTrade</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>486</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Logs when items are moved from cursor to trade window</TooltipReference>
+    <Text>Log add to trade</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- Second column -->
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1718,6 +1749,7 @@
     <Pieces>Zeal_AddGroupColors</Pieces>
     <Pieces>Zeal_AutoConsent</Pieces>
     <Pieces>Zeal_DialogPosition</Pieces>
+    <Pieces>Zeal_LogAddToTrade</Pieces>
     <!-- Second column. -->
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -696,6 +696,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_LogAddToTrade">
+    <ScreenID>Zeal_LogAddToTrade</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>20</X>
+      <Y>972</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Logs when items are moved from cursor to trade window</TooltipReference>
+    <Text>Log add to trade</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1718,6 +1749,7 @@
     <Pieces>Zeal_AddGroupColors</Pieces>
     <Pieces>Zeal_AutoConsent</Pieces>
     <Pieces>Zeal_DialogPosition</Pieces>
+    <Pieces>Zeal_LogAddToTrade</Pieces>
     
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>


### PR DESCRIPTION
- Added new zeal option 'Log Add to Trade' that will print a chat message when items or coin are added to the trade window to either npcs or players
  - Note: This does not apply to the world crafting stations