### PR TITLE
Add per character keybind support

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,14 @@ ___
      - enhanced tab completion for /tell, /t, and /consent
 
 ___
-### Key Binds (Added to Options->Keyboard)
+### Key Binds
+
+Per character keybinds are supported through an option in the Zeal General Tab. When enabled the
+keybinds are stored in a `"[Keymaps_<name>]"` section of the client.ini file. Each character starts
+with the default keybinds and Zeal does not support copying keybinds from one profile to another.
+Manual editing of the ini file is required to copy from old section to the new section to reuse binds.
+
+#### Additional available binds Added to Options->Keyboard
 - Cycle through nearest NPCs
 - Cycle through nearest PCs
 - Assist

--- a/Zeal/binds.cpp
+++ b/Zeal/binds.cpp
@@ -4,6 +4,7 @@
 #include "game_addresses.h"
 #include "game_functions.h"
 #include "game_structures.h"
+#include "game_ui.h"
 #include "hook_wrapper.h"
 #include "zeal.h"
 
@@ -31,33 +32,47 @@ bool Binds::execute_cmd(unsigned int cmd, int isdown) {
   return false;
 }
 
+// Called in OptionsWnd::OptionsWnd() which happens upon creation of the new UI. This will handle updating
+// the keybinds from the ini if they are per character.
 void __fastcall InitKeyboardAssignments(void *options_window, int unused) {
   ZealService *zeal = ZealService::get_instance();
-  zeal->binds_hook->initialize_options_with_keybinds(options_window);
-  zeal->binds_hook->read_ini();
+  zeal->binds_hook->handle_init_keyboard_assignments(options_window);
   zeal->hooks->hook_map["InitKeyboardAssignments"]->original(InitKeyboardAssignments)(options_window, unused);
 }
 
-UINT32 read_internal_from_ini(int index, int key_type) {
-  int fn = 0x525520;
-  __asm
-  {
-		push key_type
-		push index
-		call fn
-		pop ecx
-		pop ecx
+// Sets the name used in the ini file to allow per character support.
+void Binds::update_ini_section_name() {
+  strcpy_s(ini_section_name, sizeof(ini_section_name), "KeyMaps");  // Start with default section name.
+  auto self = Zeal::Game::get_self();
+  if (self && per_character_mode) {
+    std::string name = std::string("KeyMaps_") + self->Name;
+    if (name.length() < sizeof(ini_section_name)) strcpy_s(ini_section_name, sizeof(ini_section_name), name.c_str());
   }
 }
 
+// The ini keybinds are normally initialized from the ini in loadOptions() as part of the game constructor.
+// This happens before Zeal is loaded in the first boot, so we need to perform the loads for the Zeal
+// custom binds here. In order to support per character keybinds, this was expanded to completely redo all
+// keys so it repeats the default initialization and reloads all ini key values.
 void Binds::read_ini() {
-  int size = sizeof(KeyMapNames) / sizeof(KeyMapNames[0]);
-  for (int i = 128; i < size; i++)  // the game will load its own properly
-  {
+  // First call default_key_bindings() to reset state. For some reason that code also resets the
+  // mouse y invert global and sensitivity, so we cache and restore them.
+  BYTE *const g_mouse_y_invert = reinterpret_cast<BYTE *>(0x007985e8);
+  DWORD *const g_mouse_sensitivity = reinterpret_cast<DWORD *>(0x0079858a);
+  BYTE invert = *g_mouse_y_invert;
+  DWORD sensitivity = *g_mouse_sensitivity;
+  const int kDefaultKeyBindingsAddr = 0x0055a83b;
+  reinterpret_cast<void (*)()>(kDefaultKeyBindingsAddr)();  // Restore to defaults.
+  *g_mouse_y_invert = invert;
+  *g_mouse_sensitivity = sensitivity;
+
+  // Update all bound keycodes after possibly updating to point to per character ini section.
+  update_ini_section_name();
+  for (int i = 1; i < kNumBinds; i++) {
     if (KeyMapNames[i])  // check if its not nullptr
     {
-      int keycode = read_internal_from_ini(i, 0);
-      int keycode_alt = read_internal_from_ini(i, 1);
+      int keycode = Zeal::Game::GameInternal::readKeyMapFromIni(i, 0);
+      int keycode_alt = Zeal::Game::GameInternal::readKeyMapFromIni(i, 1);
       if (keycode != -0x2) {
         Zeal::Game::ptr_PrimaryKeyMap[i] = keycode;
       }
@@ -66,6 +81,22 @@ void Binds::read_ini() {
       }
     }
   }
+}
+
+void Binds::set_per_character_mode(bool enable) {
+  if (per_character_mode == enable) return;  // Nothing to do.
+
+  per_character_mode = enable;
+
+  if (Zeal::Game::get_gamestate() != GAMESTATE_INGAME) return;
+
+  read_ini();  // Synchronizes the current keybinds based on character (if needed).
+
+  // Update UI elements (options wnd lists, other special wnd cases).
+  auto options = Zeal::Game::Windows->Options;
+  if (options) options->UpdateKeyboardAssignmentList();
+  auto display = Zeal::Game::get_display();
+  if (display) display->KeyMapUpdated();
 }
 
 // Returns true if the bind is an existing game_bind.
@@ -89,13 +120,22 @@ void Binds::add_bind(int cmd, const char *name, const char *short_name, key_cate
   KeyMapFunctions[cmd] = callback;
 }
 
-void Binds::initialize_options_with_keybinds(void *options_window) {
-  int options = reinterpret_cast<int>(options_window);  // TODO: Add an OptionsWindow class.
+// Handle the custom initialization of the keybinds.
+void Binds::handle_init_keyboard_assignments(void *options_window) {
+  // First update the OptionsWnd keymaps with the new custom values so they show up as configurable.
+  // Note that the default available binds (1 to 0x74) are taken care of by the default
+  // InitKeyboardAssignments() since the corresponding KeyMapFunctions won't exist since we
+  // block adding binds in that region.
+  auto options = reinterpret_cast<Zeal::GameUI::OptionsWnd *>(options_window);
   for (int cmd = 0; cmd < kNumBinds; ++cmd) {
-    if (KeyMapNames[cmd] == nullptr || !KeyMapFunctions.count(cmd)) continue;  // Empty, skip.
-    Zeal::Game::GameInternal::InitKeyBindStr((options + cmd * 0x8 + 0x20c), 0, KeyMapNames[cmd]);
-    *(int *)((options + cmd * 0x8 + 0x210)) = KeyMapCategories[cmd];
+    if (KeyMapNames[cmd] == nullptr || !KeyMapFunctions.count(cmd)) continue;  // Empty or default, skip.
+    options->KeyMaps[cmd].name.Set(KeyMapNames[cmd]);
+    options->KeyMaps[cmd].category = KeyMapCategories[cmd];
   }
+
+  // Take advantage of this call to handle ini synchronization to support custom keybinds and
+  // also the per character option.
+  read_ini();
 }
 
 void Binds::replace_cmd(int cmd, std::function<bool(int state)> callback) {
@@ -113,15 +153,20 @@ void Binds::print_keybinds() const {
 Binds::Binds(ZealService *zeal) {
   zeal->callbacks->AddCommand([this](UINT opcode, int state) { return execute_cmd(opcode, state); },
                               callback_type::ExecuteCmd);
-  for (int i = 0; i < 128; i++)
-    KeyMapNames[i] = *(char **)(0x611220 + (i * 4));  // copy the original short names to the new array
-  mem::write(0x52507A, (int)KeyMapNames);             // write ini keymap
-  mem::write(0x5254D9, (int)KeyMapNames);             // clear ini keymap
-  mem::write(0x525544, (int)KeyMapNames);             // read ini keymap
-  mem::write(0x42C52F, (BYTE)0xEB);  // remove the check for max index of 116 being stored in client ini
-  mem::write(0x52485A, (int)256);    // increase this for loop to look through all 256
-  mem::write(0x52591C,
-             (int)(Zeal::Game::ptr_AlternateKeyMap + (256 * 4)));  // fix another for loop to loop through all 256
+  update_ini_section_name();               // Initializes to default.
+  const int kNumOriginalShortNames = 128;  // Length of initialized pointer array in the client.
+  char **const kOriginalShortNames = reinterpret_cast<char **const>(0x611220);
+  for (int i = 0; i < kNumOriginalShortNames; i++)
+    KeyMapNames[i] = kOriginalShortNames[i];     // copy the original short names to the new array
+  mem::write(0x52507A, (int)KeyMapNames);        // write ini keymap
+  mem::write(0x525477, (int)&ini_section_name);  // write ini section name
+  mem::write(0x5254D9, (int)KeyMapNames);        // clear ini keymap
+  mem::write(0x525514, (int)&ini_section_name);  // clear ini section name
+  mem::write(0x525544, (int)KeyMapNames);        // read ini keymap
+  mem::write(0x525596, (int)&ini_section_name);  // read ini section name
+  mem::write(0x42C52F, (BYTE)0xEB);              // remove the check for max index of 116 being stored in client ini
+  mem::write(0x52485A, (int)kNumBinds);          // increase this for loop to look through all 256
+  mem::write(0x52591C, (int)(&Zeal::Game::ptr_AlternateKeyMap[kNumBinds]));  // also loop through 256
   zeal->hooks->Add("InitKeyboardAssignments", Zeal::Game::GameInternal::fn_initkeyboardassignments,
                    InitKeyboardAssignments, hook_type_detour);
 }

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -491,33 +491,35 @@ chatfilter::chatfilter(ZealService *zeal) {
 
   zeal->callbacks->AddGeneric([this]() { isDamage = false; }, callback_type::ReportSuccessfulHitPost);
 
+  Extended_ChannelMaps.push_back(CustomFilter(
+      "Random", 0x10000, [this](short &color, const std::string &data) { return color == USERCOLOR_RANDOM; }));
   Extended_ChannelMaps.push_back(
-      CustomFilter("Random", 0x10000, [this](short &color, std::string &data) { return color == USERCOLOR_RANDOM; }));
-  Extended_ChannelMaps.push_back(
-      CustomFilter("Loot", 0x10001, [this](short &color, std::string &data) { return color == USERCOLOR_LOOT; }));
-  Extended_ChannelMaps.push_back(CustomFilter("Money", 0x10002, [this](short &color, std::string &data) {
+      CustomFilter("Loot", 0x10001, [this](short &color, const std::string &data) { return color == USERCOLOR_LOOT; }));
+  Extended_ChannelMaps.push_back(CustomFilter("Money", 0x10002, [this](short &color, const std::string &data) {
     return color == USERCOLOR_MONEY_SPLIT || color == USERCOLOR_ECHO_AUTOSPLIT;
   }));
-  Extended_ChannelMaps.push_back(CustomFilter(
-      "My Pet Say", 0x10003, [this, zeal](short &color, std::string &data) { return color == CHANNEL_MYPETSAY; }));
-  Extended_ChannelMaps.push_back(CustomFilter("My Pet Damage", 0x10004, [this, zeal](short &color, std::string &data) {
-    if (isDamage && damageData.source && damageData.source->PetOwnerSpawnId &&
-        damageData.source->PetOwnerSpawnId == Zeal::Game::get_self()->SpawnId) {
-      color = CHANNEL_MYPETDMG;
-      return true;
-    }
-    if (isDamage && damageData.target && damageData.target->PetOwnerSpawnId &&
-        damageData.target->PetOwnerSpawnId == Zeal::Game::get_self()->SpawnId) {
-      color = CHANNEL_MYPETDMG;
-      return true;
-    }
-    return false;
-  }));
-  Extended_ChannelMaps.push_back(CustomFilter("Other Pet Say", 0x10005, [this, zeal](short &color, std::string &data) {
-    return color == CHANNEL_OTHERPETSAY;
-  }));
   Extended_ChannelMaps.push_back(
-      CustomFilter("Other Pet Damage", 0x10006, [this, zeal](short &color, std::string &data) {
+      CustomFilter("My Pet Say", 0x10003,
+                   [this, zeal](short &color, const std::string &data) { return color == CHANNEL_MYPETSAY; }));
+  Extended_ChannelMaps.push_back(
+      CustomFilter("My Pet Damage", 0x10004, [this, zeal](short &color, const std::string &data) {
+        if (isDamage && damageData.source && damageData.source->PetOwnerSpawnId &&
+            damageData.source->PetOwnerSpawnId == Zeal::Game::get_self()->SpawnId) {
+          color = CHANNEL_MYPETDMG;
+          return true;
+        }
+        if (isDamage && damageData.target && damageData.target->PetOwnerSpawnId &&
+            damageData.target->PetOwnerSpawnId == Zeal::Game::get_self()->SpawnId) {
+          color = CHANNEL_MYPETDMG;
+          return true;
+        }
+        return false;
+      }));
+  Extended_ChannelMaps.push_back(
+      CustomFilter("Other Pet Say", 0x10005,
+                   [this, zeal](short &color, const std::string &data) { return color == CHANNEL_OTHERPETSAY; }));
+  Extended_ChannelMaps.push_back(
+      CustomFilter("Other Pet Damage", 0x10006, [this, zeal](short &color, const std::string &data) {
         if (isDamage && damageData.target == Zeal::Game::get_self()) return false;  // Don't re-route damage to self.
         if (isDamage && damageData.source && damageData.source->PetOwnerSpawnId &&
             damageData.source->PetOwnerSpawnId != Zeal::Game::get_self()->SpawnId) {
@@ -531,24 +533,25 @@ chatfilter::chatfilter(ZealService *zeal) {
         }
         return false;
       }));
-  Extended_ChannelMaps.push_back(
-      CustomFilter("/who", 0x10007, [this, zeal](short &color, std::string &data) { return color == USERCOLOR_WHO; }));
+  Extended_ChannelMaps.push_back(CustomFilter(
+      "/who", 0x10007, [this, zeal](short &color, const std::string &data) { return color == USERCOLOR_WHO; }));
   Extended_ChannelMaps.push_back(
       CustomFilter("My Melee Special", 0x10008,
-                   [this, zeal](short &color, std::string &data) { return color == CHANNEL_MYMELEESPECIAL; }));
+                   [this, zeal](short &color, const std::string &data) { return color == CHANNEL_MYMELEESPECIAL; }));
   Extended_ChannelMaps.push_back(
       CustomFilter("Other Melee Special", 0x10009,
-                   [this, zeal](short &color, std::string &data) { return color == CHANNEL_OTHERMELEESPECIAL; }));
+                   [this, zeal](short &color, const std::string &data) { return color == CHANNEL_OTHERMELEESPECIAL; }));
   Extended_ChannelMaps.push_back(CustomFilter(
-      "/mystats", 0x1000A, [this, zeal](short &color, std::string &data) { return color == CHANNEL_MYSTATS; }));
-  Extended_ChannelMaps.push_back(CustomFilter(
-      "Item Speech", 0x1000B, [this, zeal](short &color, std::string &data) { return color == CHANNEL_ITEMSPEECH; }));
+      "/mystats", 0x1000A, [this, zeal](short &color, const std::string &data) { return color == CHANNEL_MYSTATS; }));
+  Extended_ChannelMaps.push_back(
+      CustomFilter("Item Speech", 0x1000B,
+                   [this, zeal](short &color, const std::string &data) { return color == CHANNEL_ITEMSPEECH; }));
   Extended_ChannelMaps.push_back(
       CustomFilter("Other Melee Critical", 0x1000C,
-                   [this, zeal](short &color, std::string &data) { return color == CHANNEL_OTHER_MELEE_CRIT; }));
-  Extended_ChannelMaps.push_back(
-      CustomFilter("Other Damage Shield", 0x1000D,
-                   [this, zeal](short &color, std::string &data) { return color == CHANNEL_OTHER_DAMAGE_SHIELD; }));
+                   [this, zeal](short &color, const std::string &data) { return color == CHANNEL_OTHER_MELEE_CRIT; }));
+  Extended_ChannelMaps.push_back(CustomFilter(
+      "Other Damage Shield", 0x1000D,
+      [this, zeal](short &color, const std::string &data) { return color == CHANNEL_OTHER_DAMAGE_SHIELD; }));
   Extended_ChannelMaps.push_back(CustomFilter(
       "Zeal Spam", 0x1000E, [this](short &color, std::string &data) { return HandleZealSpamCallbacks(color, data); }));
 

--- a/Zeal/game_addresses.h
+++ b/Zeal/game_addresses.h
@@ -31,7 +31,6 @@ static GameStructures::GAMEZONEINFO *ZoneInfo = (GameStructures::GAMEZONEINFO *)
 
 // static DWORD* ptr_LocalPC = (DWORD*)0x7F94E8;
 static GameUI::ContainerMgr **ptr_ContainerMgr = reinterpret_cast<GameUI::ContainerMgr **>(0x0063d6b8);
-static int *ptr_COptionsWnd = (int *)0x63d634;
 static int *ptr_PrimaryKeyMap = (int *)0x7CD84C;
 static int *ptr_AlternateKeyMap = (int *)0x7CDC4C;
 static BYTE *strafe_direction = (BYTE *)0x7985EB;

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1646,7 +1646,7 @@ void do_ooc(std::string data) { GameInternal::do_ooc(get_self(), data.c_str()); 
 
 void send_raid_chat(std::string data) { GameInternal::send_raid_chat(Zeal::Game::RaidInfo, 0, data.c_str()); }
 
-void print_chat(std::string data) {
+void print_chat(const std::string& data) {
   if (!is_in_game()) {
     ZealService::get_instance()->queue_chat_message(data);
     return;

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -51,11 +51,9 @@ static mem::function<void __fastcall(int, int, float)> MouseLook = 0x4db384;
 static mem::function<void __fastcall(DWORD, int unused, DWORD)> proc_mouse = 0x537707;
 static mem::function<void __fastcall(DWORD, int unused, int cmd, int str_id, int category)> InitKeyBind =
     0x42B21D;  // arguments coptionswnd ptr, cmd, string_id, category
-static mem::function<void __fastcall(DWORD, int unused, char *str)> InitKeyBindStr =
-    0x576190;  // arguments coptionswnd ptr, cmd, string_id, category
 static mem::function<int __cdecl(Zeal::GameUI::CXSTR *, const char *format)> CXStr_PrintString = 0x578110;
 static mem::function<int __fastcall(void *this_game, int unused_edx)> LoadOptions = 0x536CE0;  // Game ::loadOptions()
-static mem::function<int __fastcall(int t, int unk, int key, int type)> readKeyMapFromIni = 0x525520;
+static mem::function<int __cdecl(int key, int type)> readKeyMapFromIni = 0x525520;
 static mem::function<void __cdecl(Zeal::GameStructures::GAMECHARINFO *_char, Zeal::GameStructures::_GAMEITEMINFO **Item,
                                   int)>
     auto_inventory = 0x4F0EEB;
@@ -204,7 +202,7 @@ std::vector<Zeal::GameStructures::Entity *> get_world_visible_actor_list(float m
 Zeal::GameStructures::ActorLocation get_actor_location(int actor);
 float get_target_blink_fade_factor(float speed_factor, bool auto_attack_only);  // Returns 0 to 1.0f.
 bool is_view_actor_me();
-void print_chat(std::string data);
+void print_chat(const std::string& data);
 void print_chat(const char *format, ...);
 void print_chat(short color, const char *format, ...);
 void print_chat_wnd(Zeal::GameUI::ChatWnd *, short color, const char *format, ...);

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -1174,6 +1174,8 @@ struct Display {
         this, start_x, start_y, start_z, end_x, end_y, end_z, result_x, result_y, result_z, collision_type);
   }
 
+  void KeyMapUpdated() { reinterpret_cast<void(__thiscall *)(Display *)>(0x004a7ca5)(this); }
+
   struct ReferenceList {
     int unknown;
     int count;           // Number of valid entries in list.

--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -1092,6 +1092,92 @@ class CContextMenuManager {
   /*0x1128*/ DWORD MenuCount;
 };
 
+class OptionsWnd : public SidlWnd {
+ public:
+  static constexpr SidlScreenWndVTable *default_vtable = reinterpret_cast<SidlScreenWndVTable *>(0x005e60f0);
+
+  struct KeyMapPair {
+    CXSTR name;    // Descriptive name show in UI.
+    int category;  // Bitfield with key category (can be multiple).
+  };
+
+  // Maps the KeyMapPairs to keyboard page lists of rows and columns per category.
+  void UpdateKeyboardAssignmentList() { reinterpret_cast<void(__thiscall *)(const OptionsWnd *)>(0x0042b07b)(this); }
+
+  /*0x134*/ void *Subwindows;
+  /*0x138*/ void *GeneralPage;
+  /*0x13C*/ void *FastItemDestroyCheckbox;
+  /*0x140*/ void *GuildInvitesCheckbox;
+  /*0x144*/ void *LootAutoSplitCheckbox;
+  /*0x148*/ void *AnonymousCheckbox;
+  /*0x14C*/ void *RolePlayingCheckbox;
+  /*0x150*/ void *PlayerTradeCombobox;
+  /*0x154*/ void *ItemDroppingCombobox;
+  /*0x158*/ void *SoundRealismSlider;
+  /*0x15C*/ void *SoundRealismValueLabel;
+  /*0x160*/ void *MusicVolumeSlider;
+  /*0x164*/ void *MusicVolumeValueLabel;
+  /*0x168*/ void *SoundVolumeSlider;
+  /*0x16C*/ void *SoundVolumeValueLabel;
+  /*0x170*/ void *LoadSkinButton;
+  /*0x174*/ void *DisplayPage;
+  /*0x178*/ void *PCNamesCheckbox;
+  /*0x17C*/ void *NPCNamesCheckbox;
+  /*0x180*/ void *LevelOfDetailCheckbox;
+  /*0x184*/ void *GammaSlider;
+  /*0x188*/ void *GammaValueLabel;
+  /*0x18C*/ void *ClipPlaneSlider;
+  /*0x190*/ void *ClipPlaneValueLabel;
+  /*0x194*/ void *VideoModesButton;
+  /*0x198*/ void *ParticleDensityCombobox;
+  /*0x19C*/ void *SkyCombobox;
+  /*0x1A0*/ void *FadeDelaySlider;
+  /*0x1A4*/ void *FadeDelayValueLabel;
+  /*0x1A8*/ void *FadeDurationSlider;
+  /*0x1AC*/ void *FadeDurationValueLabel;
+  /*0x1B0*/ void *WindowAlphaSlider;
+  /*0x1B4*/ void *WindowAlphaValueLabel;
+  /*0x1B8*/ void *FadeToAlphaSlider;
+  /*0x1BC*/ void *FadeToAlphaValueLabel;
+  /*0x1C0*/ void *SpellParticleDensityCombobox;
+  /*0x1C4*/ void *SpellParticleNearClipCombobox;
+  /*0x1C8*/ void *SpellParticleOpacitySlider;
+  /*0x1CC*/ void *SpellParticleOpacityValueLabel;
+  /*0x1D0*/ int GlobalAlpha;
+  /*0x1D4*/ int GlobalFadeToAlpha;
+  /*0x1D8*/ int GlobalFadeDelay;
+  /*0x1DC*/ int GlobalFadeDuration;
+  /*0x1E0*/ int Unknown_0x1e0;  // Set to 0 in constructor.
+  /*0x1E4*/ void *MousePage;
+  /*0x1E8*/ void *InvertYAxisCheckbox;
+  /*0x1EC*/ void *LookSpringCheckbox;
+  /*0x1F0*/ void *MouseLookCheckbox;
+  /*0x1F4*/ void *MouseSensitivitySlider;
+  /*0x1F8*/ void *MouseSensitivityValueLabel;
+  /*0x1FC*/ void *KeyboardPage;
+  /*0x200*/ void *KeyboardFilterCombobox;
+  /*0x204*/ void *KeyboardAssignmentList;
+  /*0x208*/ void *DefaultKeysButton;
+  /*0x20C*/ KeyMapPair KeyMaps[256];  // Allocates 256 pairs (through 0xa0c).
+  /*0xA0C*/ int KeyAssignmentRow;     // Set to -1 in constructor. List row.
+  /*0xA10*/ int KeyAssignmentColumn;  // Set to -1 in constructor. List col: 1 = primary, 2 = alt key.
+  /*0xA14*/ void *ChatPage;
+  /*0xA18*/ void *ChatArray[10];  // Chat0 to Chat9.
+  /*0xA40*/ void *DamageShields;
+  /*0xA44*/ void *NPCSpells;
+  /*0xA48*/ void *PCSpellsComboBo;
+  /*0xA4C*/ void *BardSongsComboBox;
+  /*0xA50*/ void *CriticalSpellsComboBox;
+  /*0xA54*/ void *CriticalMeleeComboBox;
+  /*0xA58*/ void *ColorPage;
+  /*0xA5C*/ int Unknown0xA5c;
+  /*0xA60*/ void *UserColorDefault;
+  /*0xA64*/ void *UserColorArray[0x48];  // UserColor0 to UserColor71.
+  /*0xB84*/ int Unknown0xb84;            // Possibly activated?
+  /*0xB88*/ int Timestamp;               // Set to diplay tick time in constructor.
+  /*0xB8C*/                              // Size of new allocation.
+};
+
 class SpellBookWnd : public SidlWnd {
  public:
   static constexpr SidlScreenWndVTable *default_vtable = reinterpret_cast<SidlScreenWndVTable *>(0x005e6e48);
@@ -1310,7 +1396,7 @@ struct pInstWindows {
   HotButton *HotButton;                     // 0x63D628
   ColorPickerWnd *ColorPicker;              // 0x63D62C
   SidlWnd *Player;                          // 0x63D630
-  SidlWnd *Options;                         // 0x63D634
+  OptionsWnd *Options;                      // 0x63D634
   SidlWnd *BuffWindowNORMAL;                // 0x63D638
   SidlWnd *CharacterCreation;               // 0x63D63C
   SidlWnd *CursorAttachment;                // 0x63D640

--- a/Zeal/outputfile.cpp
+++ b/Zeal/outputfile.cpp
@@ -242,7 +242,7 @@ void OutputFile::export_raidlist(std::vector<std::string> &args) {
     }
     std::string fname = "RaidTick-" + timestamp;
     write_to_file(oss.str(), "", fname);
-    Zeal::Game::print_chat("Raid tick saved to: %s", fname);
+    Zeal::Game::print_chat("Raid tick saved to: %s", fname.c_str());
   } else {
     Zeal::Game::print_chat("Currently not in a raid.");
   }

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -3,6 +3,7 @@
 #include <array>
 
 #include "assist.h"
+#include "binds.h"
 #include "callbacks.h"
 #include "camera_mods.h"
 #include "chat.h"
@@ -327,6 +328,8 @@ void ui_options::InitGeneral() {
                           [this](Zeal::GameUI::BasicWnd *wnd) { setting_escape_raid_lock.set(wnd->Checked); });
   ui->AddCheckboxCallback(wnd, "Zeal_DialogPosition",
                           [this](Zeal::GameUI::BasicWnd *wnd) { setting_dialog_position.set(wnd->Checked); });
+  ui->AddCheckboxCallback(wnd, "Zeal_PerCharKeybinds",
+                          [this](Zeal::GameUI::BasicWnd *wnd) { setting_per_char_keybinds.set(wnd->Checked); });
   ui->AddCheckboxCallback(wnd, "Zeal_LogAddToTrade", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->give->setting_log_add_to_trade.set(wnd->Checked);
   });
@@ -951,6 +954,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_Escape", setting_escape.get());
   ui->SetChecked("Zeal_RaidEscapeLock", setting_escape_raid_lock.get());
   ui->SetChecked("Zeal_DialogPosition", setting_dialog_position.get());
+  ui->SetChecked("Zeal_PerCharKeybinds", setting_per_char_keybinds.get());
   ui->SetChecked("Zeal_LogAddToTrade", ZealService::get_instance()->give->setting_log_add_to_trade.get());
   ui->SetChecked("Zeal_ShowHelm", ZealService::get_instance()->helm->ShowHelmEnabled.get());
   ui->SetChecked("Zeal_AltContainerTooltips", ZealService::get_instance()->tooltips->all_containers.get());
@@ -1336,6 +1340,12 @@ static int __fastcall SidlScreenWndHandleRButtonDown(Zeal::GameUI::SidlWnd *wnd,
 
   return ZealService::get_instance()->hooks->hook_map["SidlScreenWndHandleRButtonDown"]->original(
       SidlScreenWndHandleRButtonDown)(wnd, unused_edx, mouse_x, mouse_y, unknown3);
+}
+
+// Applies the per character keybind setting to the low level binds module and also handles triggering
+// the immediate full reload if this is triggered in game.
+void ui_options::SyncKeybinds() {
+  ZealService::get_instance()->binds_hook->set_per_character_mode(setting_per_char_keybinds.get());
 }
 
 // Disables centering of the confirmation dialog window if enabled.

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -41,6 +41,8 @@ class ui_options {
   ZealSetting<bool> setting_escape_raid_lock = {false, "Zeal", "EscapeRaidLock", false};
   ZealSetting<bool> setting_dialog_position = {false, "Zeal", "DialogPosition", false,
                                                [this](const bool &) { SyncDialogPosition(); }};
+  ZealSetting<bool> setting_per_char_keybinds = {false, "Zeal", "PerCharKeybinds", false,
+                                                 [this](const bool &) { SyncKeybinds(); }};
 
  private:
   void InitUI();
@@ -59,6 +61,7 @@ class ui_options {
   int FindComboIndex(std::string combobox, std::string text_value);
   void UpdateComboBox(const std::string &name, const std::string &label, const std::string &default_label);
   void SyncDialogPosition();
+  void SyncKeybinds();
 
   Zeal::GameUI::SidlWnd *wnd = nullptr;
   std::vector<Zeal::GameUI::BasicWnd *> color_buttons;

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -727,6 +727,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_PerCharKeybinds">
+    <ScreenID>Zeal_PerCharKeybinds</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>508</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables storing keybinds per character</TooltipReference>
+    <Text>Per char keybinds</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- Second column -->
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1750,6 +1781,7 @@
     <Pieces>Zeal_AutoConsent</Pieces>
     <Pieces>Zeal_DialogPosition</Pieces>
     <Pieces>Zeal_LogAddToTrade</Pieces>
+    <Pieces>Zeal_PerCharKeybinds</Pieces>
     <!-- Second column. -->
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -727,6 +727,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_PerCharKeybinds">
+    <ScreenID>Zeal_PerCharKeybinds</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>20</X>
+      <Y>1016</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables storing keybinds per character</TooltipReference>
+    <Text>Per char keybinds</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1750,6 +1781,7 @@
     <Pieces>Zeal_AutoConsent</Pieces>
     <Pieces>Zeal_DialogPosition</Pieces>
     <Pieces>Zeal_LogAddToTrade</Pieces>
+    <Pieces>Zeal_PerCharKeybinds</Pieces>
     
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -1771,17 +1771,17 @@ const ZoneMapData *ZoneMap::get_zone_map(int zone_id) {
 
   // Optional data from additional files (typically poi's).
   bool additional_file_found = false;
-  int additional_file_index = 1; // Default to shortname_1.txt
+  int additional_file_index = 1;  // Default to shortname_1.txt
   do {
     std::string filename_alt = "map_files/" + short_name + "_" + std::to_string(additional_file_index) + ".txt";
     additional_file_found = add_map_data_from_file(filename_alt, *new_map);
     additional_file_index++;
-  } while (additional_file_found && additional_file_index <= 10); // Limit max additional files to check for
+  } while (additional_file_found && additional_file_index <= 10);  // Limit max additional files to check for
 
   if (map_data_mode == MapDataMode::kBoth && internal_map) {
     add_map_data_from_internal(*internal_map, *new_map);  // Add all lines, labels and levels
   } else if (map_data_mode == MapDataMode::kNoInternalPOI && internal_map && new_map->labels.size() > 0) {
-    add_map_lines_from_internal(*internal_map, *new_map); // Add internal lines and levels
+    add_map_lines_from_internal(*internal_map, *new_map);  // Add internal lines and levels
     add_map_levels_from_internal(*internal_map, *new_map);
   } else if (new_map->lines.size() == 0) {
     map_data_cache[zone_id] = nullptr;  // Flag it as a failed load.
@@ -1806,8 +1806,8 @@ void ZoneMap::add_map_lines_from_internal(const ZoneMapData &internal_map, Custo
 }
 
 void ZoneMap::add_map_labels_from_internal(const ZoneMapData &internal_map, CustomMapData &map_data) {
-  for (int i = 0; i < internal_map.num_labels; ++i) // Not modifying label pointers.
-      map_data.labels.push_back(internal_map.labels[i]);
+  for (int i = 0; i < internal_map.num_labels; ++i)  // Not modifying label pointers.
+    map_data.labels.push_back(internal_map.labels[i]);
 }
 
 void ZoneMap::add_map_levels_from_internal(const ZoneMapData &internal_map, CustomMapData &map_data) {
@@ -1840,8 +1840,8 @@ bool ZoneMap::add_map_data_from_file(const std::string &filename, CustomMapData 
       map_data.labels.emplace_back(static_cast<int>(x0 + 0.5f), static_cast<int>(y0 + 0.5f),
                                    static_cast<int>(z0 + 0.5f), static_cast<uint8_t>(red), static_cast<uint8_t>(green),
                                    static_cast<uint8_t>(blue), map_data.label_strings.back().c_str());
-    } else {
-      Zeal::Game::print_chat("Line failed in %s: %s", filename, line);
+    } else if (!line.empty()) {
+      Zeal::Game::print_chat("Line failed in %s: %s", filename, line.c_str());
     }
   }
 


### PR DESCRIPTION
- Added new zeal general options tab option to enable per character keybinds. When enabled, these are stored in a new eqclient.ini section called "Keymaps_<name".
- Did some std::string cleanup to make more parameters const refs instead of refs or copies and fixed two cases of debug printfs not properly using .c_str().
- Suppressed the map external data mode complaint about blank lines in map files.