### PR TITLE
Add show raid members health option

### DIFF
--- a/Zeal/bitmap_font.cpp
+++ b/Zeal/bitmap_font.cpp
@@ -866,6 +866,7 @@ void SpriteFont::calculate_glyph_vertices(const GlyphQueueEntry &entry, Glyph3DV
 }
 
 float SpriteFont::get_text_height(const std::string &text) const {
+  if (text.empty()) return 0;
   auto text_lines = Zeal::String::split_text(text);
   float y_height = 0;
   float y_advance = 0;

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -744,6 +744,9 @@ bool is_raid_pet(const Zeal::GameStructures::Entity &entity) {
   const auto raid_info = Zeal::Game::RaidInfo;
   if (!raid_info->is_in_raid()) return false;
 
+  auto owner = Zeal::Game::get_entity_by_id(pet_owner_id);
+  if (!owner || owner->Type != Zeal::GameEnums::Player) return false;
+
   for (int i = 0; i < Zeal::GameStructures::RaidInfo::kRaidMaxMembers; ++i) {
     const Zeal::GameStructures::RaidMember &member = raid_info->MemberList[i];
     if (member.Name[0] == 0)  // Empty string check.
@@ -1646,7 +1649,7 @@ void do_ooc(std::string data) { GameInternal::do_ooc(get_self(), data.c_str()); 
 
 void send_raid_chat(std::string data) { GameInternal::send_raid_chat(Zeal::Game::RaidInfo, 0, data.c_str()); }
 
-void print_chat(const std::string& data) {
+void print_chat(const std::string &data) {
   if (!is_in_game()) {
     ZealService::get_instance()->queue_chat_message(data);
     return;

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -93,6 +93,7 @@ class NamePlate {
 
   // Advanced fonts
   ZealSetting<bool> setting_health_bars = {false, "Zeal", "NameplateHealthBars", false};
+  ZealSetting<bool> setting_raid_health_bars = {false, "Zeal", "NameplateRaidHealthBars", false};
   ZealSetting<bool> setting_mana_bars = {false, "Zeal", "NameplateManaBars", false};
   ZealSetting<bool> setting_stamina_bars = {false, "Zeal", "NameplateStaminaBars", false};
   ZealSetting<bool> setting_zeal_fonts = {false, "Zeal", "NamePlateZealFonts", false, [this](bool val) { clean_ui(); }};
@@ -134,6 +135,7 @@ class NamePlate {
   bool is_nameplate_hidden_by_race(const Zeal::GameStructures::Entity &entity) const;
   bool is_group_member(const Zeal::GameStructures::Entity &entity) const;
   bool is_raid_member(const Zeal::GameStructures::Entity &entity) const;
+  bool is_hp_updated(const Zeal::GameStructures::Entity *entity) const;
   bool handle_shownames_command(const std::vector<std::string> &args);
   void handle_tag_command(const std::vector<std::string> &args);
   bool handle_tag_target(const std::string &target_text);

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -815,6 +815,9 @@ void ui_options::InitNameplate() {
   ui->AddCheckboxCallback(wnd, "Zeal_NameplateHealthBars", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->nameplate->setting_health_bars.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_NameplateRaidHealthBars", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->nameplate->setting_raid_health_bars.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_NameplateManaBars", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->nameplate->setting_mana_bars.set(wnd->Checked);
   });
@@ -1093,6 +1096,8 @@ void ui_options::UpdateOptionsNameplate() {
   ui->SetChecked("Zeal_NameplateZealFonts", ZealService::get_instance()->nameplate->setting_zeal_fonts.get());
   ui->SetChecked("Zeal_NameplateDropShadow", ZealService::get_instance()->nameplate->setting_drop_shadow.get());
   ui->SetChecked("Zeal_NameplateHealthBars", ZealService::get_instance()->nameplate->setting_health_bars.get());
+  ui->SetChecked("Zeal_NameplateRaidHealthBars",
+                 ZealService::get_instance()->nameplate->setting_raid_health_bars.get());
   ui->SetChecked("Zeal_NameplateManaBars", ZealService::get_instance()->nameplate->setting_mana_bars.get());
   ui->SetChecked("Zeal_NameplateStaminaBars", ZealService::get_instance()->nameplate->setting_stamina_bars.get());
   ui->SetChecked("Zeal_TagEnable", ZealService::get_instance()->nameplate->setting_tag_enable.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <XML ID="EQInterfaceDefinitionLanguage">
   <Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
-<!-- Zeal Nameplates -->
+  <!-- Zeal Nameplates -->
   <Button item="Zeal_NameplateColors">
     <ScreenID>Zeal_NameplateColors</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -32,7 +32,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-    <Button item="Zeal_NameplateConColors">
+  <Button item="Zeal_NameplateConColors">
     <ScreenID>Zeal_NameplateConColors</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -62,7 +62,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateHideSelf">
+  <Button item="Zeal_NameplateHideSelf">
     <ScreenID>Zeal_NameplateHideSelf</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -92,7 +92,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateX">
+  <Button item="Zeal_NameplateX">
     <ScreenID>Zeal_NameplateX</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -122,7 +122,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateHideRaidPets">
+  <Button item="Zeal_NameplateHideRaidPets">
     <ScreenID>Zeal_NameplateHideRaidPets</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -152,7 +152,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateShowPetOwnerName">
+  <Button item="Zeal_NameplateShowPetOwnerName">
     <ScreenID>Zeal_NameplateShowPetOwnerName</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -212,7 +212,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateCharSelect">
+  <Button item="Zeal_NameplateCharSelect">
     <ScreenID>Zeal_NameplateCharSelect</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -316,7 +316,7 @@
     <Style_Border>true</Style_Border>
     <Choices>Off</Choices>
   </Combobox>
-<!-- Local AA Title Label -->
+  <!-- Local AA Title Label -->
   <Label item="Zeal_NameplateLocalAATitle_Label">
     <ScreenID>Zeal_NameplateLocalAATitle_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -392,7 +392,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-    <Button item="Zeal_NameplateTargetMarker">
+  <Button item="Zeal_NameplateTargetMarker">
     <ScreenID>Zeal_NameplateTargetMarker</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -422,7 +422,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateTargetHealth">
+  <Button item="Zeal_NameplateTargetHealth">
     <ScreenID>Zeal_NameplateTargetHealth</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -609,8 +609,38 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Enable health bars (zeal fonts only)</TooltipReference>
+    <TooltipReference>Enable health bars for self, pet, group, target (zeal fonts only)</TooltipReference>
     <Text>Show health bars</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_NameplateRaidHealthBars">
+    <ScreenID>Zeal_NameplateRaidHealthBars</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>185</X>
+      <Y>226</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Also show raid member healthbars (requires healthbars enabled and server to send updates)</TooltipReference>
+    <Text>Also show raid</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -629,7 +659,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>185</X>
-      <Y>226</Y>
+      <Y>248</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -659,7 +689,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>185</X>
-      <Y>248</Y>
+      <Y>270</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -974,6 +1004,7 @@
     <Pieces>Zeal_NameplateZealFonts</Pieces>
     <Pieces>Zeal_NameplateDropShadow</Pieces>
     <Pieces>Zeal_NameplateHealthBars</Pieces>
+    <Pieces>Zeal_NameplateRaidHealthBars</Pieces>
     <Pieces>Zeal_NameplateManaBars</Pieces>
     <Pieces>Zeal_NameplateStaminaBars</Pieces>
     <Pieces>Zeal_NameplateFont_Combobox</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Nameplate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <XML ID="EQInterfaceDefinitionLanguage">
   <Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
-
+  
   <Button item="Zeal_NameplateColors">
     <ScreenID>Zeal_NameplateColors</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -32,7 +32,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-    <Button item="Zeal_NameplateConColors">
+  <Button item="Zeal_NameplateConColors">
     <ScreenID>Zeal_NameplateConColors</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -62,7 +62,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateHideSelf">
+  <Button item="Zeal_NameplateHideSelf">
     <ScreenID>Zeal_NameplateHideSelf</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -92,7 +92,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateX">
+  <Button item="Zeal_NameplateX">
     <ScreenID>Zeal_NameplateX</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -122,7 +122,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateHideRaidPets">
+  <Button item="Zeal_NameplateHideRaidPets">
     <ScreenID>Zeal_NameplateHideRaidPets</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -152,7 +152,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateShowPetOwnerName">
+  <Button item="Zeal_NameplateShowPetOwnerName">
     <ScreenID>Zeal_NameplateShowPetOwnerName</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -212,7 +212,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateCharSelect">
+  <Button item="Zeal_NameplateCharSelect">
     <ScreenID>Zeal_NameplateCharSelect</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -316,7 +316,7 @@
     <Style_Border>true</Style_Border>
     <Choices>Off</Choices>
   </Combobox>
-
+  
   <Label item="Zeal_NameplateLocalAATitle_Label">
     <ScreenID>Zeal_NameplateLocalAATitle_Label</ScreenID>
     <RelativePosition>true</RelativePosition>
@@ -392,7 +392,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-    <Button item="Zeal_NameplateTargetMarker">
+  <Button item="Zeal_NameplateTargetMarker">
     <ScreenID>Zeal_NameplateTargetMarker</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -422,7 +422,7 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
-<Button item="Zeal_NameplateTargetHealth">
+  <Button item="Zeal_NameplateTargetHealth">
     <ScreenID>Zeal_NameplateTargetHealth</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
@@ -609,8 +609,38 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Enable health bars (zeal fonts only)</TooltipReference>
+    <TooltipReference>Enable health bars for self, pet, group, target (zeal fonts only)</TooltipReference>
     <Text>Show health bars</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_NameplateRaidHealthBars">
+    <ScreenID>Zeal_NameplateRaidHealthBars</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>370</X>
+      <Y>452</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Also show raid member healthbars (requires healthbars enabled and server to send updates)</TooltipReference>
+    <Text>Also show raid</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -629,7 +659,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>370</X>
-      <Y>452</Y>
+      <Y>496</Y>
     </Location>
     <Size>
       <CX>300</CX>
@@ -659,7 +689,7 @@
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>370</X>
-      <Y>496</Y>
+      <Y>540</Y>
     </Location>
     <Size>
       <CX>300</CX>
@@ -974,6 +1004,7 @@
     <Pieces>Zeal_NameplateZealFonts</Pieces>
     <Pieces>Zeal_NameplateDropShadow</Pieces>
     <Pieces>Zeal_NameplateHealthBars</Pieces>
+    <Pieces>Zeal_NameplateRaidHealthBars</Pieces>
     <Pieces>Zeal_NameplateManaBars</Pieces>
     <Pieces>Zeal_NameplateStaminaBars</Pieces>
     <Pieces>Zeal_NameplateFont_Combobox</Pieces>


### PR DESCRIPTION
- Added a new nameplate options tab checkbox to allow showing healthbars for raid members. 
  - This is only useful if the server shares up to date health status reports, so it is optional.
- Also modified the /tag behavior:
  - Now supports showing tag and tag shape even if the nameplate text is hidden (still does not work on mobs w/out nameplates)
    - This fixes an issue where filtering wasn't working when nameplates were hidden
  - Modified the text coloring behavior to only override with the Tagged color if no explicit shape is specified