### PR TITLE
Add very simple log-based triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,10 @@ ___
   - **Aliases:** `/opentrade`, `/ot`
   - **Description:** Opens a trade window with your current target.
 
+- `/triggers`
+  - **Description:** Supports very simplistic countdown timers from chat parsing triggers.
+     See the [Triggers](#Triggers) section for more details.
+
 - `/uierrors`
   - **Arguments:** `on`, `off`
   - **Description:** Sets (on) or clears (off) the enable for showing dialog messages for unknown xml errors.
@@ -509,6 +513,28 @@ Manual editing of the ini file is required to copy from old section to the new s
   RingRight, Ammo
 - Can hold Shift (2nd) / Ctrl (3rd) / Shift+Ctrl (4th) to equip the item to alternate slots
   if it can be equipped in several slots in the list.
+
+## Triggers
+- Supports a very simplistic visible timer countdown display based on char parsed trigger events
+  - This is not a replacement for GINA or eqlogparser and is unlikely to be expanded
+- Supports the following commands:
+  - `/triggers on`, `/triggers off`: Enables or disables trigger monitoring. The on reloads the file.
+  - `/triggers load [filename]`: Loads triggers from a file. If filename is blank, uses default
+     per character trigger file (`<name>-Triggers.txt`). If not blank and the load is successful,
+     the filename becomes the new default for the character.
+  - `/triggers clear`: Clears list of active trigger events.
+  - `/triggers list`: Lists the loaded trigger and active events.
+  - `/triggers font <fontname>`: Sets the font to use for events list (default is `arial_12`)
+  - `/triggers position <x> <y>`: Sets the upper left offset of the events list on screen.
+- Triggers file format: Five columns delimited by four `^` symbol
+  - Column 1: "Arm" or "Clear" actions
+  - Column 2: Label for event in display (also used by Clear to Clear an event)
+  - Column 3: Pattern matching expression (c++ std::regex, don't get fancy, no sanitization)
+  - Column 4: Duration in seconds
+  - Column 5: Color in hex ARGB (0xffffffff = white, 0xffff0000 = red)
+ - Example that sets a 60 sec countdown when a charm lands and clears early if breaks:
+   - `Add^Charm^.*'s eyes glaze over.^60^0xff00ff00`
+   - `Clear^Charm^Your charm spell has worn off.^0^0`
 
 ## Nameplate tagging
 - Controlled through either the `/tag` command or Nameplate tab options

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -85,6 +85,7 @@
     <ClInclude Include="survey.h" />
     <ClInclude Include="tag_arrows.h" />
     <ClInclude Include="tick.h" />
+    <ClInclude Include="triggers.h" />
     <ClInclude Include="ui_buff.h" />
     <ClInclude Include="ui_group.h" />
     <ClInclude Include="ui_inputdialog.h" />
@@ -165,6 +166,7 @@
     <ClCompile Include="survey.cpp" />
     <ClCompile Include="tag_arrows.cpp" />
     <ClCompile Include="tick.cpp" />
+    <ClCompile Include="triggers.cpp" />
     <ClCompile Include="ui_buff.cpp" />
     <ClCompile Include="ui_group.cpp" />
     <ClCompile Include="ui_inputdialog.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -291,6 +291,9 @@
     <ClInclude Include="tag_arrows.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="triggers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -504,6 +507,9 @@
       <Filter>Source Files\helpers</Filter>
     </ClCompile>
     <ClCompile Include="tag_arrows.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="triggers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Zeal/triggers.cpp
+++ b/Zeal/triggers.cpp
@@ -1,0 +1,280 @@
+#include "triggers.h"
+
+#include <algorithm>
+#include <fstream>
+#include <regex>
+
+#include "callbacks.h"
+#include "chat.h"
+#include "commands.h"
+#include "game_functions.h"
+#include "string_util.h"
+#include "zeal.h"
+
+// TODO:
+// - Look into tick synchronization option / specify in ticks.
+
+Triggers::Triggers(ZealService *zeal) {
+  zeal->chat_hook->add_print_chat_callback(
+      [this](const char *data, int color_index) { HandlePrintChat(data, color_index); });
+  zeal->callbacks->AddGeneric([this]() { CallbackRender(); }, callback_type::RenderUI);
+  zeal->callbacks->AddGeneric([this]() { LoadTriggers("", false); }, callback_type::InitUI);
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::EnterZone);
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::CleanUI);  // Note: new_ui only call.
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::DXReset);  // Just release all resources.
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::DXCleanDevice);
+
+  zeal->commands_hook->Add("/triggers", {}, "Controls log trigger parsing", [this](std::vector<std::string> &args) {
+    ParseArgs(args);
+    return true;
+  });
+}
+
+Triggers::~Triggers() { Clean(); }
+
+void Triggers::Clean() {
+  bitmap_font.reset();  // Releases all DX and other resources.
+  trigger_events.clear();
+}
+
+void Triggers::SynchronizeEnable(bool verbose) {
+  triggers.clear();
+  trigger_events.clear();
+  if (!enabled.get()) return;
+
+  LoadTriggers(triggers_filename.get(), verbose);
+}
+
+bool Triggers::LoadTriggers(const std::string &load_filename, bool verbose) {
+  triggers.clear();
+  std::string filename = load_filename;
+  if (filename.empty()) {
+    // Parse the default per user triggers file.
+    auto char_info = Zeal::Game::get_char_info();
+    if (!char_info) return false;
+    filename = std::string(char_info->Name) + "-Triggers.txt";
+  }
+
+  std::filesystem::path file_path = Zeal::Game::get_game_path() / std::filesystem::path(filename);
+  if (!std::filesystem::exists(file_path)) {
+    if (verbose) Zeal::Game::print_chat("Failed to load trigger file: %s", file_path.string().c_str());
+    return false;
+  }
+
+  std::ifstream input_file(file_path);
+  if (!input_file.is_open()) {
+    if (verbose) Zeal::Game::print_chat("Error opening protect file: %s", file_path.string().c_str());
+    return false;
+  }
+
+  std::string line;
+  int error_count = 0;
+  while (std::getline(input_file, line)) {
+    if (line.empty()) continue;  // Ignore blank lines.
+    if (!AddTrigger(line)) {
+      if (verbose) Zeal::Game::print_chat("Zeal Triggers error parsing line: %s", line.c_str());
+      return false;  // Bail out.
+    }
+  }
+  if (verbose) Zeal::Game::print_chat("Zeal loaded %d triggers", triggers.size());
+  return true;
+}
+
+bool Triggers::AddTrigger(const std::string &line) {
+  auto fields = Zeal::String::split_text(line, "^");
+  if (fields.size() != 5) return false;
+
+  Action action = Action::Clear;
+  if (fields[0] == "Add")
+    action = Action::Add;
+  else if (fields[0] != "Clear")
+    return false;
+
+  int duration_sec = 0;
+  if (!Zeal::String::tryParse(fields[3], &duration_sec)) return false;
+  if (duration_sec < 0 || duration_sec > 10 * 3600) return false;  // Failed duration sanity check of up to 10 hours.
+
+  DWORD color = 0;
+  try {
+    color = std::stoul(fields[4], nullptr, 0);  // Hex conversion
+  } catch (const std::exception &e) {
+    return false;
+  }
+
+  Trigger trigger = {.action = action,
+                     .label = fields[1],
+                     .pattern_str = fields[2],
+                     .pattern = std::regex(fields[2]),
+                     .duration_sec = static_cast<DWORD>(duration_sec),
+                     .color = color};
+  triggers.push_back(trigger);
+  return true;
+}
+
+std::string Triggers::GetTriggerDescription(const Trigger &trigger) const {
+  switch (trigger.action) {
+    case Action::Clear:
+      return std::format("Clear {}", trigger.label);
+    case Action::Add:
+      return std::format("Add {}: \"{}\" {} secs, Color: {:#08x}", trigger.label, trigger.pattern_str,
+                         trigger.duration_sec, trigger.color);
+  }
+  return "Unrecognized trigger";
+}
+
+void Triggers::ParseArgs(const std::vector<std::string> &args) {
+  if (args.size() == 2 && (args[1] == "on" || args[1] == "off")) {
+    enabled.set(args[1] == "on");
+    Zeal::Game::print_chat("Triggers are %s", enabled.get() ? "on" : "off");
+    return;
+  }
+
+  if ((args.size() == 2 || args.size() == 3) && args[1] == "load") {
+    if (!enabled.get()) {
+      Zeal::Game::print_chat("Triggers are disabled");
+      return;
+    }
+    std::string filename = (args.size() == 3) ? args[2] : "";
+    if (LoadTriggers(filename, true) && filename != triggers_filename.get()) {
+      triggers_filename.set(filename);
+      if (filename == "") filename = "(default)";
+      Zeal::Game::print_chat("Loaded %d triggers from file: %s", triggers.size(), filename.c_str());
+    }
+    return;
+  }
+
+  if (args.size() == 2 && args[1] == "clear") {
+    trigger_events.clear();
+    Zeal::Game::print_chat("Cleared active trigger events");
+    return;
+  }
+
+  if (args.size() == 2 && args[1] == "list") {
+    if (!enabled.get()) {
+      Zeal::Game::print_chat("Triggers are disabled");
+      return;
+    }
+    if (triggers.empty()) {
+      Zeal::Game::print_chat("No triggers are loaded");
+      return;
+    }
+    Zeal::Game::print_chat("Triggers:");
+    for (int i = 0; i < triggers.size(); ++i) {
+      Zeal::Game::print_chat("[%d]: %s", i, GetTriggerDescription(triggers[i]).c_str());
+    }
+
+    if (trigger_events.empty()) return;
+
+    Zeal::Game::print_chat("Active events:");
+    for (const auto &event : trigger_events) {
+      Zeal::Game::print_chat("%s: %d", event.label.c_str(), event.end_timestamp_ms);
+    }
+    return;
+  }
+
+  if (args.size() == 3 && args[1] == "font") {
+    bitmap_font_filename.set(args[2]);
+    Zeal::Game::print_chat("Font filename set to %s", bitmap_font_filename.get().c_str());
+    return;
+  }
+
+  if (args.size() == 4 && args[1] == "position") {
+    int x, y;
+    if (Zeal::String::tryParse(args[2], &x) && Zeal::String::tryParse(args[3], &y)) {
+      position_x.set(x);
+      position_y.set(y);
+      Zeal::Game::print_chat("Trigger list position set to (%d, %d)", x, y);
+      return;
+    }
+
+    Zeal::Game::print_chat("Usage: /triggers position <x> <y> where (x,y) is the upper left of list");
+    return;
+  }
+
+  Zeal::Game::print_chat("Usage: /triggers <on | off>, list, clear");
+  Zeal::Game::print_chat("Usage: /triggers load [filename] (blank filename = load per user default)");
+  Zeal::Game::print_chat("Usage: /triggers font font_filename");
+  Zeal::Game::print_chat("Usage: /triggers position <x> <y> where (x,y) is the upper left of list");
+}
+
+void Triggers::HandlePrintChat(const char *data, int color_index) {
+  if (!enabled.get()) return;
+
+  for (const auto &trigger : triggers) {
+    if (std::regex_match(data, trigger.pattern)) {
+      ActivateTrigger(trigger);
+      return;  // Only activates the first trigger.
+    }
+  }
+}
+
+void Triggers::ActivateTrigger(const Trigger &trigger) {
+  if (trigger.action == Action::Clear) {
+    std::erase_if(trigger_events, [trigger](const TriggerEvent &t) { return t.label == trigger.label; });
+    return;
+  }
+
+  if (trigger.action != Action::Add) return;  // Unknown, ignore.
+
+  auto display = Zeal::Game::get_display();
+  if (!display) return;  // Unlikely but protect against.
+
+  DWORD end_timestamp_ms = display->GameTimeMs + trigger.duration_sec * 1000;
+  TriggerEvent event = {.label = trigger.label, .color = trigger.color, .end_timestamp_ms = end_timestamp_ms};
+  trigger_events.push_back(event);
+}
+
+// Loads the bitmap font for real-time text rendering to screen.
+void Triggers::LoadBitmapFont() {
+  if (bitmap_font || bitmap_font_filename.get().empty()) return;
+
+  IDirect3DDevice8 *device = ZealService::get_instance()->dx->GetDevice();
+  std::string font_filename = bitmap_font_filename.get();
+  bool is_default_font = (font_filename.empty() || font_filename == kUseDefaultFont);
+  if (is_default_font) font_filename = kDefaultTriggerFont;
+  if (device != nullptr) bitmap_font = BitmapFont::create_bitmap_font(*device, font_filename);
+  if (!bitmap_font) {
+    Zeal::Game::print_chat("Failed to load font: %s", font_filename.c_str());
+    if (is_default_font) {
+      Zeal::Game::print_chat("Disabling triggers due to font issue");
+      enabled.set(false);
+    } else {
+      bitmap_font_filename.set(kUseDefaultFont);  // Try again with default next round.
+    }
+    return;
+  }
+
+  bitmap_font->set_drop_shadow(true);  // TODO
+}
+
+void Triggers::CallbackRender() {
+  if (!enabled.get() || trigger_events.empty() || !Zeal::Game::is_in_game() || !Zeal::Game::is_gui_visible()) return;
+
+  auto display = Zeal::Game::get_display();
+  if (!display) return;
+
+  LoadBitmapFont();
+  if (!bitmap_font) return;
+
+  // First remove any expired trigger events.
+  DWORD current_time_ms = display->GameTimeMs;
+  std::erase_if(trigger_events,
+                [current_time_ms](const TriggerEvent &trigger) { return trigger.end_timestamp_ms <= current_time_ms; });
+  if (trigger_events.empty()) return;
+
+  Vec2 screen_size = ZealService::get_instance()->dx->GetScreenRect();
+  float x = static_cast<float>(position_x.get());
+  float y = static_cast<float>(position_y.get());
+  for (const auto &event : trigger_events) {
+    int seconds = (event.end_timestamp_ms - current_time_ms) / 1000;
+    int hours = seconds / 3600;
+    seconds = seconds - hours * 3600;
+    int minutes = seconds / 60;
+    seconds = seconds - minutes / 60;
+    std::string label = std::format("{:02d}:{:02d}:{:02d}: {}", hours, minutes, seconds, event.label);
+    bitmap_font->queue_string(label.c_str(), Vec3(x, y, 0), false, event.color, true);
+    y += bitmap_font->get_line_spacing();
+  }
+
+  bitmap_font->flush_queue_to_screen();
+}

--- a/Zeal/triggers.h
+++ b/Zeal/triggers.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <Windows.h>
+
+#include <regex>
+#include <string>
+#include <vector>
+
+#include "bitmap_font.h"
+#include "zeal_settings.h"
+
+class Triggers {
+ public:
+  static constexpr char kUseDefaultFont[] = "Default";
+  static constexpr char kDefaultTriggerFont[] = "arial_12";
+
+  explicit Triggers(class ZealService *zeal);
+  ~Triggers();
+
+  // Disable copy.
+  Triggers(Triggers const &) = delete;
+  Triggers &operator=(Triggers const &) = delete;
+
+  ZealSetting<bool> enabled = {false, "Triggers", "Enabled", true, [this](bool val) { SynchronizeEnable(); }};
+  ZealSetting<int> position_x = {100, "Triggers", "PositionX", true};
+  ZealSetting<int> position_y = {100, "Triggers", "PositionY", true};
+  ZealSetting<std::string> triggers_filename = {std::string(), "Triggers", "Filename", true};
+  ZealSetting<std::string> bitmap_font_filename = {std::string(kUseDefaultFont), "Triggers", "Font", true,
+                                                   [this](std::string val) { bitmap_font.reset(); }};
+
+ private:
+  enum class Action { Clear = 0, Add = 1 };
+
+  struct Trigger {
+    Action action;            // Action to perform when there is a match.
+    std::string label;        // Screen label for a visible trigger.
+    std::string pattern_str;  // Original string used to generate regex pattern.
+    std::regex pattern;       // Pattern to match to activate trigger.
+    DWORD duration_sec;       // Countdown duration in seconds.
+    D3DCOLOR color;           // Color of text.
+  };
+
+  struct TriggerEvent {
+    std::string label;       // Copied from Trigger.
+    D3DCOLOR color;          // Copied from Trigger.
+    DWORD end_timestamp_ms;  // Set by activation time + duration.
+  };
+
+  void Clean();                                  // Resets state and releases all resources.
+  void SynchronizeEnable(bool verbose = false);  // Loads triggers from file if enabled.
+  bool LoadTriggers(const std::string &triggers_filename, bool verbose);
+  void ParseArgs(const std::vector<std::string> &args);
+  bool AddTrigger(const std::string &line);
+  void LoadBitmapFont();  // Loads the bitmap font for rendering.
+  std::string GetTriggerDescription(const Trigger &trigger) const;
+
+  void HandlePrintChat(const char *data, int color_index);  // Scans chat text for matches.
+  void ActivateTrigger(const Trigger &trigger);             // Executed when there is a match.
+  void CallbackRender();                                    // Displays visible trigger list.
+
+  std::unique_ptr<BitmapFont> bitmap_font = nullptr;
+  std::vector<Trigger> triggers;
+  std::vector<TriggerEvent> trigger_events;
+};

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -53,6 +53,7 @@
 #include "tellwindows.h"
 #include "tick.h"
 #include "tooltip.h"
+#include "triggers.h"
 #include "ui_manager.h"
 #include "ui_skin.h"
 #include "utils.h"
@@ -152,6 +153,7 @@ ZealService::ZealService() {
   equip_item_hook = MakeCheckedUnique(EquipItem);   // Uses new UI InvSlotWnd.
   chatfilter_hook = MakeCheckedUnique(chatfilter);  // Uses new UI ChatWnd
   chat_hook = MakeCheckedUnique(Chat);              // Uses chatfilter.
+  triggers = MakeCheckedUnique(Triggers);           // Uses chat_hook.
   nameplate = MakeCheckedUnique(NamePlate);         // Uses target ring blink rate, chat, chatfilter.
   tells = MakeCheckedUnique(TellWindows);           // Uses new UI ChatManager.
   looting_hook = MakeCheckedUnique(Looting);        // Uses new UI Loot window (and ChatManager).

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -65,6 +65,7 @@ class ZealService {
   std::unique_ptr<class BuffTimers> buff_timers = nullptr;
   std::unique_ptr<class HelmManager> helm = nullptr;
 
+  std::unique_ptr<class Triggers> triggers = nullptr;
   std::unique_ptr<class TargetRing> target_ring = nullptr;
   std::unique_ptr<class FloatingDamage> floating_damage = nullptr;
 


### PR DESCRIPTION
- Added a new /triggers command that supports loading a list of triggers from a specially formatted text file that will match to events in the chat output stream and generate on screen labels with timer countdowns