### PR TITLE
Add per character chat autojoin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To disable Zeal, just delete the zeal.asi file.
 ### Features
 - Camera motion improvements (major improvements to third person view)
 - Additional key binds (tab targeting, corpse cycling, strafe, pet, map,
-  autoinventory, autofire, buy/sell stacks)
+  autoinventory, autofire, buy/sell stacks, per character)
 - Additional commands (melody, autofire, useitem, autoinventory, autobank,
   link all, loot all, raid survey, singleclick, show loot lockouts, etc)
 - Integrated map (see In-game Map section below)
@@ -29,7 +29,7 @@ To disable Zeal, just delete the zeal.asi file.
 - Autostand on move/cast, autosit on camp with export inventory/spellbook option,
   enhanced autorun behavior option
 - Enhanced chat (% replacements, additional filters and colors, tell windows,
-  tab completion, copy and paste)
+  tab completion, copy and paste, per character autojoin channels)
 - Optional enhanced spell info (spells, scrolls, items) on info displays
 - Notification sounds (tells, group invites)
 - Third party tool support (silent log messages, direct ZealPipes)

--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -452,7 +452,7 @@ static std::string get_tab_completion_target(const std::string &text, const std:
 static std::vector<std::string> get_tell_list_matches(const std::string &start_of_name) {
   std::vector<std::string> result;
   const int tell_list_size = 31;  // Stores most recent 31 tell names.
-  const char (*tell_list)[64] = reinterpret_cast<const char (*)[64]>(0x007CE45C);
+  const char(*tell_list)[64] = reinterpret_cast<const char(*)[64]>(0x007CE45C);
   for (int i = 0; i < tell_list_size; ++i) {
     if (tell_list[i][0] == 0)  // Rest of list is empty.
       break;
@@ -920,21 +920,21 @@ Chat::Chat(ZealService *zeal) {
         return true;  // return true to stop the game from processing any further on this command,
                       // false if you want to just add features to an existing cmd
       });
-  zeal->commands_hook->Add("/timestamp", {"/tms"}, "Toggles/sets timestamps on chat windows: 0:Off, 1:Long, 2:Short, 3:Short+Secs.",
-                           [this](std::vector<std::string> &args) {
-                             TimeStampsStyle.set(0);
-                             if (args.size() > 1) {
-                               if (args[1] == "1") {
-                                 TimeStampsStyle.set(1);
-                               } else if (args[1] == "2") {
-                                 TimeStampsStyle.set(2);
-                               } else if (args[1] == "3") {
-                                 TimeStampsStyle.set(3);
-                               }
-                             }
-                             return true;  // return true to stop the game from processing any further on this command,
-                                           // false if you want to just add features to an existing cmd
-                           });
+  zeal->commands_hook->Add(
+      "/timestamp", {"/tms"}, "Toggles/sets timestamps on chat windows: 0:Off, 1:Long, 2:Short, 3:Short+Secs.",
+      [this](std::vector<std::string> &args) {
+        if (args.size() == 2) {
+          int style = 0;
+          if (Zeal::String::tryParse(args[1], &style, true) && style >= 0 && style <= 3) {
+            TimeStampsStyle.set(style);
+            Zeal::Game::print_chat("Timestamps style set to: %d", TimeStampsStyle.get());
+            return true;
+          }
+        }
+        Zeal::Game::print_chat(
+            "Usage: /timestamp <style> where <style> = 0 (Off), 1 (Long), 2 (Short), 3 (Short+Secs)");
+        return true;  // No existing cmd.
+      });
   zeal->commands_hook->Add("/zealinput", {"/zinput"}, "Toggles zeal input which gives you a more modern input feel.",
                            [this](std::vector<std::string> &args) {
                              UseZealInput.toggle();

--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -849,7 +849,10 @@ void NamePlate::handle_tag_command(const std::vector<std::string> &args) {
 
   if (args.size() >= 2 && args[1] == "join") {
     std::string channel = (args.size() == 2) ? setting_tag_channel.get() : args[2];
-    join_tag_channel(channel);
+
+    if (!join_tag_channel(channel))
+      Zeal::Game::print_chat("Invalid chat channel. It must start with %s (like '%s123')", kZealTagChannelPrefix,
+                             kZealTagChannelPrefix);
     return;
   }
 

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -43,6 +43,8 @@ class ui_options {
                                                [this](const bool &) { SyncDialogPosition(); }};
   ZealSetting<bool> setting_per_char_keybinds = {false, "Zeal", "PerCharKeybinds", false,
                                                  [this](const bool &) { SyncKeybinds(); }};
+  ZealSetting<bool> setting_per_char_autojoin = {false, "Zeal", "PerCharAutojoin", false,
+                                                 [this](const bool &) { SyncIniAutojoin(); }};
 
  private:
   void InitUI();
@@ -62,9 +64,11 @@ class ui_options {
   void UpdateComboBox(const std::string &name, const std::string &label, const std::string &default_label);
   void SyncDialogPosition();
   void SyncKeybinds();
+  void SyncIniAutojoin();
 
   Zeal::GameUI::SidlWnd *wnd = nullptr;
   std::vector<Zeal::GameUI::BasicWnd *> color_buttons;
   UIManager *const ui;
   std::vector<std::pair<int, std::string>> sound_list;  // WavePlay index table.
+  char ini_autojoin_name[16 + 30 + 2];                  // Space for "ChannelAutoJoin_" + self->name + null.
 };

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -758,6 +758,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_PerCharAutojoin">
+    <ScreenID>Zeal_PerCharAutojoin</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>530</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables storing autojoin chat channels per character</TooltipReference>
+    <Text>Per char autojoin</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- Second column -->
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1783,6 +1814,7 @@
     <Pieces>Zeal_DialogPosition</Pieces>
     <Pieces>Zeal_LogAddToTrade</Pieces>
     <Pieces>Zeal_PerCharKeybinds</Pieces>
+    <Pieces>Zeal_PerCharAutojoin</Pieces>
     <!-- Second column. -->
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -758,6 +758,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_PerCharAutojoin">
+    <ScreenID>Zeal_PerCharAutojoin</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>20</X>
+      <Y>1060</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables storing autojoin chat channels per character</TooltipReference>
+    <Text>Per char autojoin</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   
   <Label item="Zeal_HoverTimeout_Label">
     <ScreenID>Zeal_HoverTimeout_Label</ScreenID>
@@ -1783,6 +1814,7 @@
     <Pieces>Zeal_DialogPosition</Pieces>
     <Pieces>Zeal_LogAddToTrade</Pieces>
     <Pieces>Zeal_PerCharKeybinds</Pieces>
+    <Pieces>Zeal_PerCharAutojoin</Pieces>
     
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>


### PR DESCRIPTION
- Added new zeal general options checkbox to enable per character storing of the chat channels to autojoin (stored as 'ChannelAutoJoin_<name>' in the client ini)
- Also added an error message for a /tag join failure and more usage help for the /timestamp command