### PR TITLE
Add /linkall compact option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ ___
   - **Description:** Enables (on) the generation of a consider message when left clicking (like right).
 
 - `/linkall`
-  - **Arguments:** none (pastes into active chat) or `rs` (rsay), `gs` (gsay), `gu` (guildsay), `ooc`, `auc`, `say`
+  - **Arguments:** none (pastes into active chat), `compact`, or `rs` (rsay), `gs` (gsay), `gu` (guildsay), `ooc`, `auc`, `say`
   - **Description:** prints item links if looting window is open. The argument options route directly to channel for macros.
+    The `compact` argument will toggle a setting that collapses duplicate items and appends a `(count)` value to them.
 
 - `/loc noprint`
   - **Description:** adds noprint argument to /loc, this just sends loc directly to your log.

--- a/Zeal/looting.h
+++ b/Zeal/looting.h
@@ -24,6 +24,7 @@ class Looting {
   ZealSetting<bool> setting_alt_delimiter = {false, "Zeal", "LinkAllAltDelimiter", false};
   ZealSetting<bool> setting_ctrl_rightclick_loot = {false, "Zeal", "CtrlRightClickLoot", true};
   ZealSetting<bool> setting_hide_looted = {false, "Zeal", "HideLooted", false};
+  ZealSetting<bool> setting_compact_linkall = {true, "Zeal", "CompactLinkAll", false};
 
   // /protect functionality.  Command line-only for now.
   bool is_cursor_protected(const Zeal::GameStructures::GAMECHARINFO *char_info) const;


### PR DESCRIPTION
- Added a new /linkall option that is toggleable with /linkall compact (defaults to on) that will collapse identical items into a single link followed by a " (count)" value