### PR TITLE
Fix nameplate entity caching

### DIFF
--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -110,6 +110,7 @@ class NamePlate {
   bool handle_SetNameSpriteTint(Zeal::GameStructures::Entity *entity);
   bool handle_SetNameSpriteState(void *this_display, Zeal::GameStructures::Entity *entity, int show);
   void handle_targetwnd_postdraw(Zeal::GameUI::SidlWnd *wnd) const;
+  void handle_entity_destructor(Zeal::GameStructures::Entity *entity);
 
  private:
   struct NamePlateInfo {


### PR DESCRIPTION
- The previous entity despawn callback handler was removing an entity from the cache but then subsequently adding it back due to an internal call inside the client's destructor. Switched to hooking that internal call so the nameplate_info_map cache is properly flushed when an entity is deleted (which fixes a potential crash issue in /tag target).