### PR TITLE
Trigger timer update

### DIFF
--- a/Zeal/triggers.cpp
+++ b/Zeal/triggers.cpp
@@ -270,8 +270,8 @@ void Triggers::CallbackRender() {
     int hours = seconds / 3600;
     seconds = seconds - hours * 3600;
     int minutes = seconds / 60;
-    seconds = seconds - minutes / 60;
-    std::string label = std::format("{:02d}:{:02d}:{:02d}: {}", hours, minutes, seconds, event.label);
+    seconds = seconds - minutes * 60;
+    std::string label = std::format("{:02d}:{:02d}:{:02d} {}", hours, minutes, seconds, event.label);
     bitmap_font->queue_string(label.c_str(), Vec3(x, y, 0), false, event.color, true);
     y += bitmap_font->get_line_spacing();
   }


### PR DESCRIPTION
Sherra mentioned the fix to change the divisor to multiplication. I wanted to get the fix immediately for personal use, so I went ahead and changed it. I noticed that the trigger disappears when zoning, but I'm not too sure how to make it persist. Also removed the extra colon as it looks strange at the end of a timer.
<img width="219" height="129" alt="image" src="https://github.com/user-attachments/assets/5296ba9d-70cb-40c4-a7eb-6e73fe3b0c54" />