### PR TITLE
Add /autoaaswitch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ ___
 - `/autoconsent`
   - **Description:** Toggles the enable of auto-consenting from a /tc sent by a group or raid member.
 
+- `/autoaaswitch`
+  - **Arguments:** `off`, `<threshold_low> <threshold_high>` (low switches to 0% aa and high to 100% aa)
+  - **Description:** Sets exp level threshold to auto-switch to 0% or 100% AA.
+  - **Example:** `/autoaaswitch 60.5 60.99`: Sets to 0% AA below 60.5 and to 100% AA above 60.99.
+
 - `/autofire`
   - **Aliases:** `/af`
   - **Arguments:** none (toggles), `on`, `off`

--- a/Zeal/experience.h
+++ b/Zeal/experience.h
@@ -40,6 +40,8 @@ class Experience {
   float get_aa_exp_per_hour_pct() const { return aa_calc.get_exp_per_hour_pct(); }
 
   ZealSetting<bool> setting_aa_ding = {true, "Zeal", "AADing", false};
+  ZealSetting<float> setting_auto_aa_switch_low = {0.f, "Zeal", "AutoAASwitchLow", true};
+  ZealSetting<float> setting_auto_aa_switch_high = {0.f, "Zeal", "AutoAASwitchHigh", true};
 
  private:
   void reset();                     // Resets both exp and aa calcs.
@@ -48,6 +50,7 @@ class Experience {
   int get_exp_level() const;        // Returns the current level (if level and exp valid).
   int get_aa_total_points() const;  // Returns the total number of AA points.
   void callback_main();             // Periodic update and recalculation of exp rates.
+  void check_autoswitch();          // Handles checking the autoswitch exp threshold.
 
   ExperienceCalc exp_calc;  // Normal experience.
   ExperienceCalc aa_calc;   // Alternate advancement experience.

--- a/Zeal/triggers.cpp
+++ b/Zeal/triggers.cpp
@@ -270,7 +270,7 @@ void Triggers::CallbackRender() {
     int hours = seconds / 3600;
     seconds = seconds - hours * 3600;
     int minutes = seconds / 60;
-    seconds = seconds - minutes / 60;
+    seconds = seconds - minutes * 60;
     std::string label = std::format("{:02d}:{:02d}:{:02d}: {}", hours, minutes, seconds, event.label);
     bitmap_font->queue_string(label.c_str(), Vec3(x, y, 0), false, event.color, true);
     y += bitmap_font->get_line_spacing();


### PR DESCRIPTION
- Added a new /autoaaswitch <threshold_low> <threshold_high> command that will automatically toggle the AA share to 0% or 100% (e.g. 60.5 60.99 to set to 0% at 60.5 and 100% aa at 60.99)

- Also fixed a math error in the /triggers seconds residual calc