### PR TITLE
Add /raidbars command

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ ___
           enable, value, and protected list are stored per character with the list stored in the
           `./<character_name>_protected.ini` file.
 
+- `/raidbars`
+  - **Arguments:** `on`, `off`, `font <filename>`, `position <x> <y>`, `showall <on | off>`,
+                   `priority <classes list>`, `always <classes list>`
+  - **Example:** `/raidbars position 10 100` Sets upper left edge of raid bars list at (10, 100) on the screen
+  - **Example:** `/raidbars showall on` Shows healthbars of all raid members (including 100% health, out of zone)
+  - **Example:** `/raidbars always WAR PAL SHD ENC` These classes are always shown (even w/out showall on)
+  - **Example:** `/raidbars priority WAR WIZ ENC PAL SHD` Shows those classes first then remaining classes
+  - **Description:** Supports enabling a class-prioritized list of raid members with health bars.
+
 - `/reloadskin`
   - **Description:** reloads your current skin using ini.
 
@@ -547,22 +556,23 @@ Manual editing of the ini file is required to copy from old section to the new s
 - Controlled through either the `/tag` command or Nameplate tab options
 - Requires enabling both Nameplates Zeal fonts and tags (`/tag on`)
 - Tagged NPC nameplates use either the dedicated `Tagged` color or if targeted the `Target` color
-- Tagged nameplates have a matching colored arrow added if `Default tag arrow` is set
-- Tags can be cleared with:
-  - `/tag clear`: Clears tag from current target if there is one else all tags
-  - `/tag local -`: Clears text only from current target locally (can also gsay, rsay)
-  - `/tag local ^-^`: Clears arrow only from current target locally (can also gsay, rsay)
+- Tagged nameplates have a matching implicit colored arrow added if `Default tag arrow` is set
 - Tags can be set with locally or broadcast through rsay, gsay, or a joined chat channel
-  - `/tag <rsay | gsay | local> <tag_text>`
+  - `/tag <rsay | gsay | chat | local> <tag_text>`
   - Note: % replacement commands (%t, %n) aren't supported in `<tag_text>`
   - A <tag_text> == `clear` will clear the tags of everyone receiving it
   - The <tag_text> message supports special prefixes:
-    - `+` to append tag text (must be first character)
-    - `-` to erase only existing text (must be first character)
-    - `^?^`: to set explicit shapes over the nametag where `?` can be one of (case-insensitive):
+    - `+` to append tag text (must be first character, does not impact explicit shape)
+    - `-` to erase only existing text (must be first character, does not impact explicit shape)
+    - `^?^`: to set an explicit shape over the nametag where `?` can be one of (case-insensitive):
       - Colored arrow: (`R` = red, `O` = orange, `Y` = yellow, `G` = green, `B` = blue, `W` = white)
       - Green pet paw symbol: `P`
       - Red stop sign (octagon): `S`
+      - Clear any existing shape: `-`
+- Tags can be cleared with:
+  - `/tag clear`: Clears tag from current target if there is a target else all tags
+  - `/tag local -`: Clears text only from current target locally (can also gsay, rsay, chat)
+  - `/tag local ^-^`: Clears shape only from current target locally (can also gsay, rsay, chat)
 - Chat channel support / usage
   - Note: Zeal does not autojoin the channel at boot. Use `/tag channel`, `/tag join`, or autojoin.
   - `/tag channel <name>` broadcasts a special message to rsay (if in raid) else gsay (if in group) 
@@ -586,9 +596,11 @@ Manual editing of the ini file is required to copy from old section to the new s
 
 ### Tagging Examples
   - `/tag rsay Assist me` broadcasts a raid-wide tag that sets 'Assist Me'
-  - `/tag rsay +^Y^OFFTANK` appends ' | OFFTANK' to the tag text and sets the arrow to yellow
-  - `/tag rsay -` clears text but leaves arrow if explicitly colored
-  - `/tag rsay ^-^` leaves text but clears the arrow
+  - `/tag rsay +TASH` appends ' | TASH' to the tag text (does not affect explicit shape)
+  - `/tag rsay ^p^` adds an explicit paw shape above the target for all raid members
+  - `/tag rsay -` clears text but leaves shape if explicitly set
+  - `/tag rsay ^-^` leaves text but clears the shape
+  - `/tag rsay +^Y^OFFTANK` appends ' | OFFTANK' to the tag text and adds explicit yellow arrow shape
   - `/tag gsay clear` broadcasts a special message to clear all group members' tags
   - `/tag clear` clears target tag if target else all tags on local client
 

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -82,6 +82,7 @@
     <ClInclude Include="json.hpp" />
     <ClInclude Include="helm_manager.h" />
     <ClInclude Include="music.h" />
+    <ClInclude Include="raid_bars.h" />
     <ClInclude Include="survey.h" />
     <ClInclude Include="tag_arrows.h" />
     <ClInclude Include="tick.h" />
@@ -163,6 +164,7 @@
     <ClCompile Include="helm_manager.cpp" />
     <ClCompile Include="items.cpp" />
     <ClCompile Include="music.cpp" />
+    <ClCompile Include="raid_bars.cpp" />
     <ClCompile Include="survey.cpp" />
     <ClCompile Include="tag_arrows.cpp" />
     <ClCompile Include="tick.cpp" />

--- a/Zeal/bitmap_font.h
+++ b/Zeal/bitmap_font.h
@@ -51,6 +51,8 @@ class BitmapFontBase {
 
   float get_line_spacing() const { return line_spacing; }
 
+  float get_text_height(const std::string &text) const;
+
   // Drop shadow and alignment configuration.
   void set_shadow_offset_factor(float factor) { shadow_offset_factor = factor; }
 
@@ -59,6 +61,8 @@ class BitmapFontBase {
   void set_outlined(bool enable) { outlined = enable; }
 
   void set_align_bottom(bool enable) { align_bottom = enable; }
+
+  void set_full_screen_viewport(bool enable) { full_screen_viewport = enable; }
 
   // Set these stats bar values before calling queue_string() which contains their glyphs.
   void set_hp_percent(int value) { hp_percent = value; }
@@ -103,6 +107,7 @@ class BitmapFontBase {
     const Glyph *glyph;
     const Vec2 position;
     const D3DCOLOR color;
+    char hp_percent;
   };
 
   static constexpr int kNumGlyphs = 128;  // Support ASCII 0 - 127.
@@ -127,7 +132,8 @@ class BitmapFontBase {
   float shadow_offset_factor = kDefaultShadowOffsetFactor;
   bool drop_shadow = false;
   bool outlined = false;
-  bool align_bottom = false;  // Applies only when text is queued with center flag.
+  bool align_bottom = false;          // Applies only when text is queued with center flag.
+  bool full_screen_viewport = false;  // If true, overrides viewport to full screen resolution.
   char hp_percent = 0;
   char mana_percent = 0;
   char stamina_percent = 0;

--- a/Zeal/floating_damage.cpp
+++ b/Zeal/floating_damage.cpp
@@ -159,7 +159,6 @@ void FloatingDamage::callback_render() {
 void FloatingDamage::render_spells() {
   if (!spell_icons.get()) return;
   std::vector<Zeal::GameStructures::Entity *> visible_ents = Zeal::Game::get_world_visible_actor_list(250, false);
-  Vec2 screen_size = ZealService::get_instance()->dx->GetScreenRect();
   for (auto &[target, dmg_vec] : damage_numbers) {
     for (auto &dmg : dmg_vec) {
       if (dmg.spell) {
@@ -187,7 +186,8 @@ void FloatingDamage::render_text() {
     Zeal::GameUI::CTextureFont *fnt = bitmap_font ? nullptr : Zeal::Game::get_wnd_manager()->GetFont(font_size);
     if (bitmap_font || fnt) {
       std::vector<Zeal::GameStructures::Entity *> visible_ents = Zeal::Game::get_world_visible_actor_list(250, false);
-      Vec2 screen_size = ZealService::get_instance()->dx->GetScreenRect();
+      int screen_x = Zeal::Game::get_screen_resolution_x();
+      int screen_y = Zeal::Game::get_screen_resolution_y();
       for (auto &[target, dmg_vec] : damage_numbers) {
         for (auto &dmg : dmg_vec) {
           dmg.tick(get_active_damage_count(target));
@@ -207,7 +207,7 @@ void FloatingDamage::render_text() {
                     dmg.str_dmg.c_str(),
                     Zeal::GameUI::CXRect((int)(screen_pos.y + dmg.x_offset), (int)(screen_pos.x + dmg.y_offset),
                                          (int)(screen_pos.y + 150), (int)(screen_pos.x + 150)),
-                    Zeal::GameUI::CXRect(0, 0, (int)(screen_size.x * 2), (int)(screen_size.y * 2)), color, 1, 0);
+                    Zeal::GameUI::CXRect(0, 0, 2 * screen_x, 2 * screen_y), color, 1, 0);
             }
           }
         }

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -2211,49 +2211,49 @@ std::string class_name_short(int class_id) {
   if (modified_class_id > 16 && modified_class_id < 32) modified_class_id -= 16;
   switch (modified_class_id) {
     case Zeal::GameEnums::ClassTypes::Warrior:
-      class_string = "War";
+      class_string = "WAR";
       break;
     case Zeal::GameEnums::ClassTypes::Cleric:
-      class_string = "Clr";
+      class_string = "CLR";
       break;
     case Zeal::GameEnums::ClassTypes::Paladin:
-      class_string = "Pal";
+      class_string = "PAL";
       break;
     case Zeal::GameEnums::ClassTypes::Ranger:
-      class_string = "Rng";
+      class_string = "RNG";
       break;
     case Zeal::GameEnums::ClassTypes::Shadowknight:
-      class_string = "Shd";
+      class_string = "SHD";
       break;
     case Zeal::GameEnums::ClassTypes::Druid:
-      class_string = "Dru";
+      class_string = "DRU";
       break;
     case Zeal::GameEnums::ClassTypes::Monk:
-      class_string = "Mnk";
+      class_string = "MNK";
       break;
     case Zeal::GameEnums::ClassTypes::Bard:
-      class_string = "Brd";
+      class_string = "BRD";
       break;
     case Zeal::GameEnums::ClassTypes::Rogue:
-      class_string = "Rog";
+      class_string = "ROG";
       break;
     case Zeal::GameEnums::ClassTypes::Shaman:
-      class_string = "Shm";
+      class_string = "SHM";
       break;
     case Zeal::GameEnums::ClassTypes::Necromancer:
-      class_string = "Nec";
+      class_string = "NEC";
       break;
     case Zeal::GameEnums::ClassTypes::Wizard:
-      class_string = "Wiz";
+      class_string = "WIZ";
       break;
     case Zeal::GameEnums::ClassTypes::Magician:
-      class_string = "Mag";
+      class_string = "MAG";
       break;
     case Zeal::GameEnums::ClassTypes::Enchanter:
-      class_string = "Enc";
+      class_string = "ENC";
       break;
     case Zeal::GameEnums::ClassTypes::Beastlord:
-      class_string = "Bst";
+      class_string = "BST";
       break;
     case Zeal::GameEnums::ClassTypes::Banker:
       class_string = "Banker";

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -202,7 +202,7 @@ std::vector<Zeal::GameStructures::Entity *> get_world_visible_actor_list(float m
 Zeal::GameStructures::ActorLocation get_actor_location(int actor);
 float get_target_blink_fade_factor(float speed_factor, bool auto_attack_only);  // Returns 0 to 1.0f.
 bool is_view_actor_me();
-void print_chat(const std::string& data);
+void print_chat(const std::string &data);
 void print_chat(const char *format, ...);
 void print_chat(short color, const char *format, ...);
 void print_chat_wnd(Zeal::GameUI::ChatWnd *, short color, const char *format, ...);
@@ -315,5 +315,18 @@ Zeal::GameEnums::SkillType get_weapon_skill(const Zeal::GameStructures::GAMEITEM
 int get_hand_to_hand_delay();
 void print_melee_attack_stats(bool primary, const Zeal::GameStructures::GAMEITEMINFO *weapon = nullptr,
                               short color = USERCOLOR_DEFAULT);
+
+inline int get_screen_resolution_x() { return *reinterpret_cast<int *>(0x00798564); }
+
+inline int get_screen_resolution_y() { return *reinterpret_cast<int *>(0x00798568); }
+
+inline int get_viewport_left() { return *reinterpret_cast<short *>(0x00798548); }
+
+inline int get_viewport_top() { return *reinterpret_cast<short *>(0x0079854a); }
+
+inline int get_viewport_right() { return *reinterpret_cast<short *>(0x0079854c); }
+
+inline int get_viewport_bottom() { return *reinterpret_cast<short *>(0x0079854e); }
+
 }  // namespace Game
 }  // namespace Zeal

--- a/Zeal/item_display.cpp
+++ b/Zeal/item_display.cpp
@@ -180,7 +180,6 @@ static std::string GetSpellClassLevels(const Zeal::GameStructures::_GAMEITEMINFO
     if ((item.Common.Classes & class_bit) == 0) continue;
     int class_level = spell->ClassLevel[i];
     auto class_name = Zeal::Game::class_name_short(i);
-    std::transform(class_name.begin(), class_name.end(), class_name.begin(), ::toupper);
     result += std::format(" {} ({})", class_name, class_level);
   }
 
@@ -366,7 +365,7 @@ static void fix_effect_line(std::string &line, Zeal::GameStructures::SPELL *spel
       line = std::format("  {}: Increase Absorb Magic Damage by ", display_index);
       append_effect_description(line, spell, caster_level, effect_index);
       break;
-    case 110: // Ranger Hawk Eye and Eagle Eye archery accuracy
+    case 110:  // Ranger Hawk Eye and Eagle Eye archery accuracy
       line = std::format("  {}: Increase Chance to Hit with Archery by ", display_index);
       append_effect_description(line, spell, caster_level, effect_index);
       break;

--- a/Zeal/raid_bars.cpp
+++ b/Zeal/raid_bars.cpp
@@ -1,0 +1,288 @@
+#include "raid_bars.h"
+
+#include <algorithm>
+
+#include "callbacks.h"
+#include "commands.h"
+#include "entity_manager.h"
+#include "game_addresses.h"
+#include "game_functions.h"
+#include "game_structures.h"
+#include "string_util.h"
+#include "zeal.h"
+
+RaidBars::RaidBars(ZealService *zeal) {
+  zeal->callbacks->AddGeneric([this]() { CallbackRender(); }, callback_type::RenderUI);
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::EnterZone);
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::CleanUI);  // Note: new_ui only call.
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::DXReset);  // Just release all resources.
+  zeal->callbacks->AddGeneric([this]() { Clean(); }, callback_type::DXCleanDevice);
+
+  zeal->commands_hook->Add("/raidbars", {}, "Controls raid status bars display",
+                           [this](std::vector<std::string> &args) {
+                             ParseArgs(args);
+                             return true;
+                           });
+
+  // Ensure our cached entity pointer is flushed when an entity despawns.
+  zeal->callbacks->AddEntity(
+      [this](struct Zeal::GameStructures::Entity *entity) {
+        if (!setting_enabled.get() || !entity || entity->Type != Zeal::GameEnums::Player) return;
+
+        // For now use an unoptimized full sweep to ensure the entity is definitely flushed.
+        for (auto &class_group : raid_classes)
+          for (auto &member : class_group)
+            if (member.entity == entity) member.entity = nullptr;
+      },
+      callback_type::EntityDespawn);
+}
+
+RaidBars::~RaidBars() { Clean(); }
+
+void RaidBars::Clean() {
+  next_update_game_time_ms = 0;
+  bitmap_font.reset();                                         // Releases all DX and other resources.
+  for (auto &class_group : raid_classes) class_group.clear();  // Drop all entity references.
+}
+
+void RaidBars::ParseArgs(const std::vector<std::string> &args) {
+  if (args.size() == 2 && (args[1] == "on" || args[1] == "off")) {
+    setting_enabled.set(args[1] == "on");
+    Zeal::Game::print_chat("Raidbars are %s", setting_enabled.get() ? "on" : "off");
+    return;
+  }
+
+  if (args.size() == 3 && args[1] == "font") {
+    setting_bitmap_font_filename.set(args[2]);
+    Zeal::Game::print_chat("Font filename set to %s", setting_bitmap_font_filename.get().c_str());
+    return;
+  }
+
+  if (args.size() >= 2 && args[1] == "position") {
+    int x, y;
+    if (args.size() == 4 && Zeal::String::tryParse(args[2], &x) && Zeal::String::tryParse(args[3], &y)) {
+      setting_position_x.set(x);
+      setting_position_y.set(y);
+    }
+
+    Zeal::Game::print_chat("Raidbars position set to (%d, %d)", setting_position_x.get(), setting_position_y.get());
+    return;
+  }
+
+  if (args.size() >= 2 && args[1] == "showall") {
+    if (args.size() == 3 && (args[2] == "on" || args[2] == "off")) setting_show_all.set(args[2] == "on");
+    Zeal::Game::print_chat("Raidbars showall is set to %s", setting_show_all.get() ? "on" : "off");
+    return;
+  }
+
+  if (args.size() >= 2 && (args[1] == "priority" || args[1] == "always")) {
+    if (args.size() > 2) {
+      std::string text = args[2];
+      for (int i = 3; i < args.size(); ++i) text += " " + args[i];
+      std::transform(text.begin(), text.end(), text.begin(), ::toupper);
+      if (args[1] == "priority")
+        setting_class_priority.set(text);
+      else
+        setting_class_always.set(text);
+    }
+    DumpClassSettings();
+    return;
+  }
+
+  Zeal::Game::print_chat("Usage: /raidbars <on | off>");
+  Zeal::Game::print_chat("Usage: /raidbars font font_filename");
+  Zeal::Game::print_chat("Usage: /raidbars position <x> <y> where (x,y) is the upper left of list");
+  Zeal::Game::print_chat("Usage: /raidbars showall <on | off>");
+  Zeal::Game::print_chat("Usage: /raidbars always <class list> where list is like 'WAR PAL SHD'");
+  Zeal::Game::print_chat("Usage: /raidbars priority <class list> where list is like 'WAR PAL SHD ENC'");
+}
+
+// Loads the bitmap font for real-time text rendering to screen.
+void RaidBars::LoadBitmapFont() {
+  if (bitmap_font || setting_bitmap_font_filename.get().empty()) return;
+
+  IDirect3DDevice8 *device = ZealService::get_instance()->dx->GetDevice();
+  std::string font_filename = setting_bitmap_font_filename.get();
+  bool is_default_font = (font_filename.empty() || font_filename == kUseDefaultFont);
+  if (is_default_font) font_filename = kDefaultFont;
+  if (device != nullptr) bitmap_font = BitmapFont::create_bitmap_font(*device, font_filename);
+  if (!bitmap_font) {
+    Zeal::Game::print_chat("Failed to load font: %s", font_filename.c_str());
+    if (is_default_font) {
+      Zeal::Game::print_chat("Disabling raidbars due to font issue");
+      setting_enabled.set(false);
+    } else {
+      setting_bitmap_font_filename.set(kUseDefaultFont);  // Try again with default next round.
+    }
+    return;
+  }
+
+  bitmap_font->set_drop_shadow(true);
+  bitmap_font->set_full_screen_viewport(true);  // Allow rendering list outside reduced viewport.
+}
+
+// Load the class priority from settings (based on defaults).
+void RaidBars::SyncClassPriority() {
+  std::string priority_list = setting_class_priority.get();
+
+  // Somewhat arbitrary ordering based on likelihood to need healing / monitoring.
+  using Zeal::GameEnums::ClassTypes;
+  class_priority = {ClassTypes::Warrior,   ClassTypes::Paladin,  ClassTypes::Shadowknight, ClassTypes::Enchanter,
+                    ClassTypes::Wizard,    ClassTypes::Monk,     ClassTypes::Ranger,       ClassTypes::Rogue,
+                    ClassTypes::Beastlord, ClassTypes::Bard,     ClassTypes::Cleric,       ClassTypes::Shaman,
+                    ClassTypes::Druid,     ClassTypes::Magician, ClassTypes::Necromancer};
+  for (auto &index : class_priority) index -= kClassIndexOffset;  // Convert to zero index.
+
+  if (priority_list.empty()) return;  // Just go with default.
+
+  // Capitalize to simplify comparisons.
+  std::transform(priority_list.begin(), priority_list.end(), priority_list.begin(), ::toupper);
+
+  auto split = Zeal::String::split_text(priority_list, " ");
+  std::vector<int> entries;
+  for (const auto &entry : split) {
+    for (int i = 0; i < class_priority.size(); ++i) {
+      if (entry == Zeal::Game::class_name_short(i + kClassIndexOffset)) {
+        auto it = std::find(entries.begin(), entries.end(), i);
+        if (it == entries.end())  // Do not add duplicates (could have used a set).
+          entries.push_back(i);   // Pushing back zero index value.
+        break;
+      }
+    }
+  }
+  // Copy the defaults into std::vector to extract from.
+  std::vector<int> source(class_priority.begin(), class_priority.end());
+  size_t index = 0;
+  for (auto &value : entries) {
+    class_priority[index++] = value;
+    std::erase(source, value);
+  }
+  // Append any non-specified classes.
+  for (auto &value : source) {
+    if (index >= class_priority.size()) break;  // Paranoid overflow clamp (shouldn't happen).
+    class_priority[index++] = value;
+  }
+}
+
+// Load the show class always flags from settings.
+void RaidBars::SyncClassAlways() {
+  std::string always_list = setting_class_always.get();
+
+  for (auto &entry : class_always) entry = false;  // Default to none.
+
+  if (always_list.empty()) return;  // Just go with default.
+
+  // Capitalize to simplify comparisons.
+  std::transform(always_list.begin(), always_list.end(), always_list.begin(), ::toupper);
+
+  auto split = Zeal::String::split_text(always_list, " ");
+  for (const auto &entry : split) {
+    for (int i = 0; i < kNumClasses; ++i) {
+      if (entry == Zeal::Game::class_name_short(i + kClassIndexOffset)) {
+        class_always[i] = true;
+        break;
+      }
+    }
+  }
+}
+
+void RaidBars::DumpClassSettings() const {
+  std::string prio_list;
+  for (const auto &value : class_priority) prio_list += " " + Zeal::Game::class_name_short(value + kClassIndexOffset);
+  std::string message = "RaidBars class priority:" + prio_list;
+  Zeal::Game::print_chat(message.c_str());
+
+  std::string list;
+  for (int i = 0; i < class_always.size(); ++i)
+    if (class_always[i]) list += " " + Zeal::Game::class_name_short(i + kClassIndexOffset);
+  message = "RaidBars class always:" + list;
+  Zeal::Game::print_chat(message.c_str());
+}
+
+// Populates raid_classes with all raid members.
+void RaidBars::UpdateRaidMembers() {
+  // For now do a full clear and reload every time.
+  for (auto &class_group : raid_classes) class_group.clear();  // Drop all entity references.
+
+  Zeal::GameStructures::RaidInfo *raid_info = Zeal::Game::RaidInfo;
+  if (!raid_info->is_in_raid()) {
+    return;
+  }
+
+  // Sweep through the entire raid list bucketizing into the difference classes.
+  auto entity_manager = ZealService::get_instance()->entity_manager.get();  // Short-term ptr.
+  for (int i = 0; i < Zeal::GameStructures::RaidInfo::kRaidMaxMembers; ++i) {
+    const auto &member = raid_info->MemberList[i];
+    if (!member.Name || !member.Name[0]) continue;  // Skip empty slots.
+    size_t class_index = member.ClassValue - 1;
+    if (class_index >= raid_classes.size()) continue;  // Paranoia, shouldn't happen.
+    auto &class_group = raid_classes[class_index];
+    auto entity = entity_manager->Get(member.Name);  // Could be null if out of zone or a corpse.
+    if (entity && entity->Type != Zeal::GameEnums::EntityTypes::Player) entity = nullptr;
+    class_group.emplace_back(RaidMember{.name = member.Name, .entity = entity});
+  }
+
+  // And then alphabetically sort all class groups.
+  for (auto &class_group : raid_classes) {
+    std::sort(class_group.begin(), class_group.end(),
+              [](const RaidMember &a, const RaidMember &b) { return a.name < b.name; });
+  }
+}
+
+void RaidBars::CallbackRender() {
+  if (!setting_enabled.get() || !Zeal::Game::is_in_game()) return;
+
+  // Bail out if not in raid and also perform cleanup here when exiting a raid.
+  if (!Zeal::Game::RaidInfo->is_in_raid()) {
+    if (bitmap_font) Clean();  // Initialized font used as a flag for the need to flush.
+    return;
+  }
+
+  auto display = Zeal::Game::get_display();
+  if (!display || !Zeal::Game::is_gui_visible()) return;
+
+  LoadBitmapFont();
+  if (!bitmap_font) return;
+
+  DWORD current_time_ms = display->GameTimeMs;
+  if (next_update_game_time_ms <= current_time_ms) {
+    next_update_game_time_ms = current_time_ms + 1000;  // Roughly one second update intervals.
+    UpdateRaidMembers();
+  }
+
+  // The position coordinates are full screen (not viewport reduced).
+  float x = static_cast<float>(setting_position_x.get());
+  float y = static_cast<float>(setting_position_y.get());
+  const float y_max = static_cast<float>(Zeal::Game::get_screen_resolution_y());
+
+  // Then go through the classes in prioritized order.
+  bool show_all = setting_show_all.get();
+  const auto self = Zeal::Game::get_self();
+  for (const int class_index : class_priority) {
+    const auto &group = raid_classes[class_index];
+    if (group.empty()) continue;
+    bool show_class = show_all || class_always[class_index];
+
+    // Get class color.
+    DWORD class_color = Zeal::Game::get_raid_class_color(class_index + kClassIndexOffset);
+    const DWORD out_of_zone_color = D3DCOLOR_XRGB(0x80, 0x80, 0x80);  // Grey color.
+    for (const auto &member : group) {
+      if (y > y_max) break;  // Bail out if list grows off-screen.
+      const auto entity = member.entity;
+      if (entity == self) continue;          // Skip self.
+      if (!entity && !show_class) continue;  // Skip out of zone if not forced on.
+      int hp_percent =
+          (entity && entity->HpCurrent > 0 && entity->HpMax > 0) ? (entity->HpCurrent * 100) / entity->HpMax : 0;
+      if (hp_percent >= 99 && !(show_all || class_always[class_index])) continue;  // Skip.
+      const char healthbar[4] = {'\n', BitmapFontBase::kStatsBarBackground, BitmapFontBase::kHealthBarValue, 0};
+      std::string full_text = member.name + healthbar;
+
+      bitmap_font->set_hp_percent(hp_percent);
+      DWORD color = entity ? class_color : out_of_zone_color;
+      bitmap_font->queue_string(full_text.c_str(), Vec3(x, y, 0), false, color);
+      y += bitmap_font->get_text_height(full_text) + 0.25f;
+    }
+  }
+
+  bitmap_font->flush_queue_to_screen();
+}

--- a/Zeal/raid_bars.h
+++ b/Zeal/raid_bars.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <Windows.h>
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "bitmap_font.h"
+#include "game_structures.h"
+#include "zeal_settings.h"
+
+class RaidBars {
+ public:
+  static constexpr char kUseDefaultFont[] = "Default";
+  static constexpr char kDefaultFont[] = "arial_08";
+
+  explicit RaidBars(class ZealService *zeal);
+  ~RaidBars();
+
+  // Disable copy.
+  RaidBars(RaidBars const &) = delete;
+  RaidBars &operator=(RaidBars const &) = delete;
+
+  ZealSetting<bool> setting_enabled = {false, "RaidBars", "Enabled", false, [this](bool) { Clean(); }};
+  ZealSetting<int> setting_position_x = {100, "RaidBars", "PositionX", false};
+  ZealSetting<int> setting_position_y = {100, "RaidBars", "PositionY", false};
+  ZealSetting<bool> setting_show_all = {false, "RaidBars", "ShowAll", false};
+  ZealSetting<std::string> setting_class_priority = {std::string(), "RaidBars", "ClassPriority", false,
+                                                     [this](const std::string &) { SyncClassPriority(); }};
+  ZealSetting<std::string> setting_class_always = {std::string(), "RaidBars", "ClassAlways", false,
+                                                   [this](const std::string &) { SyncClassAlways(); }};
+  ZealSetting<std::string> setting_bitmap_font_filename = {std::string(kUseDefaultFont), "RaidBars", "Font", false,
+                                                           [this](std::string val) { bitmap_font.reset(); }};
+
+ private:
+  static constexpr int kNumClasses = Zeal::GameEnums::ClassTypes::Beastlord - Zeal::GameEnums::ClassTypes::Warrior + 1;
+  static constexpr int kClassIndexOffset = Zeal::GameEnums::ClassTypes::Warrior;
+
+  struct RaidMember {
+    std::string name;                      // Copy to compare against when out of zone.
+    Zeal::GameStructures::Entity *entity;  // Set to nullptr when out of zone.
+  };
+
+  void Clean();  // Resets state and releases all resources.
+  void ParseArgs(const std::vector<std::string> &args);
+  void LoadBitmapFont();  // Loads the bitmap font for rendering.
+  void CallbackRender();  // Displays raid bars.
+  void SyncClassPriority();
+  void SyncClassAlways();
+  void DumpClassSettings() const;
+  void UpdateRaidMembers();
+
+  DWORD next_update_game_time_ms = 0;
+  std::unique_ptr<BitmapFont> bitmap_font = nullptr;
+
+  std::array<std::vector<RaidMember>, kNumClasses> raid_classes;  // Per class vectors of raid members.
+  std::array<int, kNumClasses> class_priority;                    // Prioritization order for class types.
+  std::array<bool, kNumClasses> class_always;                     // Boolean flag to show always for class types.
+};

--- a/Zeal/triggers.cpp
+++ b/Zeal/triggers.cpp
@@ -244,7 +244,8 @@ void Triggers::LoadBitmapFont() {
     return;
   }
 
-  bitmap_font->set_drop_shadow(true);  // TODO
+  bitmap_font->set_drop_shadow(true);
+  bitmap_font->set_full_screen_viewport(true);  // Allow rendering list outside reduced viewport.
 }
 
 void Triggers::CallbackRender() {
@@ -262,10 +263,12 @@ void Triggers::CallbackRender() {
                 [current_time_ms](const TriggerEvent &trigger) { return trigger.end_timestamp_ms <= current_time_ms; });
   if (trigger_events.empty()) return;
 
-  Vec2 screen_size = ZealService::get_instance()->dx->GetScreenRect();
+  // The position coordinates are full screen (not viewport reduced).
   float x = static_cast<float>(position_x.get());
   float y = static_cast<float>(position_y.get());
+  const float y_max = static_cast<float>(Zeal::Game::get_screen_resolution_y());
   for (const auto &event : trigger_events) {
+    if (y > y_max) break;
     int seconds = (event.end_timestamp_ms - current_time_ms) / 1000;
     int hours = seconds / 3600;
     seconds = seconds - hours * 3600;

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -46,6 +46,7 @@
 #include "physics.h"
 #include "player_movement.h"
 #include "raid.h"
+#include "raid_bars.h"
 #include "spellsets.h"
 #include "string_util.h"
 #include "survey.h"
@@ -153,6 +154,7 @@ ZealService::ZealService() {
   equip_item_hook = MakeCheckedUnique(EquipItem);   // Uses new UI InvSlotWnd.
   chatfilter_hook = MakeCheckedUnique(chatfilter);  // Uses new UI ChatWnd
   chat_hook = MakeCheckedUnique(Chat);              // Uses chatfilter.
+  raid_bars = MakeCheckedUnique(RaidBars);          // Uses entity_manager, callbacks.
   triggers = MakeCheckedUnique(Triggers);           // Uses chat_hook.
   nameplate = MakeCheckedUnique(NamePlate);         // Uses target ring blink rate, chat, chatfilter.
   tells = MakeCheckedUnique(TellWindows);           // Uses new UI ChatManager.

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -65,6 +65,7 @@ class ZealService {
   std::unique_ptr<class BuffTimers> buff_timers = nullptr;
   std::unique_ptr<class HelmManager> helm = nullptr;
 
+  std::unique_ptr<class RaidBars> raid_bars = nullptr;
   std::unique_ptr<class Triggers> triggers = nullptr;
   std::unique_ptr<class TargetRing> target_ring = nullptr;
   std::unique_ptr<class FloatingDamage> floating_damage = nullptr;


### PR DESCRIPTION
- Added a new /raidbars command that controls the rendering of raid member health bars in a positionable and class prioritizable list (see README.md or usage)
- Updated bitmap fonts to support health bars in 2d mode and also added support for overriding viewport to render to full screen (instead of reduced viewport region)
- Cleaned up some of the resolution access calls
- Added some more details to README about /tag commands