### PR TITLE
Added UI options for Abbreviated Chat & Class Chat Colors

### DIFF
--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -310,6 +310,12 @@ void ui_options::InitColors() {
 void ui_options::InitGeneral() {
   if (!wnd) return;
   /*add callbacks when the buttons are pressed in the options window*/
+  ui->AddCheckboxCallback(wnd, "Zeal_AbbreviatedChat", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->chat_hook->UseAbbreviatedChat.set(wnd->Checked);
+  });
+  ui->AddCheckboxCallback(wnd, "Zeal_ClassChatColors", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->chat_hook->UseClassChatColors.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_HideCorpse", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->looting_hook->set_hide_looted(wnd->Checked);
   });
@@ -931,6 +937,8 @@ void ui_options::UpdateOptionsGeneral() {
       fps_limit_selection = 0;
       break;
   }
+  ui->SetChecked("Zeal_AbbreviatedChat", ZealService::get_instance()->ZealService::get_instance()->chat_hook->UseAbbreviatedChat.get());
+  ui->SetChecked("Zeal_ClassChatColors", ZealService::get_instance()->chat_hook->UseClassChatColors.get());
   ui->SetComboValue("Zeal_FPS_Combobox", fps_limit_selection);
   ui->SetComboValue("Zeal_LockToggleBag_Combobox",
                     ZealService::get_instance()->utils->setting_lock_toggle_bag_slot.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -1766,6 +1766,68 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_AbbreviatedChat">
+    <ScreenID>Zeal_AbbreviatedChat</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>508</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shortens non-combat chat messages</TooltipReference>
+    <Text>Abbreviated Chat</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
+  <Button item="Zeal_ClassChatColors">
+    <ScreenID>Zeal_ClassChatColors</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>530</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Adds color to player names in chat</TooltipReference>
+    <Text>Class Chat Colors</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- end -->
     
   <Page item="Tab_General">
@@ -1853,6 +1915,8 @@
     <Pieces>Zeal_SuppressOtherPets</Pieces>
     <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
     <Pieces>Zeal_BuffClickThru</Pieces>
+    <Pieces>Zeal_AbbreviatedChat</Pieces>
+    <Pieces>Zeal_ClassChatColors</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -1766,6 +1766,68 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_AbbreviatedChat">
+    <ScreenID>Zeal_AbbreviatedChat</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>1016</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shortens non-combat chat messages</TooltipReference>
+    <Text>Abbreviated Chat</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
+  <Button item="Zeal_ClassChatColors">
+    <ScreenID>Zeal_ClassChatColors</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>1060</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Adds color to player names in chat</TooltipReference>
+    <Text>Class Chat Colors</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   
     
   <Page item="Tab_General">
@@ -1853,6 +1915,8 @@
     <Pieces>Zeal_SuppressOtherPets</Pieces>
     <Pieces>Zeal_ReportOtherNonMeleeDmg</Pieces>
     <Pieces>Zeal_BuffClickThru</Pieces>
+    <Pieces>Zeal_AbbreviatedChat</Pieces>
+    <Pieces>Zeal_ClassChatColors</Pieces>
     <Location>
       <X>0</X>
       <Y>44</Y>


### PR DESCRIPTION
Added 2 buttons at the bottom-right of the Zeal options general tab.