### PR TITLE
Support multi-column raidbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ ___
           `./<character_name>_protected.ini` file.
 
 - `/raidbars`
-  - **Arguments:** `on`, `off`, `font <filename>`, `position <x> <y>`, `showall <on | off>`,
+  - **Arguments:** `on`, `off`, `font <filename>`, `position <top> <left> [<right>=0 <bottom>=0]`, `showall <on | off>`,
                    `priority <classes list>`, `always <classes list>`
-  - **Example:** `/raidbars position 10 100` Sets upper left edge of raid bars list at (10, 100) on the screen
+  - **Example:** `/raidbars position 5 10 150 0` Constrains bars to a box from (5,10) to (150, bottom of screen).
   - **Example:** `/raidbars showall on` Shows healthbars of all raid members (including 100% health, out of zone)
   - **Example:** `/raidbars always WAR PAL SHD ENC` These classes are always shown (even w/out showall on)
   - **Example:** `/raidbars priority WAR WIZ ENC PAL SHD` Shows those classes first then remaining classes

--- a/Zeal/raid_bars.h
+++ b/Zeal/raid_bars.h
@@ -22,8 +22,10 @@ class RaidBars {
   RaidBars &operator=(RaidBars const &) = delete;
 
   ZealSetting<bool> setting_enabled = {false, "RaidBars", "Enabled", false, [this](bool) { Clean(); }};
-  ZealSetting<int> setting_position_x = {100, "RaidBars", "PositionX", false};
-  ZealSetting<int> setting_position_y = {100, "RaidBars", "PositionY", false};
+  ZealSetting<int> setting_position_left = {5, "RaidBars", "Left", false};
+  ZealSetting<int> setting_position_top = {5, "RaidBars", "Top", false};
+  ZealSetting<int> setting_position_right = {0, "RaidBars", "Right", false};
+  ZealSetting<int> setting_position_bottom = {0, "RaidBars", "Bottom", false};
   ZealSetting<bool> setting_show_all = {false, "RaidBars", "ShowAll", false};
   ZealSetting<std::string> setting_class_priority = {std::string(), "RaidBars", "ClassPriority", false,
                                                      [this](const std::string &) { SyncClassPriority(); }};
@@ -52,6 +54,8 @@ class RaidBars {
 
   DWORD next_update_game_time_ms = 0;
   std::unique_ptr<BitmapFont> bitmap_font = nullptr;
+  float grid_height = 0;
+  float grid_width = 0;
 
   std::array<std::vector<RaidMember>, kNumClasses> raid_classes;  // Per class vectors of raid members.
   std::array<int, kNumClasses> class_priority;                    // Prioritization order for class types.


### PR DESCRIPTION
- Modified /raidbars position to support left top right bottom format for specifying where to draw the status bars and it now supports multi-column if necessary to fill that space
  - Setting 0 for right or bottom uses the screen size max