### PR TITLE
Add clickable option for /raidbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ ___
 
 - `/raidbars`
   - **Arguments:** `on`, `off`, `font <filename>`, `position <top> <left> [<right>=0 <bottom>=0]`, `showall <on | off>`,
-                   `priority <classes list>`, `always <classes list>`
+                   `clickable <on | off>`, `priority <classes list>`, `always <classes list>`
   - **Example:** `/raidbars position 5 10 150 0` Constrains bars to a box from (5,10) to (150, bottom of screen).
   - **Example:** `/raidbars showall on` Shows healthbars of all raid members (including 100% health, out of zone)
   - **Example:** `/raidbars always WAR PAL SHD ENC` These classes are always shown (even w/out showall on)

--- a/Zeal/raid_bars.h
+++ b/Zeal/raid_bars.h
@@ -22,6 +22,7 @@ class RaidBars {
   RaidBars &operator=(RaidBars const &) = delete;
 
   ZealSetting<bool> setting_enabled = {false, "RaidBars", "Enabled", false, [this](bool) { Clean(); }};
+  ZealSetting<bool> setting_clickable = {false, "RaidBars", "Clickable", false};
   ZealSetting<int> setting_position_left = {5, "RaidBars", "Left", false};
   ZealSetting<int> setting_position_top = {5, "RaidBars", "Top", false};
   ZealSetting<int> setting_position_right = {0, "RaidBars", "Right", false};
@@ -33,6 +34,9 @@ class RaidBars {
                                                    [this](const std::string &) { SyncClassAlways(); }};
   ZealSetting<std::string> setting_bitmap_font_filename = {std::string(kUseDefaultFont), "RaidBars", "Font", false,
                                                            [this](std::string val) { bitmap_font.reset(); }};
+
+  // Internal callback use only.
+  bool HandleLMouseUp(short x, short y);
 
  private:
   static constexpr int kNumClasses = Zeal::GameEnums::ClassTypes::Beastlord - Zeal::GameEnums::ClassTypes::Warrior + 1;
@@ -56,8 +60,10 @@ class RaidBars {
   std::unique_ptr<BitmapFont> bitmap_font = nullptr;
   float grid_height = 0;
   float grid_width = 0;
+  int grid_height_count_max = 0;  // Maximum number of bars that will fit in a column.
 
   std::array<std::vector<RaidMember>, kNumClasses> raid_classes;  // Per class vectors of raid members.
   std::array<int, kNumClasses> class_priority;                    // Prioritization order for class types.
   std::array<bool, kNumClasses> class_always;                     // Boolean flag to show always for class types.
+  std::vector<Zeal::GameStructures::Entity *> visible_list;       // List of visible names (for clicking).
 };


### PR DESCRIPTION
- Added new /raidbars clickable <on | off> option that makes the raid bars target the raidmember with a left mouse click
  - This uses /target logic with those restrictions (200 range)
  - Will be blocked by any non-tranparent UI element above it