### PR TITLE
Add /playerclickthru command

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ ___
   - **Arguments:** `None`
   - **Description:** toggles on/off extra output raid and group member info fields
 
+- `/playerclickthru`
+  - **Arguments:** `on`, `off`
+  - **Description:** Disables (on) left click targeting of other players (excludes self).
+
 - `/protect`
   - **Arguments:** `on`, `off`, `value`, `item`, `<item_link>`, `list`, `cursor`, `worn`
   - **Example:** `/protect value 10` Protects against dropping or destroying items >= 10 pp

--- a/Zeal/camera_mods.h
+++ b/Zeal/camera_mods.h
@@ -21,6 +21,7 @@ class CameraMods {
   ZealSetting<float> fov = {45.f, "Zeal", "Fov", false, [this](float val) { synchronize_fov(); }};
   ZealSetting<int> pan_delay = {0, "Zeal", "PanDelay", false};
   ZealSetting<bool> setting_selfclickthru = {false, "Zeal", "SelfClickThru", false};
+  ZealSetting<bool> setting_playerclickthru = {false, "Zeal", "PlayerClickThru", false};
   ZealSetting<bool> setting_leftclickcon = {false, "Zeal", "LeftClickCon", false};
   ZealSetting<bool> setting_toggle_overhead_view = {true, "Camera", "ToggleOverheadView", false};
   ZealSetting<bool> setting_toggle_zeal_view = {true, "Camera", "ToggleZealView", false};


### PR DESCRIPTION
- New /playerclickthru command disables left click targeting of other players and their mounts (excludes self)