### PR TITLE
Bump to v1.3.6-beta0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ To disable Zeal, just delete the zeal.asi file.
   link all, loot all, raid survey, singleclick, show loot lockouts, etc)
 - Integrated map (see In-game Map section below)
 - Additional ui support (new gauges, bag control & locking, looting, spellsets, targetrings,
-  nameplates, right click to equip, skill window sorting, ctrl for context menus/looting, etc)
+  nameplates, right click to equip, skill window sorting, ctrl for context menus/looting,
+  tagging (text and shapes), raidbars, etc)
 - Autostand on move/cast, autosit on camp with export inventory/spellbook option,
   enhanced autorun behavior option
 - Enhanced chat (% replacements, additional filters and colors, tell windows,
@@ -294,11 +295,13 @@ ___
 - `/raidbars`
   - **Arguments:** `on`, `off`, `font <filename>`, `position <top> <left> [<right>=0 <bottom>=0]`, `showall <on | off>`,
                    `clickable <on | off>`, `priority <classes list>`, `always <classes list>`
+  - **Example:** `/raidbars position 5 10 0 0` Constrains bars to a box from (5,10) to right and bottom screen edge.
   - **Example:** `/raidbars position 5 10 150 0` Constrains bars to a box from (5,10) to (150, bottom of screen).
   - **Example:** `/raidbars showall on` Shows healthbars of all raid members (including 100% health, out of zone)
   - **Example:** `/raidbars always WAR PAL SHD ENC` These classes are always shown (even w/out showall on)
   - **Example:** `/raidbars priority WAR WIZ ENC PAL SHD` Shows those classes first then remaining classes
-  - **Description:** Supports enabling a class-prioritized list of raid members with health bars.
+  - **Description:** Supports enabling a class-prioritized list of raid members with health bars. The bars are 
+          drawn into a rectangular screen area specified by the position command (viewport compatible).
 
 - `/reloadskin`
   - **Description:** reloads your current skin using ini.

--- a/Zeal/item_display.cpp
+++ b/Zeal/item_display.cpp
@@ -344,6 +344,13 @@ static void fix_effect_line(std::string &line, Zeal::GameStructures::SPELL *spel
       }
       append_effect_description(line, spell, caster_level, effect_index);
       break;
+    case 11:  // Attack Speed (wrong on some spells, particular items with haste spell 998).
+      if (spell->Base[effect_index] < 100 || (spell->Max[effect_index] > 0 && spell->Max[effect_index] < 100))
+        line = std::format("  {}: Decrease Attack Speed by ", display_index);
+      else
+        line = std::format("  {}: Increase Attack Speed by ", display_index);
+      append_effect_description(line, spell, caster_level, effect_index);
+      break;
   }
 }
 

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#define ZEAL_VERSION "1.3.5"
+#define ZEAL_VERSION "1.3.6-beta0"
 #ifndef ZEAL_BUILD_VERSION               // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif


### PR DESCRIPTION
- Also add back a correction to the spell info haste values which must be dynamically calculated based on the item's effect level