### PR TITLE
Add unique tags feature

### DIFF
--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -1068,7 +1068,6 @@ bool NamePlate::handle_tag_message(const char *message, bool apply) {
         continue; // Skip namplate if tag wasn't found
       std::string name_existing = entry.second.text;
       std::string spawn_id_existing = std::to_string(entry.first->SpawnId);
-      Zeal::Game::print_debug(("Found text: " + tag_text_existing).c_str());
       // Create removal message for current nameplate
       std::string remove_message = std::format("{0}{1}{2}{3}{4}{5}{6}", kZealTagHeader, kDelimiter, tag_text_modified, kDelimiter,
                                                 name_existing, kDelimiter, spawn_id_existing);


### PR DESCRIPTION
Added Unique tags feature with the '!' prefix.
Example: /tag gsay !ASSIST

When this prefix is used, Zeal will remove the tag from any existing nameplates, then add it to the requested entity as normal.

Also updated the erase tag feature to support this. Now if a tag is specified it will remove that specific tag but leave other existing tags in place. Using the erase prefix by itself will behave as it did previously.