### PR TITLE
Improve melody support for songs with recast times

### DIFF
--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -18,6 +18,8 @@ class Melody {
 
  private:
   void tick();
+  int get_next_gem_index();
+  bool is_gem_ready(int gem_index);
   void stop_current_cast();
   bool is_active = false;                          // Set when melody is actively running.
   int current_index = 0;                           // Active song index. -1 if not started yet.
@@ -25,6 +27,8 @@ class Melody {
   int retry_count = 0;                             // Tracks unsuccessful song casts.
   WORD casting_melody_spell_id = kInvalidSpellId;  // Current melody song being cast. Is only a valid id while cast
                                                    // window is visible (actively casting).
+  WORD retry_spell_id = kInvalidSpellId;           // Song failed (fizzled or otherwise, retry).
+  WORD deferred_spell_id = kInvalidSpellId;        // Song wasn't ready so deferred to next opportunity.
   int use_item_index = -1;                         // The pending use_item() to try.
   ULONGLONG use_item_timeout = 0;                  // The max timestamp until the pending use_item() gives up.
   ULONGLONG enter_zone_time = 0;                   // Timestamp of the most recent enter zone callback.


### PR DESCRIPTION
- /melody will now check if a song is ready (recast timer is not active) before trying to cast it, avoiding some extra traffic and the you have not recovered yet message
  - It also supports deferring (queuing) up to one song that wasn't ready so it is cast once it becomes ready. This makes Ancient Lullaby and Ervaj's lost composition more useful in melodies.