### PR TITLE
Add guild out of zone autoconsent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ___
   - **Description:** Drops whatever is on your cursor into your bank. [requires you to be at a banker] (not fully functional atm)
 
 - `/autoconsent`
-  - **Description:** Toggles the enable of auto-consenting from a /tc sent by a group or raid member.
+  - **Description:** Toggles the enable of auto-consenting from a /tc sent by a guild, group, or raid member.
 
 - `/autoaaswitch`
   - **Arguments:** `off`, `<threshold_low> <threshold_high>` (low switches to 0% aa and high to 100% aa)

--- a/Zeal/chat.h
+++ b/Zeal/chat.h
@@ -23,7 +23,7 @@ class Chat {
 
   void set_classes();
 
-  void AddOutputText(Zeal::GameUI::ChatWnd *wnd, std::string &msg, short channel);
+  void AddOutputText(Zeal::GameUI::ChatWnd *wnd, std::string &msg, short &channel);
 
   void add_get_color_callback(std::function<unsigned int(int index)> callback) { get_color_callback = callback; };
 
@@ -65,6 +65,11 @@ class Chat {
   void handle_opt_chat(std::vector<std::string> &args);
 
   void DoPercentReplacements(std::string &str_data);
+
+  bool SendWhoQueryForConsentCheck(const std::string &name);
+
+  bool IsConsentWhoPending();
+
   Chat(class ZealService *pHookWrapper);
   ~Chat();
 
@@ -76,4 +81,6 @@ class Chat {
   std::vector<std::function<void(const char *data)>> rsay_callbacks;
   std::vector<std::function<bool(const char *data, int color_index)>> chat_callbacks;
   std::function<bool(int key, bool down, int modifier)> key_press_callback;
+  DWORD pending_consent_timeout_ms = 0;
+  std::string pending_consent_name;
 };

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -500,6 +500,15 @@ bool do_attack(uint8_t type, uint8_t p2) {
                                                                                                get_target());
 }
 
+void do_who(const char *query) {
+  if (get_self() && query) {
+    char buffer[512];  // Probably unnecessary but protect the input buffer from possible modification by the call.
+    strcpy_s(buffer, sizeof(buffer), query);
+    reinterpret_cast<void(__cdecl *)(Zeal::GameStructures::Entity * player, char *arguments)>(0x004f491e)(get_self(),
+                                                                                                          buffer);
+  }
+}
+
 void do_raidaccept() {
   if (get_self())
     reinterpret_cast<void(__thiscall *)(Zeal::GameStructures::Entity * player, const char *unused)>(0x004f3be5)(

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -165,6 +165,7 @@ int get_game_main();
 void do_autoattack(bool enabled);
 bool CanIHitTarget(float dist);
 bool do_attack(uint8_t type, uint8_t p2);
+void do_who(const char *query);
 void do_raidaccept();
 void do_raiddecline();
 void do_inspect(Zeal::GameStructures::Entity *player);

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -27,6 +27,8 @@
 #define GAMESTATE_LOGGINGIN 253
 #define GAMESTATE_UNLOADING 255  // Set to this state to exit ProcessGame() loop.
 
+#define CHATCOLOR_DEFAULT 0  // Defined in namespace Chat of common/eq_constants.h.
+#define CHATCOLOR_WHITE 0
 #define USERCOLOR_SAY 0xFF + 1                 //  1  - Say
 #define USERCOLOR_TELL 0xFF + 2                //  2  - Tell
 #define USERCOLOR_GROUP 0xFF + 3               //  3  - Group


### PR DESCRIPTION
- /autoconsent was modified to:
  - Now grants permissions to guild (in addition to raid and grp)
  - Replaces the trigger tell "Consent me" when it activates with a default chat trigger message to avoid player confusion.
  - In order to support out of zone guild membership checks, it performs a /who all <name> query and processes the response to check for a guild match when necessary