### PR TITLE
Route spell damage from others to Spells->Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,16 @@ Manual editing of the ini file is required to copy from old section to the new s
      to populate a new cycle list (tab or shift-tab) which is printed to chat
     - Any key besides tab or shift will clear the search cycle list
 
+## Chat filtering
+- Adds additional chat filtering options under the Zeal submenu that includes things like:
+  - Random, loot, money, Pet chat & damage, Melee specials, Other damage shield, Zeal Spam
+- Supports reporting damage taken by NPCs from damage shields and spell damage from other
+  players if the 'Others non-melee' option is enabled
+  - Spell damage by others is routed to the Spells->Others channel
+  - Damage shield is routed to the Zeal->Other Damage Shield channel
+- Note that self generated spell damage goes to Spells->Non Melee Hits for direct damage
+  and to Spells->Worn Off for damage over time
+
 ## Right click to equip item
 - Enabled in Zeal general options
 - Must be in your bags.

--- a/Zeal/chatfilter.cpp
+++ b/Zeal/chatfilter.cpp
@@ -466,7 +466,7 @@ void chatfilter::callback_hit(Zeal::GameStructures::Entity *source, Zeal::GameSt
     if ((source->Position.Dist2D(Zeal::Game::get_self()->Position) < 500 ||
          target->Position.Dist2D(Zeal::Game::get_self()->Position) < 500) &&
         std::abs(source->Position.z - Zeal::Game::get_self()->Position.z) < 20) {
-      short channel = is_ds_damage_to_non_pet_npcs ? CHANNEL_OTHER_DAMAGE_SHIELD : USERCOLOR_NON_MELEE;
+      short channel = is_ds_damage_to_non_pet_npcs ? CHANNEL_OTHER_DAMAGE_SHIELD : USERCOLOR_OTHERS_SPELLS;
       Zeal::Game::print_chat(channel, "%s hit %s for %i points of non-melee damage.",
                              Zeal::Game::strip_name(source->Name), Zeal::Game::strip_name(target->Name), damage);
     }


### PR DESCRIPTION
- Change the Zeal generated reports of spell damage generated by others from non_melee to Spells->Others
- Also added more description about the filtering to the README