### PR TITLE
New Tag option to disable Tagged coloring

### DIFF
--- a/Zeal/nameplate.cpp
+++ b/Zeal/nameplate.cpp
@@ -560,7 +560,8 @@ bool NamePlate::handle_SetNameSpriteTint(Zeal::GameStructures::Entity *entity) {
   bool is_corpse = (entity->Type >= Zeal::GameEnums::NPCCorpse);
   auto it = zeal_fonts ? nameplate_info_map.find(entity) : nameplate_info_map.end();
   if (!is_target && !is_corpse && it != nameplate_info_map.end() && !it->second.tag_text.empty() &&
-      (it->second.tag_color == TagArrowColor::Off || it->second.tag_color == TagArrowColor::Nameplate))
+      (it->second.tag_color == TagArrowColor::Off || it->second.tag_color == TagArrowColor::Nameplate) &&
+      !setting_tag_disable_tagged_color.get())
     color_index = ColorIndex::Tagged;
 
   auto color = D3DCOLOR_XRGB(128, 255, 255);  // Approximately the default nameplate color.
@@ -1139,7 +1140,8 @@ bool NamePlate::handle_tag_message(const char *message, bool apply, bool allow_m
   it->second.tag_text = tag_text;
 
   // Update nameplate color immediately (otherwise there is typically a lag).
-  if (entity != Zeal::Game::get_target() && ZealService::get_instance()->ui && get_color_callback)
+  if (entity != Zeal::Game::get_target() && !setting_tag_disable_tagged_color.get() &&
+      ZealService::get_instance()->ui && get_color_callback)
     it->second.color = get_color_callback(static_cast<int>(ColorIndex::Tagged));
 
   return true;

--- a/Zeal/nameplate.h
+++ b/Zeal/nameplate.h
@@ -50,6 +50,7 @@ class NamePlate {
 
   // Tag settings.
   ZealSetting<bool> setting_tag_enable = {false, "Zeal", "NameplateTagEnable", false};
+  ZealSetting<bool> setting_tag_disable_tagged_color = {false, "Zeal", "NameplateTagDisableColor", false};
   ZealSetting<bool> setting_tag_tooltip = {false, "Zeal", "NameplateTagToolTip", false};
   ZealSetting<bool> setting_tag_tooltip_align = {false, "Zeal", "NameplateTagToolTipAlign", false};
   ZealSetting<bool> setting_tag_filter = {false, "Zeal", "NameplateTagFilter", false};

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -853,6 +853,9 @@ void ui_options::InitNameplate() {
   ui->AddCheckboxCallback(wnd, "Zeal_TagDefaultArrow", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->nameplate->setting_tag_default_arrow.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_TagDisableTaggedColor", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->nameplate->setting_tag_disable_tagged_color.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_TagAlternateSymbols", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->nameplate->setting_tag_alternate_symbols.set(wnd->Checked);
   });
@@ -937,7 +940,8 @@ void ui_options::UpdateOptionsGeneral() {
       fps_limit_selection = 0;
       break;
   }
-  ui->SetChecked("Zeal_AbbreviatedChat", ZealService::get_instance()->ZealService::get_instance()->chat_hook->UseAbbreviatedChat.get());
+  ui->SetChecked("Zeal_AbbreviatedChat",
+                 ZealService::get_instance()->ZealService::get_instance()->chat_hook->UseAbbreviatedChat.get());
   ui->SetChecked("Zeal_ClassChatColors", ZealService::get_instance()->chat_hook->UseClassChatColors.get());
   ui->SetComboValue("Zeal_FPS_Combobox", fps_limit_selection);
   ui->SetComboValue("Zeal_LockToggleBag_Combobox",
@@ -1118,6 +1122,8 @@ void ui_options::UpdateOptionsNameplate() {
   ui->SetChecked("Zeal_TagSuppress", ZealService::get_instance()->nameplate->setting_tag_suppress.get());
   ui->SetChecked("Zeal_TagPrettyPrint", ZealService::get_instance()->nameplate->setting_tag_prettyprint.get());
   ui->SetChecked("Zeal_TagDefaultArrow", ZealService::get_instance()->nameplate->setting_tag_default_arrow.get());
+  ui->SetChecked("Zeal_TagDisableTaggedColor",
+                 ZealService::get_instance()->nameplate->setting_tag_disable_tagged_color.get());
   ui->SetChecked("Zeal_TagAlternateSymbols",
                  ZealService::get_instance()->nameplate->setting_tag_alternate_symbols.get());
 

--- a/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Nameplate.xml
@@ -933,12 +933,43 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_TagDisableTaggedColor">
+    <ScreenID>Zeal_TagDisableTaggedColor</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>178</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Nameplates and default arrows are not set to Tagged color.</TooltipReference>
+    <Text>Disable Tagged color</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <Button item="Zeal_TagAlternateSymbols">
     <ScreenID>Zeal_TagAlternateSymbols</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>360</X>
-      <Y>178</Y>
+      <Y>200</Y>
     </Location>
     <Size>
       <CX>150</CX>
@@ -1017,6 +1048,7 @@
     <Pieces>Zeal_TagSuppress</Pieces>
     <Pieces>Zeal_TagPrettyPrint</Pieces>
     <Pieces>Zeal_TagDefaultArrow</Pieces>
+    <Pieces>Zeal_TagDisableTaggedColor</Pieces>
     <Pieces>Zeal_TagAlternateSymbols</Pieces>
 
     <Location>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Nameplate.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Nameplate.xml
@@ -933,12 +933,43 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_TagDisableTaggedColor">
+    <ScreenID>Zeal_TagDisableTaggedColor</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>356</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Nameplates and default arrows are not set to Tagged color.</TooltipReference>
+    <Text>Disable Tagged color</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <Button item="Zeal_TagAlternateSymbols">
     <ScreenID>Zeal_TagAlternateSymbols</ScreenID>
     <RelativePosition>true</RelativePosition>
     <Location>
       <X>720</X>
-      <Y>356</Y>
+      <Y>400</Y>
     </Location>
     <Size>
       <CX>300</CX>
@@ -1017,6 +1048,7 @@
     <Pieces>Zeal_TagSuppress</Pieces>
     <Pieces>Zeal_TagPrettyPrint</Pieces>
     <Pieces>Zeal_TagDefaultArrow</Pieces>
+    <Pieces>Zeal_TagDisableTaggedColor</Pieces>
     <Pieces>Zeal_TagAlternateSymbols</Pieces>
 
     <Location>


### PR DESCRIPTION
- Added a new Zeal Nameplate options to disable applying the Tagged color to nameplate text (including tag text) and the default (automatic) arrow shape. Instead they will use the untagged nameplate color (cons, target, etc).