### PR TITLE
Add /raidbars groups, never, thresholds,background

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,18 +293,29 @@ ___
           `./<character_name>_protected.ini` file.
 
 - `/raidbars`
-  - **Arguments:** `on`, `off`, `font <filename>`, `position <left> <top> [<right>=0 <bottom>=0]`, `showall <on | off>`,
-                   `clickable <on | off>`, `priority <classes list>`, `always <classes list>`,
-                   `barwidth <value> (0 = autoscale)`, `barheight <value> (0 = autoscale)`
+  - **Arguments:** `on`, `off`, `toggle`:  Enables or disables the raidbars
+                   `position <left> <top> [<right> <bottom>]`: Specifies rectangle to draw into (all screen coordinates)
+                   `background <value>`: Sets the opacity of the position rectangle (0 to 100 = invisible to solid)
+                   `font <filename>`: Selects the font to use for names
+                   `<barheight | bardwidth> <value>`: Sets HP bar height or width (0 = autoscale, clamped to sane values)
+                   `clickable <on | off>`: Enables or disables click targeting with raidbars
+                   `groups <on | off | toggle>`: Switches between listing by class prioritization or by groups
+                   `showall <on | off>`: Class mode: Disables health thresholding, Group mode: Shows empty slots
+                   `never <classes list>`: Never shows classes in the list (class prio mode only)
+                   `always <classes list>`: Like showall but only applies to classes in list (class prio mode only)
+                   `priority <classes list>`: Sets listing order of classes (class prio mode only)
+                   `filter <classes list>`: Shows classes only if HP <= threshold value (class prio mode only)
+                   `threshold <value>`: Sets the filter threshold value (0 to 100%)
   - **Example:** `/raidbars position 5 10` Constrains bars to a box from (x=5,y=10) to right and bottom screen edge.
-  - **Example:** `/raidbars position 5 10 0 250` Constrains bars to a box from (x=5,y=10) to (right screen edge, y=250).
+  - **Example:** `/raidbars position 5 10 300 250` Constrains bars to a box from (x=5,y=10) to (x=300, y=250).
   - **Example:** `/raidbars showall on` Shows healthbars of all raid members (including 100% health, out of zone)
   - **Example:** `/raidbars always WAR PAL SHD ENC` These classes are always shown (even w/out showall on)
+  - **Example:** `/raidbars never SHM NEC` These classes are never shown (even w/ showall on)
   - **Example:** `/raidbars priority WAR WIZ ENC PAL SHD` Shows those classes first then remaining classes
-  - **Description:** Supports enabling a class-prioritized list of raid members with health bars. The bars are 
-          drawn into a rectangular screen area specified by the position command (viewport compatible) where
+  - **Example:** `/raidbars filter SHM NEC` These classes are hidden if HP > threshold (if showall off)
+  - **Description:** Supports enabling a class-prioritized or a by group list of raid members with health bars. The bars
+          are drawn into a rectangular screen area specified by the position command (viewport compatible) where
           the upper left screen corner is (x=0, y=0) and x increases to the right, y increases to the bottom.
-          Setting a coordinate of 0 for right or bottom extends to the corresponding screen edge.
 
 - `/reloadskin`
   - **Description:** reloads your current skin using ini.

--- a/Zeal/bitmap_font.h
+++ b/Zeal/bitmap_font.h
@@ -29,6 +29,9 @@ class BitmapFontBase {
   static constexpr char kManaBarValue = 3;        // ASCII '\x03' draws the mana value
   static constexpr char kStaminaBarValue = 4;     // ASCII '\x04' draws the stamina value.
 
+  // The Background Rectangle should not be passed in queue_strings(). Also 2-D BitmapFont only.
+  static constexpr char kBackgroundRect = 5;  // ASCII '\x05\ draws the background rectangle.
+
   static constexpr float kDefaultShadowOffsetFactor = 0.01f;
 
   // Utility method to report the available fonts.
@@ -74,6 +77,9 @@ class BitmapFontBase {
   void set_mana_percent(int value) { mana_percent = value; }
 
   void set_stamina_percent(int value) { stamina_percent = value; }
+
+  // Inserts a request to render the background rect into the queue. Only one per flush allowed.
+  void queue_background_rect(const RECT &rect, D3DCOLOR color);
 
   // Primary interface for drawing text. The position is in screen pixel coordinates
   // and specifies the center (true) or the upper left (false).
@@ -143,6 +149,7 @@ class BitmapFontBase {
   char hp_percent = 0;
   char mana_percent = 0;
   char stamina_percent = 0;
+  RECT background_rect = {0, 0, 0, 0};  // Cached value (only one per flush allowed).
 
   IDirect3DDevice8 &device;
   Glyph glyph_table[kNumGlyphs] = {};

--- a/Zeal/raid_bars.h
+++ b/Zeal/raid_bars.h
@@ -30,10 +30,17 @@ class RaidBars {
   ZealSetting<int> setting_bar_width = {0, "RaidBars", "BarWidth", false, [this](int) { Clean(); }};
   ZealSetting<int> setting_bar_height = {0, "RaidBars", "BarHeight", false, [this](int) { Clean(); }};
   ZealSetting<bool> setting_show_all = {false, "RaidBars", "ShowAll", false};
+  ZealSetting<bool> setting_group_sort = {false, "RaidBars", "GroupSort", false};
+  ZealSetting<int> setting_show_threshold = {100, "RaidBars", "ShowThreshold", false};
+  ZealSetting<int> setting_background_alpha = {0, "RaidBars", "BackgroundAlpha", false};
   ZealSetting<std::string> setting_class_priority = {std::string(), "RaidBars", "ClassPriority", false,
                                                      [this](const std::string &) { SyncClassPriority(); }};
   ZealSetting<std::string> setting_class_always = {std::string(), "RaidBars", "ClassAlways", false,
                                                    [this](const std::string &) { SyncClassAlways(); }};
+  ZealSetting<std::string> setting_class_never = {std::string(), "RaidBars", "ClassNever", false,
+                                                  [this](const std::string &) { SyncClassNever(); }};
+  ZealSetting<std::string> setting_class_filter = {std::string(), "RaidBars", "ClassFilter", false,
+                                                   [this](const std::string &) { SyncClassFilter(); }};
   ZealSetting<std::string> setting_bitmap_font_filename = {std::string(kUseDefaultFont), "RaidBars", "Font", false,
                                                            [this](std::string val) { bitmap_font.reset(); }};
 
@@ -47,6 +54,9 @@ class RaidBars {
   struct RaidMember {
     std::string name;                      // Copy to compare against when out of zone.
     Zeal::GameStructures::Entity *entity;  // Set to nullptr when out of zone.
+    D3DCOLOR color;                        // Class color.
+    unsigned long group_number;            // Group number within raid.
+    bool is_group_leader;                  // Lead of the group.
   };
 
   void Clean();  // Resets state and releases all resources.
@@ -55,8 +65,12 @@ class RaidBars {
   void CallbackRender();  // Displays raid bars.
   void SyncClassPriority();
   void SyncClassAlways();
+  void SyncClassNever();
+  void SyncClassFilter();
   void DumpClassSettings() const;
   void UpdateRaidMembers();
+  void QueueByClass(const float x_min, const float y_min, const float x_max, const float y_max);
+  void QueueByGroup(const float x_min, const float y_min, const float x_max, const float y_max);
 
   DWORD next_update_game_time_ms = 0;
   std::unique_ptr<BitmapFont> bitmap_font = nullptr;
@@ -67,5 +81,7 @@ class RaidBars {
   std::array<std::vector<RaidMember>, kNumClasses> raid_classes;  // Per class vectors of raid members.
   std::array<int, kNumClasses> class_priority;                    // Prioritization order for class types.
   std::array<bool, kNumClasses> class_always;                     // Boolean flag to show always for class types.
+  std::array<bool, kNumClasses> class_never;                      // Boolean flag to show never for class types.
+  std::array<bool, kNumClasses> class_filter;                     // Boolean flag to filter class types by threshold.
   std::vector<Zeal::GameStructures::Entity *> visible_list;       // List of visible names (for clicking).
 };


### PR DESCRIPTION
- Added new /raidbars arguments:
  - toggle argument to toggle raidbars on and off
  - groups on/off/toggle: switches to a new by group mode
  - never <class_list>: list of classes to never show
  - filter <class_list>: list of classes to use threshold value
  - threshold <value>: optional value to filter with
  - background <alpha>: set opacity of a background rectangle