### PR TITLE
Fix melody handling of bard song clickies

### DIFF
--- a/Zeal/floating_damage.cpp
+++ b/Zeal/floating_damage.cpp
@@ -298,7 +298,7 @@ void FloatingDamage::add_damage(Zeal::GameStructures::Entity *source, Zeal::Game
 
   if (is_player_damage && !is_spell && !show_melee.get()) return;
 
-  auto self = Zeal::Game::get_controlled();
+  auto self = Zeal::Game::get_self();
   bool is_my_pet = (source && self && source->PetOwnerSpawnId == self->SpawnId);
   bool is_my_damage = is_my_pet || (source && self && source->SpawnId == self->SpawnId);
   if (is_my_damage && !show_self.get()) return;
@@ -312,7 +312,7 @@ void FloatingDamage::add_damage(Zeal::GameStructures::Entity *source, Zeal::Game
   bool is_npc_damage = (source && source->Type == Zeal::GameEnums::NPC);
   if (is_npc_damage && !is_my_pet && !show_npcs.get()) return;
 
-  bool is_damage_to_me = (target == Zeal::Game::get_controlled() || target == Zeal::Game::get_self());
+  bool is_damage_to_me = (target == self || target == Zeal::Game::get_controlled());
   bool is_damage_to_player = (target->Type == Zeal::GameEnums::Player);
   bool highlight = (damage >= big_hit_threshold.get()) || (type == 8);  // Backstab as starting point.
   auto color = get_color(is_my_damage, is_damage_to_me, is_damage_to_player, is_spell, highlight);

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1888,8 +1888,7 @@ bool use_item(int item_index, bool quiet) {
     Zeal::Game::print_chat(USERCOLOR_SPELL_FAILURE, "You must be standing to cast a spell.");
     return false;
   }
-  chr->cast(0xA, 0, (int *)&item, item_index < 21 ? item_index + 1 : item_index);
-  return true;
+  return chr->cast(0xA, 0, (int *)&item, item_index < 21 ? item_index + 1 : item_index) != 0;
 }
 
 bool is_autoattacking() { return *reinterpret_cast<BYTE *>(0x007f6ffe); }

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -21,6 +21,7 @@ class Melody {
   int get_next_gem_index();
   bool is_gem_ready(int gem_index);
   void stop_current_cast();
+  bool handle_opcode(int opcode);
   bool is_active = false;                          // Set when melody is actively running.
   int current_index = 0;                           // Active song index. -1 if not started yet.
   std::vector<int> songs;                          // Gem indices (base 0) for melody.
@@ -30,6 +31,7 @@ class Melody {
   WORD retry_spell_id = kInvalidSpellId;           // Song failed (fizzled or otherwise, retry).
   WORD deferred_spell_id = kInvalidSpellId;        // Song wasn't ready so deferred to next opportunity.
   int use_item_index = -1;                         // The pending use_item() to try.
+  int use_item_ack_state = 0;                      // Tracks special server ack case for use items.
   ULONGLONG use_item_timeout = 0;                  // The max timestamp until the pending use_item() gives up.
   ULONGLONG enter_zone_time = 0;                   // Timestamp of the most recent enter zone callback.
 };


### PR DESCRIPTION
- The execution of a /useitem with a bard song during a melody was causing an ack timeout
- Added more explicit logic to handle the differences between click effects and normal melody bard songs along with some general cleanup of server handshaking
- Also fixed the FCD not visible while mounted issue