### PR TITLE
Change pet map marker when tan background

### DIFF
--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -1059,8 +1059,9 @@ void ZoneMap::add_self_pet_position_vertices(std::vector<MapVertex> &vertices) c
     if (pet_entity) {
       const float kShrinkFactor = 0.7f;  // Make pet 30% smaller.
       const float size = convert_size_fraction_to_model(position_size * kShrinkFactor);
-
-      auto pet_color = D3DCOLOR_XRGB(195, 176, 145);  // Lemon khaki
+      // The lemon khaki is hard to see with tan so switch to an olive pet color.
+      auto pet_color =
+          (map_background_state == BackgroundType::kTan) ? D3DCOLOR_XRGB(195, 176, 0) : D3DCOLOR_XRGB(195, 176, 145);
       add_position_marker_vertices(-pet_entity->Position.x, -pet_entity->Position.y, pet_entity->Heading, size,
                                    pet_color, vertices);
     }


### PR DESCRIPTION
- The default lemon khaki pet marker color was hard to see with a fully opaque tan map background so switch it to olive when the tank color is active