### PR TITLE
Use current target to raidmove and raidpromote commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,17 @@ ___
           command if the font or barheights or widths are changed. Setting `/raidbars background` to something
           like 70 will make the draw rectangle obvious.
 
+- `/raidmove`
+  - **Aliases:** `/rm`
+  - **Arguments:** `int`
+  - **Example:** `/raidmove 0` Moves targeted player to ungrouped.
+  - **Example:** `/raidmove 1` Moves targeted player to group 1.
+  - **Description:** Executes #raidmove command on the targeted player.
+
+- `/raidpromote`
+  - **Aliases:** `/rp`
+  - **Description:** Executes #raidpromote command on the targeted player.
+
 - `/reloadskin`
   - **Description:** reloads your current skin using ini.
 

--- a/Zeal/raid.cpp
+++ b/Zeal/raid.cpp
@@ -30,16 +30,13 @@ static bool handle_raidmove(std::vector<std::string> &args) {
     return true;
   }  
 
-  if (args.size() == 2) {
-    int group_number = 0;
-    if (Zeal::String::tryParse(args[1], &group_number)) {
+  int group_number = 0;
+  if (args.size() == 2 && Zeal::String::tryParse(args[1], &group_number, true)) {
       Zeal::Game::do_say(true, "#raidmove %s %d", target->Name, group_number);
-    } else {
-      Zeal::Game::print_chat("Usage: /raidmove [groupnumber]");
-    }
   } else {
     Zeal::Game::print_chat("Usage: /raidmove [groupnumber]");
   }
+
   return true;
 }
 


### PR DESCRIPTION
Raid commands will use the currently targeted player to simplify raid restructuring
* /raidmove [groupnumber]
* /raidpromote