### PR TITLE
Melody use_item fix for instant bard clickies

### DIFF
--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -1850,7 +1850,7 @@ int get_effect_required_level(Zeal::GameStructures::GAMEITEMINFO *item) {
   return 0;
 }
 
-bool use_item(int item_index, bool quiet) {
+bool use_item(int item_index, bool quiet, Zeal::GameStructures::GAMEITEMINFO** out_item) {
   Zeal::GameStructures::GAMECHARINFO *chr = Zeal::Game::get_char_info();
   Zeal::GameStructures::Entity *self = Zeal::Game::get_self();
   if (!chr || !self) {
@@ -1913,6 +1913,7 @@ bool use_item(int item_index, bool quiet) {
     Zeal::Game::print_chat(USERCOLOR_SPELL_FAILURE, "You must be standing to cast a spell.");
     return false;
   }
+  if (out_item) *out_item = item;
   return chr->cast(0xA, 0, (int *)&item, item_index < 21 ? item_index + 1 : item_index) != 0;
 }
 

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -286,7 +286,7 @@ void print_raid_ungrouped();
 void dump_raid_state();
 std::string generateTimestamp();
 int get_effect_required_level(Zeal::GameStructures::GAMEITEMINFO *item);
-bool use_item(int item_index, bool quiet = false);
+bool use_item(int item_index, bool quiet = false, Zeal::GameStructures::GAMEITEMINFO** out_item = nullptr);
 enum class SortType { Ascending, Descending, Toggle };
 void sort_list_wnd(Zeal::GameUI::ListWnd *list_wnd, int sort_column, SortType sort_type = SortType::Ascending);
 short total_spell_affects(Zeal::GameStructures::GAMECHARINFO *char_info, BYTE affect_type, BYTE a3,

--- a/Zeal/melody.cpp
+++ b/Zeal/melody.cpp
@@ -281,10 +281,14 @@ void Melody::tick() {
   use_item_ack_state = UseItemState::Idle;
   if (use_item_index >= 0) {
     stop_current_cast();  // Terminate bard song (if active) in order to cast.
-    bool success = (use_item_timeout >= current_timestamp) && Zeal::Game::use_item(use_item_index);
+    Zeal::GameStructures::GAMEITEMINFO *used_item = nullptr;
+    bool success = (use_item_timeout >= current_timestamp) && Zeal::Game::use_item(use_item_index, false, &used_item);
     use_item_index = -1;
     if (success) {
       use_item_ack_state = UseItemState::CastRequested;
+      if (used_item && used_item->Common.CastTime == 0 && Zeal::Game::get_game()->IsOkToTransact()) {
+        use_item_ack_state = UseItemState::Idle;  // Instant bard clicky. Can't use request/ack format
+      }
       start_of_cast_timestamp = current_timestamp;    // Used in timeout check.
       casting_visible_timestamp = current_timestamp;  // Insta-clickies may not update.
       return;


### PR DESCRIPTION
Fixes ack handling when clicking an instant bardsong item (Breath of Harmony, Lute of the Flowing Waters)