### PR TITLE
Add /useitem <name> and right click alt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,9 +485,14 @@ ___
   - **Description:** Sets (on) or clears (off) the UI Lock value on primary game windows. Bag windows must be open to take effect.
 
 - `/useitem`
-  - **Arguments:** `slot_#` or `bag_# slot_#` (+ optional `quiet` that suppresses warnings if no click effect)
-  - **Description:** Activates a click effect on item in slot_#, or bag_# (1-8) slot_# (1-10) for an item in a bag.
+  - **Arguments:** `slot_#`, `bag_# slot_#`, or `partial_name` (+ optional `quiet` that suppresses failure details)
+  - **Description:** Activates a click effect on inventory items
+    - Zeal click from inventory must be enabled to use click effects within bags
+    - The partial name search is case sensitive
+    - The zeal `/useitem` will queue into melody (unlike eqgame.dll's `/use, /useexact`)
   - **Example:** `/useitem 16 quiet` activates click effect on BP and suppresses some warnings
+  - **Example:** `/useitem 8 3` activates click effect on the third slot of bag 8
+  - **Example:** `/useitem Journeyman` searches inventory for first ready to click item that starts with `Journeyman`
 
 - `/zeal`
   - **Arguments:** `version`
@@ -579,7 +584,7 @@ Manual editing of the ini file is required to copy from old section to the new s
 - Note that self generated spell damage goes to Spells->Non Melee Hits for direct damage
   and to Spells->Worn Off for damage over time
 
-## Right click to equip item
+## Right click to equip item and Right click to use from inventory
 - Enabled in Zeal general options
 - Must be in your bags.
 - Will equip to an empty slot when available.
@@ -588,7 +593,11 @@ Manual editing of the ini file is required to copy from old section to the new s
   RingRight, Ammo
 - Can hold Shift (2nd) / Ctrl (3rd) / Shift+Ctrl (4th) to equip the item to alternate slots
   if it can be equipped in several slots in the list.
-- Holding Alt blocks click to equip to allow processing by the eqgame.dll
+- If Zeal `Click from inventory` is enabled, then the state of the Alt key matters
+  - If the `Click requires Alt` is enabled then the primary right click to equip
+    works normally, otherwise the right click activates clicks and the Alt key
+    must be held down for the primary right click to equip action
+- The `Click from inventory` will queue items into melody when active
 
 ## Triggers
 - Supports a very simplistic visible timer countdown display based on char parsed trigger events

--- a/Zeal/equip_item.h
+++ b/Zeal/equip_item.h
@@ -9,9 +9,11 @@ class EquipItem {
   ~EquipItem();
 
   bool HandleRButtonUp(Zeal::GameUI::InvSlot *inv_slot);
+  bool HandleRightClickActivation(Zeal::GameUI::InvSlot *inv_slot);
 
   ZealSetting<bool> Enabled = {false, "Zeal", "RightClickToEquip", false};
   ZealSetting<bool> setting_click_from_inventory = {true, "Zeal", "ClickFromInventory", false};
+  ZealSetting<bool> setting_use_alt_for_clicky = {true, "Zeal", "UseAltForClicky", false};
 
  private:
   Zeal::GameUI::InvSlot *GetInventorySlot(int inv_slot_id);

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -285,7 +285,9 @@ void print_raid_leaders(bool show_all_groups = false, bool show_open_groups = fa
 void print_raid_ungrouped();
 void dump_raid_state();
 std::string generateTimestamp();
-int get_effect_required_level(Zeal::GameStructures::GAMEITEMINFO *item);
+int get_effect_required_level(const Zeal::GameStructures::GAMEITEMINFO *item);
+int find_use_item_by_name(const std::string &partial_name, bool check_bags);
+bool is_valid_item_to_use(const Zeal::GameStructures::GAMEITEMINFO *item, bool is_equipped, bool quiet = true);
 bool use_item(int item_index, bool quiet = false);
 enum class SortType { Ascending, Descending, Toggle };
 void sort_list_wnd(Zeal::GameUI::ListWnd *list_wnd, int sort_column, SortType sort_type = SortType::Ascending);

--- a/Zeal/game_structures.h
+++ b/Zeal/game_structures.h
@@ -18,8 +18,13 @@
 #define GAME_NUM_HOTBUTTONS 10
 #define GAME_NUM_HOTBUTTONS_TOTAL 100
 #define GAME_NUM_CONTAINER_SLOTS 10
+#define GAME_EQUIPMENT_SLOTS_START 1
+#define GAME_EQUIPMENT_SLOTS_END (GAME_EQUIPMENT_SLOTS_START + GAME_NUM_INVENTORY_SLOTS - 1)
+#define GAME_PACKS_SLOTS_START 22
+#define GAME_PACKS_SLOTS_END (GAME_PACKS_SLOTS_START + GAME_NUM_INVENTORY_PACK_SLOTS - 1)
 #define GAME_CONTAINER_SLOTS_START 250
-#define GAME_CONTAINER_SLOTS_END (GAME_CONTAINER_SLOTS_START + (GAME_NUM_INVENTORY_PACK_SLOTS * GAME_NUM_CONTAINER_SLOTS) - 1)
+#define GAME_CONTAINER_SLOTS_END \
+  (GAME_CONTAINER_SLOTS_START + (GAME_NUM_INVENTORY_PACK_SLOTS * GAME_NUM_CONTAINER_SLOTS) - 1)
 #define GAMESTATE_STARTUP 0
 #define GAMESTATE_CHARSELECT 1
 #define GAMESTATE_ENTERWORLD 3   // Character selected, waiting to connect to zone.
@@ -240,6 +245,8 @@ enum ItemEffect {
 
 namespace EquipSlot {  // Avoids 'Back' collision; enum class is inconvenient.
 
+// Note: These EquipSlot enums are indices into the character Inventory array.
+// Add GAME_EQUIPMENT_SLOTS_START to calculate the global slot ID value.
 enum EquipSlot {
   LeftEar = 0,
   Head,

--- a/Zeal/melody.cpp
+++ b/Zeal/melody.cpp
@@ -126,8 +126,7 @@ void Melody::end(bool do_print) {
 }
 
 bool Melody::use_item(int item_index) {
-  if (!is_active || item_index < 0 || (item_index > 29 && item_index < GAME_CONTAINER_SLOTS_START)
-        || item_index > GAME_CONTAINER_SLOTS_END )
+  if (!is_active)
     return false;
   // Set fields so use_item(item_index) will execute during tick().
   use_item_index = item_index;

--- a/Zeal/melody.h
+++ b/Zeal/melody.h
@@ -12,7 +12,7 @@ class Melody {
   void end(bool do_print = false);
   void handle_stop_cast_callback(BYTE reason, WORD spell_id);
   void handle_deactivate_ui();
-  bool use_item(int item_index);  // asks Melody to handle /useitem command. Returns true if melody handled the command.
+  bool use_item(int item_index);  // Returns true if melody queued /useitem(item_index).
   Melody(class ZealService *pHookWrapper);
   ~Melody();
 

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -405,6 +405,9 @@ void ui_options::InitGeneral() {
   ui->AddCheckboxCallback(wnd, "Zeal_ClickFromInventory", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->equip_item_hook->setting_click_from_inventory.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_UseAltForClicky", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->equip_item_hook->setting_use_alt_for_clicky.set(wnd->Checked);
+  });
   ui->AddCheckboxCallback(wnd, "Zeal_RightClickToEquip", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->equip_item_hook->Enabled.set(wnd->Checked);
   });
@@ -1031,6 +1034,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_SpellbookAutoStand", ZealService::get_instance()->movement->SpellBookAutoStand.get());
   ui->SetChecked("Zeal_CastAutoStand", ZealService::get_instance()->movement->CastAutoStand.get());
   ui->SetChecked("Zeal_ClickFromInventory", ZealService::get_instance()->equip_item_hook->setting_click_from_inventory.get());
+  ui->SetChecked("Zeal_UseAltForClicky", ZealService::get_instance()->equip_item_hook->setting_use_alt_for_clicky.get());
   ui->SetChecked("Zeal_RightClickToEquip", ZealService::get_instance()->equip_item_hook->Enabled.get());
   ui->SetChecked("Zeal_BuffTimers", ZealService::get_instance()->ui->buffs->BuffTimers.get());
   ui->SetChecked("Zeal_RecastTimers", ZealService::get_instance()->ui->buffs->RecastTimers.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -804,8 +804,39 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Enables Alt + Right click to use clickies in invetory/bags.</TooltipReference>
+    <TooltipReference>Enables use of right click to activate click items in inventory bags.</TooltipReference>
     <Text>Click from Inventory</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
+  <Button item="Zeal_UseAltForClicky">
+    <ScreenID>Zeal_UseAltForClicky</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>574</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Requires Alt key modifier to activate click from inventory.</TooltipReference>
+    <Text>Click requires Alt</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -1909,6 +1940,7 @@
     <Pieces>Zeal_PerCharKeybinds</Pieces>
     <Pieces>Zeal_PerCharAutojoin</Pieces>
     <Pieces>Zeal_ClickFromInventory</Pieces>
+    <Pieces>Zeal_UseAltForClicky</Pieces>
     <!-- Second column. -->
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -804,8 +804,39 @@
     <Style_HScroll>false</Style_HScroll>
     <Style_Transparent>false</Style_Transparent>
     <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Enables Alt + Right click to use clickies in invetory/bags.</TooltipReference>
+    <TooltipReference>Enables use of right click to activate click items in inventory bags.</TooltipReference>
     <Text>Click from Inventory</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
+  <Button item="Zeal_UseAltForClicky">
+    <ScreenID>Zeal_UseAltForClicky</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>20</X>
+      <Y>1148</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Requires Alt key modifier to activate click from inventory.</TooltipReference>
+    <Text>Click requires Alt</Text>
     <TextColor>
       <R>255</R>
       <G>255</G>
@@ -1909,6 +1940,7 @@
     <Pieces>Zeal_PerCharKeybinds</Pieces>
     <Pieces>Zeal_PerCharAutojoin</Pieces>
     <Pieces>Zeal_ClickFromInventory</Pieces>
+    <Pieces>Zeal_UseAltForClicky</Pieces>
     
     <Pieces>Zeal_HoverTimeout_Label</Pieces>
     <Pieces>Zeal_HoverTimeout_Slider</Pieces>


### PR DESCRIPTION
- Cleaned up /useitem and added the option for a partial name search match to use items (equipped or from inventory)
- Integrated the is item valid checks from the latest eqgame to confirm the valid is a clicky
- Added an option to toggle requiring the alt modifier plus right click between click to equip and click to activate