### PR TITLE
Fixes for melody silence bug and bard insta-clicks

### DIFF
--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -2023,12 +2023,13 @@ Zeal::GameStructures::GAMEITEMINFO *get_use_item_from_global_slot_id(int slot_id
 // This function takes global_slot_id as the input but prints out error messages in "user" space
 // with decoding of equipment to 0 to 20, packs from 22 to 29, and pack slots in one-indexed
 // bag and slot numbers.
-bool use_item(int global_slot_id, bool quiet) {
+bool use_item(int global_slot_id, bool quiet, Zeal::GameStructures::GAMEITEMINFO **out_item) {
   if (!is_valid_state_to_use_item(quiet)) return false;
 
   Zeal::GameStructures::GAMECHARINFO *chr = Zeal::Game::get_char_info();
   Zeal::GameStructures::GAMEITEMINFO *item = get_use_item_from_global_slot_id(global_slot_id, quiet);
   if (!chr || !item) return false;
+  if (out_item) *out_item = item;
 
   const UINT kUseItemGemSlot = 10;  // Slot 10 tells the server this is an item clicky.
   return chr->cast(kUseItemGemSlot, 0, (int *)&item, global_slot_id) != 0;

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -274,7 +274,7 @@ int get_region_from_pos(Vec3 *pos);
 GameUI::CXWndManager *get_wnd_manager();
 bool is_player_pet(const Zeal::GameStructures::Entity &entity);
 std::vector<Zeal::GameStructures::RaidMember *> get_raid_list();
-DWORD get_raid_group_number(const char* name = nullptr);
+DWORD get_raid_group_number(const char *name = nullptr);
 int get_raid_group_count(DWORD group_number);
 DWORD get_raid_class_color(BYTE class_id);  // Returns ARGB color for the class.
 bool is_raid_pet(const Zeal::GameStructures::Entity &entity);
@@ -288,7 +288,7 @@ std::string generateTimestamp();
 int get_effect_required_level(const Zeal::GameStructures::GAMEITEMINFO *item);
 int find_use_item_by_name(const std::string &partial_name, bool check_bags);
 bool is_valid_item_to_use(const Zeal::GameStructures::GAMEITEMINFO *item, bool is_equipped, bool quiet = true);
-bool use_item(int item_index, bool quiet = false);
+bool use_item(int item_index, bool quiet = false, Zeal::GameStructures::GAMEITEMINFO **out_item = nullptr);
 enum class SortType { Ascending, Descending, Toggle };
 void sort_list_wnd(Zeal::GameUI::ListWnd *list_wnd, int sort_column, SortType sort_type = SortType::Ascending);
 short total_spell_affects(Zeal::GameStructures::GAMECHARINFO *char_info, BYTE affect_type, BYTE a3,


### PR DESCRIPTION
- Fixes a bug where Bard spell/song casting could get bugged if the melody was terminated abnormally (like silence) and then the player used an insta-cast clicky like jboots

- Fixes handling of melody /useitem queuing of items with instant cast bard songs (Breath of Harmony, Lute of Flowing Waters) so they do not cause a handshaking error