### PR TITLE
Additional formatting support for cross-zone invite dialogs and auto consent

### DIFF
--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -802,13 +802,23 @@ std::string GetAutoRaidInviteName(const std::string &data) {
 
 // Returns a player name if the tell matches the expected /tc format.
 std::string GetConsentMeTellName(const std::string &data) {
-  static const char consent_ending[] = " tells you, 'Consent me'";
-  if (!data.ends_with(consent_ending)) return "";
+  static const char consent_ending_regular[] = " tells you, 'Consent me'";
+  static const char consent_ending_abbreviated[] = "]: Consent me";
+  char name_prefix;
+  int consent_ending_len;
+  if (data.ends_with(consent_ending_regular)) {
+    name_prefix = ' ';
+    consent_ending_len = strlen(consent_ending_regular);
+  } else if (data.ends_with(consent_ending_abbreviated)) {
+    name_prefix = '[';
+    consent_ending_len = strlen(consent_ending_abbreviated);
+  }
+  else return "";
 
   // Extract the name. Normally it is the first word but we go backwards just in case.
-  std::string truncated = data.substr(0, data.length() - strlen(consent_ending));
-  size_t last_space = truncated.find_last_of(" ");
-  std::string name = (last_space == std::string::npos) ? truncated : truncated.substr(last_space + 1);
+  std::string truncated = data.substr(0, data.length() - consent_ending_len);
+  size_t name_prefix_pos = truncated.find_last_of(name_prefix);
+  std::string name = (name_prefix_pos == std::string::npos) ? truncated : truncated.substr(name_prefix_pos + 1);
   return name;
 }
 

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -42,12 +42,21 @@ static constexpr char kDefaultSoundNone[] = "None";
 // Returns a player name if the message matches a cross-zone raid invite
 std::string GetCrossZoneInviteName(const std::string &data) {
 
-  static const char raid_invite_ending[] = " a raid."; 
+  static const char raid_invite_ending[] = " a raid.";
   if (!data.ends_with(raid_invite_ending)) return "";
+
+  size_t start_pos = 0;
+  // Filter out timestamps at the start of the message
+  if (data.starts_with("[")) {
+    size_t timestamp_close = data.find_first_of("]");
+    if (timestamp_close == std::string::npos) return "";
+    start_pos = timestamp_close + 2;
+  }
 
   size_t first_space;
   std::string inviter;
-  if (data.starts_with("<c")) {
+
+  if (data[start_pos] == ('<')) {
     // Handle color tag if Class Chat Colors is on
     size_t name_start = data.find(">");
     size_t name_end = data.find("</c>");
@@ -56,8 +65,8 @@ std::string GetCrossZoneInviteName(const std::string &data) {
     inviter = data.substr(name_start + 1, name_end - name_start - 1);
   } else {
     // Handle normal messages
-    first_space = data.find_first_of(" ");
-    inviter = data.substr(0, first_space);
+    first_space = data.find_first_of(" ", start_pos);
+    inviter = data.substr(start_pos, first_space);
   }
 
   std::string invite_msg = data.substr(first_space + 1);


### PR DESCRIPTION
Auto consent now works with /abc

The cross-zone raid invite dialog now works with timestamps