### PR TITLE
Add /band support for same item ids in bags

### DIFF
--- a/Zeal/bandolier.cpp
+++ b/Zeal/bandolier.cpp
@@ -117,6 +117,7 @@ void Bandolier::load(const std::string &name) {
   }
 
   // We go in reverse order so the final appearance update is typically the primary weapon
+  std::vector<int> used_slots;  // Keep track of items pulled from inventory so only used once.
   for (auto i = BANDOLIER_SLOTS.size(); i-- > 0; /*comparison post-dec*/) {
     int item_id = item_ids[i];
 
@@ -147,10 +148,13 @@ void Bandolier::load(const std::string &name) {
 
       // And if still not found then try to find the source item in the non-equipped inventory
       if (load_slot < 0) {
-        load_slot = Zeal::Game::find_item_in_inventory(item_id, false);
+        load_slot = Zeal::Game::find_item_in_inventory(item_id, false, used_slots);
 
         // Store it's original position (if in inventory) in case we want to swap it back later
-        if (load_slot > 0) original_position[item_id] = load_slot;
+        if (load_slot > 0) {
+          original_position[item_id] = load_slot;
+          used_slots.push_back(load_slot);
+        }
       }
       if (load_slot == -1) {
         Zeal::Game::print_chat(USERCOLOR_SPELL_FAILURE,

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -2041,7 +2041,7 @@ bool is_valid_item_to_use(const Zeal::GameStructures::GAMEITEMINFO *item, bool i
 }
 
 // Returns the global slot ID of the item if found in bags, otherwise returns -1
-int find_item_in_inventory(int item_id, bool check_equipped) {
+int find_item_in_inventory(int item_id, bool check_equipped, const std::vector<int> &ignore_slots) {
   if (item_id <= 0) return -1;
   auto *char_info = get_char_info();
   if (!char_info) return -1;
@@ -2055,7 +2055,9 @@ int find_item_in_inventory(int item_id, bool check_equipped) {
 
     // Check if the item is directly in the pack slot (not inside a bag)
     if (slot_info->ID == item_id) {
-      return GAME_PACKS_SLOTS_START + pack_slot;
+      int global_slot_id = GAME_PACKS_SLOTS_START + pack_slot;
+      if (std::find(ignore_slots.begin(), ignore_slots.end(), global_slot_id) == ignore_slots.end())
+        return global_slot_id;
     }
 
     if (slot_info->Type != 1) continue;
@@ -2063,7 +2065,9 @@ int find_item_in_inventory(int item_id, bool check_equipped) {
     for (int slot = 0; slot < slot_info->Container.Capacity; slot++) {
       Zeal::GameStructures::GAMEITEMINFO *item = slot_info->Container.Item[slot];
       if (item && item->ID == item_id) {
-        return GAME_CONTAINER_SLOTS_START + (pack_slot * GAME_NUM_CONTAINER_SLOTS) + slot;
+        int global_slot_id = GAME_CONTAINER_SLOTS_START + (pack_slot * GAME_NUM_CONTAINER_SLOTS) + slot;
+        if (std::find(ignore_slots.begin(), ignore_slots.end(), global_slot_id) == ignore_slots.end())
+          return global_slot_id;
       }
     }
   }
@@ -2074,7 +2078,7 @@ int find_item_in_inventory(int item_id, bool check_equipped) {
     for (int i = GAME_EQUIPMENT_SLOTS_START; i < GAME_EQUIPMENT_SLOTS_END; i++) {
       if (char_info->InventoryItem[i - GAME_EQUIPMENT_SLOTS_START] &&
           char_info->InventoryItem[i - GAME_EQUIPMENT_SLOTS_START]->ID == item_id) {
-        return i;
+        if (std::find(ignore_slots.begin(), ignore_slots.end(), i) == ignore_slots.end()) return i;
       }
     }
   }

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -291,7 +291,7 @@ void print_raid_ungrouped();
 void dump_raid_state();
 std::string generateTimestamp();
 int get_effect_required_level(const Zeal::GameStructures::GAMEITEMINFO *item);
-int find_item_in_inventory(int item_id, bool check_equipped);  // Returns global_slot_id or -1 if not found
+int find_item_in_inventory(int item_id, bool check_equipped, const std::vector<int>& ignore_slots = std::vector<int>());
 int find_use_item_by_name(const std::string &partial_name, bool check_bags);
 bool is_valid_item_to_use(const Zeal::GameStructures::GAMEITEMINFO *item, bool is_equipped, bool print_error = false);
 bool use_item(int item_index, bool quiet = false, Zeal::GameStructures::GAMEITEMINFO **out_item = nullptr);

--- a/Zeal/triggers.cpp
+++ b/Zeal/triggers.cpp
@@ -103,10 +103,17 @@ bool Triggers::AddTrigger(const std::string &line) {
     return false;
   }
 
+  std::regex pattern;
+  try {
+    pattern = std::regex(fields[2]);
+  } catch (const std::regex_error &e) {
+    return false;
+  }
+
   Trigger trigger = {.action = action,
                      .label = fields[1],
                      .pattern_str = fields[2],
-                     .pattern = std::regex(fields[2]),
+                     .pattern = pattern,
                      .duration_sec = static_cast<DWORD>(duration_sec),
                      .color = color};
   triggers.push_back(trigger);


### PR DESCRIPTION
- /bandolier will not properly load two items with the same item ids from inventory (ie, swap in two ulaks)
- Also added exception safety in the triggers parser