### PR TITLE
Remove gating of cast rec gauge with gcd

### DIFF
--- a/Zeal/labels.cpp
+++ b/Zeal/labels.cpp
@@ -223,7 +223,7 @@ static int get_recast_time_gauge(int index, Zeal::GameUI::CXSTR *str) {
   int game_time = display->GameTimeMs;
   int spell_id = char_info->MemorizedSpell[index];
   if (!Zeal::Game::Spells::IsValidSpellIndex(spell_id) || actor_info->CastingSpellId == spell_id ||
-      actor_info->RecastTimeout[index] <= game_time || actor_info->RecastTimeout[index] <= actor_info->FizzleTimeout) {
+      actor_info->RecastTimeout[index] <= game_time) {
     if (str) str->Set("0");
     return 0;
   }


### PR DESCRIPTION
- Tweaked the recovery gauge eqtypes so they are no longer gated by the global cooldown timer (fizzle timeout)