### PR TITLE
Minor bandolier and swap updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ ___
   - **Example:** `/bandolier bag 4` sets the bag in pack slot 4 (1 to 8, 0 to disable) as the preferred store spot
   - **Description:** Allows you to save and load bandolier sets
     - Works for primary, secondary, range and ammo slots
-    - Primary and secondary always swap but range and ammo will not change if you save a set with them empty
+    - Primary and secondary always swap but range and ammo will not change if you save a set with both of them empty
     - The item getting swapped out first tries to store in the slot of the swap in item, then in the location
       it was originally swapped in from (if available), then in the preferred bag if there is room, then in
       any inventory bag (starting from last) if there is room, then in a pack slot
@@ -445,10 +445,12 @@ ___
 
 - `/swap`
   - **Arguments:** `<first_bag> <first slot> <second_bag> <second_slot>`
+  - **Arguments:** `<first_bag> <first slot> <item_name_in_inventory_>`
   - **Description:** Swaps items between the two slots where bag = 0 to use inventory slots
        0 to 29 or bag = 1 to 8 to use bag slots 1 to 10. See /useitem for inventory slots.
        The cursor must be empty and the character not busy casting, banking, trading, etc.
   - **Example:** `/swap 0 12 4 1`: Swaps the primary weapon slot with bag 4 slot 1.
+  - **Example:** `/swap 0 7 Cloak of Flames`: Swaps back slot with Cloak of Flames from inventory.
 
 - `/tag`
   - **Description:** adds an optional text tag to the top of a target NPC's nameplate

--- a/Zeal/bandolier.cpp
+++ b/Zeal/bandolier.cpp
@@ -116,14 +116,18 @@ void Bandolier::load(const std::string &name) {
     }
   }
 
+  // Support not swapping/loading range and ammo only if both are empty in the bandolier set.
+  bool bBothEmpty =
+      (BANDOLIER_SLOTS[2] == kRangeSlot && !item_ids[2]) && (BANDOLIER_SLOTS[3] == kAmmoSlot && !item_ids[3]);
+
   // We go in reverse order so the final appearance update is typically the primary weapon
   std::vector<int> used_slots;  // Keep track of items pulled from inventory so only used once.
   for (auto i = BANDOLIER_SLOTS.size(); i-- > 0; /*comparison post-dec*/) {
     int item_id = item_ids[i];
 
     // Do nothing for this slot if no items, item already loaded, or a no-load for ammo or range.
-    if ((item_id == 0) && (BANDOLIER_SLOTS[i] == kRangeSlot || BANDOLIER_SLOTS[i] == kAmmoSlot) ||
-        (item_id == 0 && !equipped[i]) || (equipped[i] && equipped[i]->ID == item_id)) {
+    bool bNoLoadEligible = bBothEmpty && (BANDOLIER_SLOTS[i] == kRangeSlot || BANDOLIER_SLOTS[i] == kAmmoSlot);
+    if ((item_id == 0 && (bNoLoadEligible || !equipped[i])) || (equipped[i] && equipped[i]->ID == item_id)) {
       continue;
     }
 

--- a/Zeal/game_functions.cpp
+++ b/Zeal/game_functions.cpp
@@ -2086,6 +2086,54 @@ int find_item_in_inventory(int item_id, bool check_equipped, const std::vector<i
   return -1;
 }
 
+// Returns the global slot ID of the item if found in bags, otherwise returns -1
+int find_item_in_inventory(const std::string &partial_name, bool check_equipped, const std::vector<int> &ignore_slots) {
+  auto char_info = get_char_info();
+
+  auto name = partial_name.c_str();
+  size_t len = partial_name.length();
+  if (!char_info || len == 0) return -1;
+
+  // Look through each inventory pack slot for the item
+  // Slot ID for bagged items is 250 + (bag_i*10) + (contents_i) = [250...329]
+  for (int pack_slot = 0; pack_slot < GAME_NUM_INVENTORY_PACK_SLOTS; pack_slot++) {
+    auto *slot_info = char_info->InventoryPackItem[pack_slot];
+
+    if (!slot_info) continue;
+
+    // Check if the item is directly in the pack slot (not inside a bag)
+    if (strncmp(slot_info->Name, name, len) == 0) {
+      int global_slot_id = GAME_PACKS_SLOTS_START + pack_slot;
+      if (std::find(ignore_slots.begin(), ignore_slots.end(), global_slot_id) == ignore_slots.end())
+        return global_slot_id;
+    }
+
+    if (slot_info->Type != 1) continue;
+    // if it's a container, check inside it for the item
+    for (int slot = 0; slot < slot_info->Container.Capacity; slot++) {
+      Zeal::GameStructures::GAMEITEMINFO *item = slot_info->Container.Item[slot];
+      if (item && strncmp(item->Name, name, len) == 0) {
+        int global_slot_id = GAME_CONTAINER_SLOTS_START + (pack_slot * GAME_NUM_CONTAINER_SLOTS) + slot;
+        if (std::find(ignore_slots.begin(), ignore_slots.end(), global_slot_id) == ignore_slots.end())
+          return global_slot_id;
+      }
+    }
+  }
+
+  if (check_equipped) {
+    // Look through equipped inventory slots for the item
+    // Equipped slot IDs are 1-22
+    for (int i = GAME_EQUIPMENT_SLOTS_START; i < GAME_EQUIPMENT_SLOTS_END; i++) {
+      auto item = char_info->InventoryItem[i - GAME_EQUIPMENT_SLOTS_START];
+      if (item && strncmp(item->Name, name, len) == 0) {
+        if (std::find(ignore_slots.begin(), ignore_slots.end(), i) == ignore_slots.end()) return i;
+      }
+    }
+  }
+
+  return -1;
+}
+
 int find_use_item_by_name(const std::string &partial_name, bool check_bags) {
   auto char_info = get_char_info();
 

--- a/Zeal/game_functions.h
+++ b/Zeal/game_functions.h
@@ -291,7 +291,9 @@ void print_raid_ungrouped();
 void dump_raid_state();
 std::string generateTimestamp();
 int get_effect_required_level(const Zeal::GameStructures::GAMEITEMINFO *item);
-int find_item_in_inventory(int item_id, bool check_equipped, const std::vector<int>& ignore_slots = std::vector<int>());
+int find_item_in_inventory(int item_id, bool check_equipped, const std::vector<int> &ignore_slots = std::vector<int>());
+int find_item_in_inventory(const std::string &partial_name, bool check_equipped,
+                           const std::vector<int> &ignore_slots = std::vector<int>());
 int find_use_item_by_name(const std::string &partial_name, bool check_bags);
 bool is_valid_item_to_use(const Zeal::GameStructures::GAMEITEMINFO *item, bool is_equipped, bool print_error = false);
 bool use_item(int item_index, bool quiet = false, Zeal::GameStructures::GAMEITEMINFO **out_item = nullptr);

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -324,16 +324,27 @@ static bool handle_useitem(const std::vector<std::string> &args, bool check_bags
 static const char *handle_swap(const std::vector<std::string> &args) {
   static constexpr char kUsage[] =
       "Usage: /swap <first_bag> <first_slot> <second_bag> <second_slot> "
+      "Usage: /swap <bag> <slot> <item_name_in_inventory>"
       " where bag = 0 to use inventory slots 0 to 29 or bag = 1 to 8 to use bag slots 1 to 10";
 
   int first_bag = 0;
   int first_index = 0;
   int second_bag = 0;
   int second_index = 0;
+  int second_slot_id = -1;
+  // First check for purely numeric parameters.
   if (args.size() != 5 || !Zeal::String::tryParse(args[1], &first_bag, true) ||
       !Zeal::String::tryParse(args[2], &first_index, true) || !Zeal::String::tryParse(args[3], &second_bag, true) ||
       !Zeal::String::tryParse(args[4], &second_index, true)) {
-    return kUsage;
+    // Failed the numeric bag slots, check if item name match parameters work.
+    if (args.size() < 4 || !Zeal::String::tryParse(args[1], &first_bag, true) ||
+        !Zeal::String::tryParse(args[2], &first_index, true)) {
+      return kUsage;
+    }
+    std::string name = args[3];
+    for (auto i = 4; i < args.size(); ++i) name += " " + args[i];  // Re-create full name string with spaces.
+    second_slot_id = Zeal::Game::find_item_in_inventory(name, false);
+    if (second_slot_id < 0) return "Could not find that item in inventory";
   }
 
   int first_slot_id = (first_bag == 0)
@@ -341,10 +352,13 @@ static const char *handle_swap(const std::vector<std::string> &args) {
                           : (GAME_CONTAINER_SLOTS_START + (first_bag - 1) * GAME_NUM_CONTAINER_SLOTS + first_index - 1);
   if (first_slot_id < GAME_EQUIPMENT_SLOTS_END) first_slot_id++;  // Convert to global.
 
-  int second_slot_id =
-      (second_bag == 0) ? second_index
-                        : (GAME_CONTAINER_SLOTS_START + (second_bag - 1) * GAME_NUM_CONTAINER_SLOTS + second_index - 1);
-  if (second_slot_id < GAME_EQUIPMENT_SLOTS_END) second_slot_id++;  // Convert to global.
+  if (second_slot_id < 0) {
+    second_slot_id =
+        (second_bag == 0)
+            ? second_index
+            : (GAME_CONTAINER_SLOTS_START + (second_bag - 1) * GAME_NUM_CONTAINER_SLOTS + second_index - 1);
+    if (second_slot_id < GAME_EQUIPMENT_SLOTS_END) second_slot_id++;  // Convert to global.
+  }
 
   if (!Zeal::Game::is_global_slot_id_an_inventory_slot(first_slot_id) ||
       !Zeal::Game::is_global_slot_id_an_inventory_slot(second_slot_id))


### PR DESCRIPTION
- /bandolier now requires both ammo and range to be empty when saved to skip reloading them (allows throwing spears in range)
- /swap now accepts an item name instead of the second bag params