### PR TITLE
Bump to v1.4.2 and disable /ari raid leader check

### DIFF
--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -966,8 +966,9 @@ void Chat::AddOutputText(Zeal::GameUI::ChatWnd *wnd, std::string &msg, short &ch
   if (channel == USERCOLOR_TELL && !autoInvitePassword.empty()) {
     std::string name = GetAutoRaidInviteName(msg);
     if (!name.empty()) {
+      const bool bEnableRaidLeaderCheck = false;  // Maybe make this an option someday if someone cares.
       const Zeal::GameStructures::RaidInfo *raid_info = Zeal::Game::RaidInfo;
-      if (raid_info->is_in_raid() && raid_info->IsLeader) {
+      if (!bEnableRaidLeaderCheck || (raid_info->is_in_raid() && raid_info->IsLeader)) {
         Zeal::Game::do_say(true, "#raidinvite %s", name.c_str());
         channel = CHATCOLOR_DEFAULT;  // Keep the invites from cluttering tell windows.
         msg = name + " sent a tell that triggered a #raidinvite.";

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#define ZEAL_VERSION "1.4.1"
+#define ZEAL_VERSION "1.4.2"
 #ifndef ZEAL_BUILD_VERSION               // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif


### PR DESCRIPTION
- By popular demand, disabled the check if a raid leader before responding to the ari password tell with the #raidinvite