### PR TITLE
Add ability to hide fake inventory slots for All-Bags-In-One UIs

### DIFF
--- a/Zeal/ui_hide_fake_slots.cpp
+++ b/Zeal/ui_hide_fake_slots.cpp
@@ -18,21 +18,42 @@ static int __fastcall InvSlotWnd_HandleLButtonUp(Zeal::GameUI::InvSlotWnd *wnd,
   int result = next_HandleLButtonUp(wnd, mouse_x, mouse_y, flags);
 
   auto *zeal = ZealService::get_instance();
-  if (!zeal->ui_hide_fake_slots || !zeal->ui_hide_fake_slots->Enabled.get()) return result;
+  if (!zeal->ui_hide_fake_slots->Enabled.get()) return result;
 
   int slot_id = wnd->SlotID;
 
   // Only run if a valid bag slot was clicked
   if (slot_id >= GAME_PACKS_SLOTS_START && slot_id <= GAME_PACKS_SLOTS_END) {
-    // Call with delay so that game has time to update
-    ZealService::get_instance()->callbacks->AddDelayed([]() {
-      auto zeal = ZealService::get_instance();
-      if (zeal->ui_hide_fake_slots)
-        zeal->ui_hide_fake_slots->update_slot_visibility();
-    }, 50);
+    zeal->callbacks->AddDelayed([]() {
+      auto *z = ZealService::get_instance();
+      if (z->ui_hide_fake_slots)
+        z->ui_hide_fake_slots->check_and_update();
+    }, 50); // Call with delay so that game has time to update
   }
 
   return result;
+}
+
+void UI_HideFakeSlots::check_and_update() {
+  // Call an update if the bag slots have changed
+  
+  if (!Enabled.get()) return;
+
+  auto *char_info = Zeal::Game::get_char_info();
+  if (!char_info) return;
+
+  bool changed = false;
+  for (int i = 0; i < GAME_NUM_INVENTORY_PACK_SLOTS; ++i) {
+    auto *bag = char_info->InventoryPackItem[i];
+    int id = (bag && bag->Type == 1) ? bag->ID : 0;
+    if (id != cached_pack_slot_ids[i]) {
+      cached_pack_slot_ids[i] = id;
+      changed = true;
+    }
+  }
+
+  if (changed)
+    update_slot_visibility();
 }
 
 void UI_HideFakeSlots::update_slot_visibility() {
@@ -55,6 +76,7 @@ void UI_HideFakeSlots::update_slot_visibility() {
     int slot_id = inv_slot->invSlotWnd->SlotID;
     if (slot_id < GAME_CONTAINER_SLOTS_START || slot_id > GAME_CONTAINER_SLOTS_END) continue;
 
+    // Determine the index of the bag that contains this item
     int offset    = slot_id - GAME_CONTAINER_SLOTS_START;
     int bag_slot  = offset / GAME_NUM_CONTAINER_SLOTS;
     int bag_index = offset % GAME_NUM_CONTAINER_SLOTS;
@@ -79,19 +101,13 @@ UI_HideFakeSlots::UI_HideFakeSlots(ZealService *zeal)
   vtable->HandleLButtonUp = InvSlotWnd_HandleLButtonUp;
   mem::reset_memory_protection(vtable);
 
-  // Update slot visibility on a timer as a fallback
-  zeal->callbacks->AddGeneric([this]() {
-    if (!Enabled.get()) return;
-
-    static DWORD last_check = 0;
-    DWORD now = GetTickCount();
-    if (now - last_check > 2000) {
-      last_check = now;
-      update_slot_visibility();
-    }
-  }, callback_type::MainLoop);
+  // Trigger update when an item is received from the server (purchase/quest/loot/etc)
+  zeal->callbacks->AddPacket([this](UINT opcode, char *buffer, UINT len) -> bool {
+    if (opcode == 0x4031 && this->Enabled.get())
+      check_and_update();
+    return false;
+  }, callback_type::WorldMessagePost);
 }
-
 
 UI_HideFakeSlots::~UI_HideFakeSlots() {
   auto *vtable = Zeal::GameUI::InvSlotWnd::default_vtable;

--- a/Zeal/ui_hide_fake_slots.cpp
+++ b/Zeal/ui_hide_fake_slots.cpp
@@ -101,6 +101,9 @@ UI_HideFakeSlots::UI_HideFakeSlots(ZealService *zeal)
   vtable->HandleLButtonUp = InvSlotWnd_HandleLButtonUp;
   mem::reset_memory_protection(vtable);
 
+  // Initial update when entring world
+  zeal->callbacks->AddGeneric([this]() { check_and_update(); }, callback_type::InitUI);
+
   // Trigger update when an item is received from the server (purchase/quest/loot/etc)
   zeal->callbacks->AddPacket([this](UINT opcode, char *buffer, UINT len) -> bool {
     if (opcode == 0x4031 && this->Enabled.get())

--- a/Zeal/ui_hide_fake_slots.cpp
+++ b/Zeal/ui_hide_fake_slots.cpp
@@ -1,0 +1,104 @@
+#include "ui_hide_fake_slots.h"
+
+#include "callbacks.h"
+#include "game_addresses.h"
+#include "game_functions.h"
+#include "game_ui.h"
+#include "zeal.h"
+
+typedef int(__thiscall *HandleLButtonUp_fn)(Zeal::GameUI::InvSlotWnd *, int, int, unsigned int);
+static HandleLButtonUp_fn next_HandleLButtonUp = nullptr;
+
+static int __fastcall InvSlotWnd_HandleLButtonUp(Zeal::GameUI::InvSlotWnd *wnd,
+                                                  void *unused_edx, int mouse_x,
+                                                  int mouse_y, unsigned int flags) {
+  // Trigger a visibility update when a pack slot is clicked,
+  //   for if a bag was added/removed
+
+  int result = next_HandleLButtonUp(wnd, mouse_x, mouse_y, flags);
+
+  auto *zeal = ZealService::get_instance();
+  if (!zeal->ui_hide_fake_slots || !zeal->ui_hide_fake_slots->Enabled.get()) return result;
+
+  int slot_id = wnd->SlotID;
+
+  // Only run if a valid bag slot was clicked
+  if (slot_id >= GAME_PACKS_SLOTS_START && slot_id <= GAME_PACKS_SLOTS_END) {
+    // Call with delay so that game has time to update
+    ZealService::get_instance()->callbacks->AddDelayed([]() {
+      auto zeal = ZealService::get_instance();
+      if (zeal->ui_hide_fake_slots)
+        zeal->ui_hide_fake_slots->update_slot_visibility();
+    }, 50);
+  }
+
+  return result;
+}
+
+void UI_HideFakeSlots::update_slot_visibility() {
+  // Hides or shows inventory slots based on the parent bag's capacity
+
+  auto *inv_slot_mgr = Zeal::Game::Windows->InvSlotMgr;
+  if (!inv_slot_mgr) return;
+  auto *char_info = Zeal::Game::get_char_info();
+  if (!char_info) return;
+
+  // Walk the slot array and update any container sub-slots found
+  for (int i = 0; i < 450; ++i) {  // 450 as per struct CInvSlotMgr
+    auto *inv_slot = inv_slot_mgr->InvSlots[i];
+
+    // Skip non-relevant slots
+    if ((DWORD)inv_slot < 0x10000) continue;
+    if (IsBadReadPtr(inv_slot, sizeof(Zeal::GameUI::InvSlot))) continue;
+    if (IsBadReadPtr(inv_slot->invSlotWnd, sizeof(Zeal::GameUI::InvSlotWnd))) continue;
+
+    int slot_id = inv_slot->invSlotWnd->SlotID;
+    if (slot_id < GAME_CONTAINER_SLOTS_START || slot_id > GAME_CONTAINER_SLOTS_END) continue;
+
+    int offset    = slot_id - GAME_CONTAINER_SLOTS_START;
+    int bag_slot  = offset / GAME_NUM_CONTAINER_SLOTS;
+    int bag_index = offset % GAME_NUM_CONTAINER_SLOTS;
+
+    auto *bag_item = char_info->InventoryPackItem[bag_slot];
+    int capacity = (bag_item && bag_item->Type == 1) ? bag_item->Container.Capacity : 0;
+
+    bool show = !Enabled.get() || (bag_index < capacity);
+    inv_slot->invSlotWnd->show(show ? 1 : 0, false);
+  }
+}
+
+UI_HideFakeSlots::UI_HideFakeSlots(ZealService *zeal)
+    : Enabled(false, "Zeal", "HideFakeSlots", false, [this](const bool &value) {
+        update_slot_visibility(); }) {  // Unhide slots if changed from Enabled to Disabled
+
+  // Save current vtable
+  auto *vtable = Zeal::GameUI::InvSlotWnd::default_vtable;
+  next_HandleLButtonUp = (HandleLButtonUp_fn)(vtable->HandleLButtonUp);
+
+  mem::unprotect_memory(vtable, sizeof(*vtable));
+  vtable->HandleLButtonUp = InvSlotWnd_HandleLButtonUp;
+  mem::reset_memory_protection(vtable);
+
+  // Update slot visibility on a timer as a fallback
+  zeal->callbacks->AddGeneric([this]() {
+    if (!Enabled.get()) return;
+
+    static DWORD last_check = 0;
+    DWORD now = GetTickCount();
+    if (now - last_check > 2000) {
+      last_check = now;
+      update_slot_visibility();
+    }
+  }, callback_type::MainLoop);
+}
+
+
+UI_HideFakeSlots::~UI_HideFakeSlots() {
+  auto *vtable = Zeal::GameUI::InvSlotWnd::default_vtable;
+  mem::unprotect_memory(vtable, sizeof(*vtable));
+  vtable->HandleLButtonUp = (LPVOID)next_HandleLButtonUp;
+  mem::reset_memory_protection(vtable);
+
+  Enabled.set(false, false);  // Disable without saving to ini
+  update_slot_visibility();
+}

--- a/Zeal/ui_hide_fake_slots.cpp
+++ b/Zeal/ui_hide_fake_slots.cpp
@@ -99,7 +99,9 @@ UI_HideFakeSlots::UI_HideFakeSlots(ZealService *zeal)
   mem::reset_memory_protection(vtable);
 
   // Initial update when entring world
-  zeal->callbacks->AddGeneric([this]() { check_and_update(); }, callback_type::InitUI);
+  zeal->callbacks->AddGeneric([this]() {
+    if (this->Enabled.get()) update_slot_visibility();
+  }, callback_type::InitUI);
 
   // Trigger update when an item is received from the server (purchase/quest/loot/etc)
   zeal->callbacks->AddPacket([this](UINT opcode, char *buffer, UINT len) -> bool {

--- a/Zeal/ui_hide_fake_slots.cpp
+++ b/Zeal/ui_hide_fake_slots.cpp
@@ -68,10 +68,7 @@ void UI_HideFakeSlots::update_slot_visibility() {
   for (int i = 0; i < 450; ++i) {  // 450 as per struct CInvSlotMgr
     auto *inv_slot = inv_slot_mgr->InvSlots[i];
 
-    // Skip non-relevant slots
-    if ((DWORD)inv_slot < 0x10000) continue;
-    if (IsBadReadPtr(inv_slot, sizeof(Zeal::GameUI::InvSlot))) continue;
-    if (IsBadReadPtr(inv_slot->invSlotWnd, sizeof(Zeal::GameUI::InvSlotWnd))) continue;
+    if ( !inv_slot || !inv_slot->invSlotWnd ) continue;
 
     int slot_id = inv_slot->invSlotWnd->SlotID;
     if (slot_id < GAME_CONTAINER_SLOTS_START || slot_id > GAME_CONTAINER_SLOTS_END) continue;

--- a/Zeal/ui_hide_fake_slots.h
+++ b/Zeal/ui_hide_fake_slots.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "callbacks.h"
+#include "zeal_settings.h"
+
+class ZealService;
+
+class UI_HideFakeSlots {
+ public:
+  UI_HideFakeSlots(ZealService* zeal);
+  ~UI_HideFakeSlots();
+
+  ZealSetting<bool> Enabled;
+  void update_slot_visibility();
+};

--- a/Zeal/ui_hide_fake_slots.h
+++ b/Zeal/ui_hide_fake_slots.h
@@ -11,4 +11,8 @@ class UI_HideFakeSlots {
 
   ZealSetting<bool> Enabled;
   void update_slot_visibility();
+  void check_and_update();
+
+ private:
+  int cached_pack_slot_ids[GAME_NUM_INVENTORY_PACK_SLOTS] = {};
 };

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -30,6 +30,7 @@
 #include "target_ring.h"
 #include "tellwindows.h"
 #include "tooltip.h"
+#include "ui_hide_fake_slots.h"
 #include "ui_manager.h"
 #include "ui_skin.h"
 #include "utils.h"
@@ -514,6 +515,9 @@ void ui_options::InitGeneral() {
   });
   ui->AddCheckboxCallback(wnd, "Zeal_LeftClickCon", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->camera_mods->setting_leftclickcon.set(wnd->Checked);
+  });
+  ui->AddCheckboxCallback(wnd, "Zeal_HideFakeSlots", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->ui_hide_fake_slots->Enabled.set(wnd->Checked);
   });
   ui->AddComboCallback(wnd, "Zeal_Timestamps_Combobox", [](Zeal::GameUI::BasicWnd *wnd, int value) {
     ZealService::get_instance()->chat_hook->TimeStampsStyle.set(value);
@@ -1027,6 +1031,7 @@ void ui_options::UpdateOptionsGeneral() {
   ui->SetChecked("Zeal_ExportOnCamp", ZealService::get_instance()->outputfile->setting_export_on_camp.get());
   ui->SetChecked("Zeal_SelfClickThru", ZealService::get_instance()->camera_mods->setting_selfclickthru.get());
   ui->SetChecked("Zeal_LeftClickCon", ZealService::get_instance()->camera_mods->setting_leftclickcon.get());
+  ui->SetChecked("Zeal_HideFakeSlots", ZealService::get_instance()->ui_hide_fake_slots->Enabled.get());
   ui->SetChecked("Zeal_ClassicClasses", ZealService::get_instance()->chat_hook->UseClassicClassNames.get());
   ui->SetLabelValue("Zeal_VersionValue", "%s (%s)", ZEAL_VERSION, ZEAL_BUILD_VERSION);
   ui->SetChecked("Zeal_BlueCon", ZealService::get_instance()->chat_hook->UseBlueCon.get());

--- a/Zeal/uifiles/zeal/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_General.xml
@@ -1890,6 +1890,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_HideFakeSlots">
+    <ScreenID>Zeal_HideFakeSlots</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>360</X>
+      <Y>552</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Hide invalid bag slots for All-Bags-In-One UIs</TooltipReference>
+    <Text>Hide Fake Bag Slots</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   <!-- end -->
     
   <Page item="Tab_General">
@@ -1981,6 +2012,7 @@
     <Pieces>Zeal_BuffClickThru</Pieces>
     <Pieces>Zeal_AbbreviatedChat</Pieces>
     <Pieces>Zeal_ClassChatColors</Pieces>
+    <Pieces>Zeal_HideFakeSlots</Pieces>
     <Location>
       <X>0</X>
       <Y>22</Y>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_General.xml
@@ -1890,6 +1890,37 @@
     </ButtonDrawTemplate>
   </Button>
 
+  <Button item="Zeal_HideFakeSlots">
+    <ScreenID>Zeal_HideFakeSlots</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>720</X>
+      <Y>1104</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Hide invalid bag slots for All-Bags-In-One UIs</TooltipReference>
+    <Text>Hide Fake Bag Slots</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+
   
     
   <Page item="Tab_General">
@@ -1981,6 +2012,7 @@
     <Pieces>Zeal_BuffClickThru</Pieces>
     <Pieces>Zeal_AbbreviatedChat</Pieces>
     <Pieces>Zeal_ClassChatColors</Pieces>
+    <Pieces>Zeal_HideFakeSlots</Pieces>
     <Location>
       <X>0</X>
       <Y>44</Y>

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -56,6 +56,7 @@
 #include "tick.h"
 #include "tooltip.h"
 #include "triggers.h"
+#include "ui_hide_fake_slots.h"
 #include "ui_manager.h"
 #include "ui_skin.h"
 #include "utils.h"
@@ -158,6 +159,7 @@ ZealService::ZealService() {
   chat_hook = MakeCheckedUnique(Chat);              // Uses chatfilter.
   raid_bars = MakeCheckedUnique(RaidBars);          // Uses entity_manager, callbacks.
   triggers = MakeCheckedUnique(Triggers);           // Uses chat_hook.
+  ui_hide_fake_slots = MakeCheckedUnique(UI_HideFakeSlots);
   nameplate = MakeCheckedUnique(NamePlate);         // Uses target ring blink rate, chat, chatfilter.
   tells = MakeCheckedUnique(TellWindows);           // Uses new UI ChatManager.
   looting_hook = MakeCheckedUnique(Looting);        // Uses new UI Loot window (and ChatManager).

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -77,6 +77,7 @@ class ZealService {
   std::unique_ptr<class EquipItem> equip_item_hook = nullptr;
   std::unique_ptr<class chatfilter> chatfilter_hook = nullptr;
   std::unique_ptr<class Chat> chat_hook = nullptr;
+  std::unique_ptr<class UI_HideFakeSlots> ui_hide_fake_slots = nullptr;
   std::unique_ptr<class NamePlate> nameplate = nullptr;
   std::unique_ptr<class TellWindows> tells = nullptr;
   std::unique_ptr<class Looting> looting_hook = nullptr;


### PR DESCRIPTION
Some UIs support an All-In-One option for inventories e.g. [NillipussUI](https://github.com/NilliP/NillipussUI_1440p/tree/master/NillipussUI_1440p/Options/All%20Bags%20Inventory%20%26%20Full%20item%20hotbar).

These UIs display 10 slots for all bags regardless of bag size, or if a bag is even in the inventory slot. Currently if you attempt to place an item in a non-existent slot, the client will disconnect to prevent item loss.

Added an option to hide any non-existent / fake slots. This blocks the ability to click on these slots, and makes it easier to identify how many slots each bag has.