### PR TITLE
Fix name length for GetCrossZoneInviteName

### DIFF
--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -67,7 +67,7 @@ std::string GetCrossZoneInviteName(const std::string &data) {
   } else {
     // Handle normal messages
     first_space = data.find_first_of(" ", start_pos);
-    inviter = data.substr(start_pos, first_space);
+    inviter = data.substr(start_pos, first_space - start_pos);
   }
 
   std::string invite_msg = data.substr(first_space + 1);


### PR DESCRIPTION
Name was including extra characters when timestamps were enabled.