### PR TITLE
S44: Bug #7 pitch clamp +/-60 -> +/-90 + Bug #2 alt-tab focus-transition DIAGNOSE log

### DIFF
--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -132,6 +132,7 @@
     <ClInclude Include="callbacks.h" />
     <ClInclude Include="memory.h" />
     <ClInclude Include="camera_mods.h" />
+    <ClInclude Include="lmb_pan.h" />
     <ClInclude Include="instruction_length.h" />
     <ClInclude Include="netstat.h" />
     <ClInclude Include="outputfile.h" />
@@ -212,6 +213,7 @@
     <ClCompile Include="callbacks.cpp" />
     <ClCompile Include="memory.cpp" />
     <ClCompile Include="camera_mods.cpp" />
+    <ClCompile Include="lmb_pan.cpp" />
     <ClCompile Include="netstat.cpp" />
     <ClCompile Include="outputfile.cpp" />
     <ClCompile Include="raid.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClInclude Include="camera_mods.h">
       <Filter>Header Files\hooks</Filter>
     </ClInclude>
+    <ClInclude Include="lmb_pan.h">
+      <Filter>Header Files\hooks</Filter>
+    </ClInclude>
     <ClInclude Include="find_pattern.h">
       <Filter>Header Files\memory</Filter>
     </ClInclude>
@@ -318,6 +321,9 @@
       <Filter>Source Files\helpers</Filter>
     </ClCompile>
     <ClCompile Include="camera_mods.cpp">
+      <Filter>Source Files\hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="lmb_pan.cpp">
       <Filter>Source Files\hooks</Filter>
     </ClCompile>
     <ClCompile Include="find_pattern.cpp">

--- a/Zeal/dllmain.cpp
+++ b/Zeal/dllmain.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "lmb_pan.h"
 #include "zeal.h"
 
 // Layer 0 addresses ported from 2002 client to RoF2 (Session 9 Ghidra work,
@@ -50,6 +51,18 @@ static const int load_options_call_jump_value_unpatched = 0x0000e9c1;
 // MouseSensitivity slider, the 8-bucket formula, and every other consumer of
 // DAT_009c7328 stay untouched. See memory/feedback_player_benefit_first.md.
 #define ZEAL_ROF2_R3_HV_PARITY 1
+
+// R3 Stage 2: LMB-pan on the vanilla 3rd-person camera. Session 14 empirical
+// mode probe identified mode 6 (S13 called it "overhead/TotalCameras",
+// disproven) as the actual vanilla scroll-out 3rd-person camera. This patch
+// installs a wrapper on mode 6's class vtable slot 0x08 that applies
+// g_yaw_offset to the camera's heading-delta math via "Approach E" (see
+// lmb_pan.cpp header). With g_yaw_offset = 0 the wrapper is byte-pass-through
+// to vanilla; non-zero offsets orbit the camera around the player anchor
+// without touching player heading. Follow-up commit wires the per-frame
+// LMB-no-RMB input poll + state machine + snap-back lerp that drives the
+// offset. See PHASE1_CAMERA.md.
+#define ZEAL_ROF2_R3_LMB_PAN 1
 
 // Our replacement constant. The linker places this in Zeal.asi's .rdata and
 // gives it a stable runtime address; the DLL is pinned for the process
@@ -189,6 +202,12 @@ static void handle_process_attach() {
     // Signature mismatch: silently skip. Y axis stays vanilla 2:1. Better
     // than risking a patch on an unexpected eqgame.exe build.
   }
+#endif
+
+#if ZEAL_ROF2_R3_LMB_PAN
+  // R3 Stage 2 MVP: patch chase camera vtable slot 0x08. Signature-gated
+  // inside lmb_pan::install — silently no-ops on mismatch.
+  lmb_pan::install(aslr_delta);
 #endif
 }
 

--- a/Zeal/dllmain.cpp
+++ b/Zeal/dllmain.cpp
@@ -25,14 +25,47 @@ static const uintptr_t load_options_call_addr_ghidra = 0x0053621a;
 static const uintptr_t load_options_func_addr_ghidra = 0x00544be0;
 static const int load_options_call_jump_value_unpatched = 0x0000e9c1;
 
-// Set to 1 during Layer 0 verification: prove the patched CALL reaches
-// initialize_zeal() without booting any submodule that still uses 2002-client
-// addresses from game_addresses.h. Flip to 0 in R3 when modules come online.
+// Set to 1 to keep ZealService::create() gated off. ZealService brings up the
+// full Zeal submodule tree (camera_mods, chatfilter, nameplate, etc.) and each
+// submodule still references 2002-client addresses via game_addresses.h. Flip
+// to 0 only after enough submodules have been RoF2-ported that ZealService
+// can safely come up.
 #define ZEAL_ROF2_LAYER0_VALIDATION 1
 
-// Set to 1 to pop a DllMain-time MessageBox showing runtime base, ASLR delta,
-// and the byte values at the (adjusted) CALL site. Triage tool — flip off in R3.
-#define ZEAL_ROF2_LAYER0_DIAGNOSE 1
+// Set to 1 to pop the two Layer 0 diagnostic MessageBoxes ([1/2] DllMain
+// showing runtime base + ASLR delta + signature decision, [2/2] in
+// initialize_zeal confirming the patched CALL reached us). On for active
+// dev; off for production / friend-ready builds.
+#define ZEAL_ROF2_LAYER0_DIAGNOSE 0
+
+// R3 Stage 1: H/V mouse-sensitivity parity patch. Inside FUN_00516d40 (RoF2
+// procMouse-equivalent), the Y-axis FMUL at 0x00516ff6 multiplies by 256.0
+// while the X-axis FMUL elsewhere multiplies by 512.0 — a hardcoded 2:1
+// disparity that's the real source of EQ's "vertical mouse feels slower than
+// horizontal." The 256.0 literal at DAT_009c7328 is shared by 19 other
+// functions in the binary (color/buffer/RTTI uses), so we can't patch the
+// literal itself. Instead we redirect this one FMUL's 4-byte displacement
+// field to point at our own 512.0 constant (k_r3_y_scale, below) which lives
+// in this DLL's .rdata. Single 4-byte write per process; the in-game
+// MouseSensitivity slider, the 8-bucket formula, and every other consumer of
+// DAT_009c7328 stay untouched. See memory/feedback_player_benefit_first.md.
+#define ZEAL_ROF2_R3_HV_PARITY 1
+
+// Our replacement constant. The linker places this in Zeal.asi's .rdata and
+// gives it a stable runtime address; the DLL is pinned for the process
+// lifetime (initialize_zeal calls GetModuleHandleExA with FLAG_PIN), so the
+// address is valid forever after handle_process_attach() runs.
+static const float k_r3_y_scale = 512.0f;
+
+// Y-axis FMUL instruction inside FUN_00516d40. Expected bytes:
+//   D8 0D 28 73 9c 00   FMUL dword ptr [DAT_009c7328]
+// The 4-byte displacement to patch lives at offset +2 from the opcode.
+// At runtime the displacement bytes are RELOCATED by the PE loader to
+// reflect ASLR — so the unpatched runtime value equals (ghidra + aslr_delta).
+static const uintptr_t r3_y_fmul_addr_ghidra = 0x00516ff6;
+static const uint8_t r3_y_fmul_opcode_byte_0 = 0xD8;  // FMUL m32
+static const uint8_t r3_y_fmul_opcode_byte_1 = 0x0D;  // mod=00, reg=001, r/m=101 (disp32)
+static const uintptr_t r3_y_fmul_disp_unpatched_ghidra = 0x009c7328;  // DAT_009c7328
 
 static void __fastcall initialize_zeal(void *this_game, int unused_edx) {
   // Pin the DLL: Miles otherwise unloads/reloads on each char-select transition.
@@ -44,15 +77,15 @@ static void __fastcall initialize_zeal(void *this_game, int unused_edx) {
   // ZealService::create() is internally singleton-guarded as a backstop.
   static bool zeal_service_created = false;
   if (!zeal_service_created) {
-#if ZEAL_ROF2_LAYER0_VALIDATION
+#if !ZEAL_ROF2_LAYER0_VALIDATION
+    ZealService::create();
+#endif
+#if ZEAL_ROF2_LAYER0_DIAGNOSE
     MessageBoxA(NULL,
                 "Patched CALL reached initialize_zeal() successfully.\n"
-                "ZealService::create() is gated off for Layer 0 validation.\n"
                 "Chaining to original loadOptions next.",
                 "Zeal-RoF2 Layer 0 [2/2] initialize_zeal",
                 MB_OK | MB_ICONINFORMATION);
-#else
-    ZealService::create();
 #endif
     zeal_service_created = true;
   }
@@ -127,6 +160,36 @@ static void handle_process_attach() {
   *ptr_jump_value = jump_value;
   VirtualProtect((LPVOID)ptr_jump_value, 4, old, &old);
   FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<PVOID *>(ptr_jump_value), 4);
+
+#if ZEAL_ROF2_R3_HV_PARITY
+  // R3 Stage 1: redirect FUN_00516d40's Y-axis FMUL from [DAT_009c7328] (256.0,
+  // shared) to [&k_r3_y_scale] (our 512.0). Single 4-byte write to the
+  // instruction's displacement field at runtime address (0x00516ff8 + delta).
+  {
+    const uintptr_t y_fmul_runtime = r3_y_fmul_addr_ghidra + aslr_delta;
+    const uint8_t *y_op = reinterpret_cast<const uint8_t *>(y_fmul_runtime);
+    uint32_t *y_disp = reinterpret_cast<uint32_t *>(y_fmul_runtime + 2);
+
+    // The instruction's displacement is an absolute address, so the PE loader
+    // applies the ASLR delta to it during relocation. Compare against the
+    // relocated value, not the static Ghidra view.
+    const uint32_t y_disp_expected =
+        static_cast<uint32_t>(r3_y_fmul_disp_unpatched_ghidra + aslr_delta);
+
+    if (y_op[0] == r3_y_fmul_opcode_byte_0 && y_op[1] == r3_y_fmul_opcode_byte_1 &&
+        *y_disp == y_disp_expected) {
+      const uint32_t new_disp =
+          static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&k_r3_y_scale));
+      DWORD r3_old;
+      VirtualProtect(y_disp, 4, PAGE_EXECUTE_READWRITE, &r3_old);
+      *y_disp = new_disp;
+      VirtualProtect(y_disp, 4, r3_old, &r3_old);
+      FlushInstructionCache(GetCurrentProcess(), y_disp, 4);
+    }
+    // Signature mismatch: silently skip. Y axis stays vanilla 2:1. Better
+    // than risking a patch on an unexpected eqgame.exe build.
+  }
+#endif
 }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {

--- a/Zeal/dllmain.cpp
+++ b/Zeal/dllmain.cpp
@@ -64,11 +64,22 @@ static const int load_options_call_jump_value_unpatched = 0x0000e9c1;
 // offset. See PHASE1_CAMERA.md.
 #define ZEAL_ROF2_R3_LMB_PAN 1
 
-// Our replacement constant. The linker places this in Zeal.asi's .rdata and
-// gives it a stable runtime address; the DLL is pinned for the process
-// lifetime (initialize_zeal calls GetModuleHandleExA with FLAG_PIN), so the
-// address is valid forever after handle_process_attach() runs.
-static const float k_r3_y_scale = 512.0f;
+// Our replacement constant. The linker places this in Zeal.asi's writable
+// data segment (the const-ness is dropped so handle_process_attach can write
+// to it at install time without VirtualProtect), and gives it a stable
+// runtime address; the DLL is pinned for the process lifetime
+// (initialize_zeal calls GetModuleHandleExA with FLAG_PIN), so the address
+// is valid forever after handle_process_attach() runs.
+//
+// Default 512.0 = the value Session 12 chose to match the X-axis FMUL's
+// hardcoded 512.0. handle_process_attach() rewrites this at install time to
+// the aspect-correct value based on the user's screen dimensions — the
+// procMouse formula  Y = mult * (dy / y_span) * y_scale  has a built-in
+// y_span/x_span asymmetry on non-square viewports (1.78× for 16:9), so
+// matching X's 512.0 actually *overshoots* parity. The corrected formula is
+//   y_scale = 512.0 * (screen_height / screen_width)
+// → 288 for 16:9, 320 for 16:10, 384 for 4:3.
+static float k_r3_y_scale = 512.0f;
 
 // Y-axis FMUL instruction inside FUN_00516d40. Expected bytes:
 //   D8 0D 28 73 9c 00   FMUL dword ptr [DAT_009c7328]
@@ -176,7 +187,21 @@ static void handle_process_attach() {
 
 #if ZEAL_ROF2_R3_HV_PARITY
   // R3 Stage 1: redirect FUN_00516d40's Y-axis FMUL from [DAT_009c7328] (256.0,
-  // shared) to [&k_r3_y_scale] (our 512.0). Single 4-byte write to the
+  // shared) to [&k_r3_y_scale] (our aspect-corrected scale). Calibrate the
+  // scale FIRST so the patched instruction sees the right value on its first
+  // read. procMouse's formula  Y = mult * (dy / y_span) * y_scale  has a
+  // built-in y_span/x_span asymmetry on non-square viewports — Session 12's
+  // 512.0 (matching X) overcorrected; the aspect-correct value compensates.
+  {
+    const int sw = GetSystemMetrics(SM_CXSCREEN);
+    const int sh = GetSystemMetrics(SM_CYSCREEN);
+    if (sw > 0 && sh > 0) {
+      k_r3_y_scale = 512.0f * (static_cast<float>(sh) / static_cast<float>(sw));
+    }
+    // else: leave at 512.0f default (no metrics available — unlikely).
+  }
+
+  // Now install the FMUL displacement patch. Single 4-byte write to the
   // instruction's displacement field at runtime address (0x00516ff8 + delta).
   {
     const uintptr_t y_fmul_runtime = r3_y_fmul_addr_ghidra + aslr_delta;

--- a/Zeal/dllmain.cpp
+++ b/Zeal/dllmain.cpp
@@ -1,59 +1,132 @@
 #include <Windows.h>
 
+#include <cstdint>
+
 #include "zeal.h"
 
-// Returns true if it detects that a version of Zeal has already been loaded.
-static bool is_zeal_already_loaded() {
-  // Simple hack check is to see if client sided mana ticking was disabled (since before 0.3.0).
-  // The patch performs: mem::set(0x4C3F93, 0x90, 7);
-  const uint8_t *ptr = reinterpret_cast<uint8_t *>(0x004C3F93);
-  bool already_patched = (*ptr == 0x90);  // Already loaded if set to a nop.
-  return already_patched;
-}
+// Layer 0 addresses ported from 2002 client to RoF2 (Session 9 Ghidra work,
+// see memory/project_zeal_rof2_addresses.md). The pin + patch + chain pattern
+// is unchanged from upstream Zeal.
+//
+// CRITICAL: RoF2's eqgame.exe has DYNAMIC_BASE (ASLR) set in its PE header
+// (the 2002 client did not). Hardcoded Ghidra addresses are relative to the
+// PE preferred base 0x00400000 and must be ADJUSTED by the runtime ASLR delta
+// before dereferencing: runtime = ghidra + (runtime_base - 0x00400000). The
+// delta is computed once in handle_process_attach() and stored in aslr_delta.
+// Our own DLL's function pointers (e.g. &initialize_zeal) are already runtime-
+// correct via the linker, so no adjustment is needed for them.
 
-// The zeal.asi is loaded by the mss which happens in-between the login screen and character select.
-// This is unlike most other libraries that are loaded only once.  In order to avoid
-// loading / unloading with multiple patching cycles, the zeal.asi dll pins itself into memory.
+static const uintptr_t EQGAME_PREFERRED_BASE = 0x00400000;
+static uintptr_t aslr_delta = 0;  // Populated in handle_process_attach().
 
-// There are restrictions on what can be done safely in the dll_attach process, so Zeal creates a replace call
-// hook in the loadOptions() call that happens shortly after the SoundManager loads the dll.
-static const int load_options_call_addr = 0x005282f8;
-static int *const ptr_load_options_call_jump_value = reinterpret_cast<int *>(load_options_call_addr + 1);
-static const int load_options_call_addr_jump_value_unpatched = 0x0000e9e3;
+// Addresses below are Ghidra's static view (preferred base 0x00400000).
+// Add aslr_delta before dereferencing.
+static const uintptr_t load_options_call_addr_ghidra = 0x0053621a;
+static const uintptr_t load_options_func_addr_ghidra = 0x00544be0;
+static const int load_options_call_jump_value_unpatched = 0x0000e9c1;
+
+// Set to 1 during Layer 0 verification: prove the patched CALL reaches
+// initialize_zeal() without booting any submodule that still uses 2002-client
+// addresses from game_addresses.h. Flip to 0 in R3 when modules come online.
+#define ZEAL_ROF2_LAYER0_VALIDATION 1
+
+// Set to 1 to pop a DllMain-time MessageBox showing runtime base, ASLR delta,
+// and the byte values at the (adjusted) CALL site. Triage tool — flip off in R3.
+#define ZEAL_ROF2_LAYER0_DIAGNOSE 1
 
 static void __fastcall initialize_zeal(void *this_game, int unused_edx) {
-  // Pin the zeal DLL into memory until the process terminates, ignoring FreeLibrary calls.
+  // Pin the DLL: Miles otherwise unloads/reloads on each char-select transition.
   static HMODULE hModule = nullptr;
   GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_PIN | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-                     (LPCSTR)&initialize_zeal,  // An address within this module.
-                     &hModule);
+                     (LPCSTR)&initialize_zeal, &hModule);
 
-  // Do not load Zeal if a version has already been loaded. This can happen normally on
-  // subsequent world logins or it can happen if the user has multiple zeal asi files.
-  if (!is_zeal_already_loaded()) {
-    // Create the zeal super-class that installs patches, hooks, callbacks, and things like
-    // the named pipe thread.
+  // Skip re-init on subsequent world logins (each refires the patched CALL).
+  // ZealService::create() is internally singleton-guarded as a backstop.
+  static bool zeal_service_created = false;
+  if (!zeal_service_created) {
+#if ZEAL_ROF2_LAYER0_VALIDATION
+    MessageBoxA(NULL,
+                "Patched CALL reached initialize_zeal() successfully.\n"
+                "ZealService::create() is gated off for Layer 0 validation.\n"
+                "Chaining to original loadOptions next.",
+                "Zeal-RoF2 Layer 0 [2/2] initialize_zeal",
+                MB_OK | MB_ICONINFORMATION);
+#else
     ZealService::create();
+#endif
+    zeal_service_created = true;
   }
 
-  // Call the original loadOptions.
-  reinterpret_cast<void(_fastcall *)(void *, int)>(0x00536ce0)(this_game, unused_edx);
+  // Chain to the original loadOptions so the client gets its INI loaded.
+  const uintptr_t load_options_runtime = load_options_func_addr_ghidra + aslr_delta;
+  reinterpret_cast<void(__fastcall *)(void *, int)>(load_options_runtime)(this_game, unused_edx);
 }
 
 static void handle_process_attach() {
-  // Bail out if already patched (either a previous login cycle or another zeal asi file).
-  if (*ptr_load_options_call_jump_value != load_options_call_addr_jump_value_unpatched) return;
+  // GetModuleHandle(NULL) returns the main exe's HMODULE, which equals its
+  // runtime base address. Compute ASLR delta from that.
+  const HMODULE eqgame_base = GetModuleHandleA(NULL);
+  aslr_delta = reinterpret_cast<uintptr_t>(eqgame_base) - EQGAME_PREFERRED_BASE;
 
-  // Install the patch by replacing the relative jump in a call to loadOptions with a jump
-  // to the initialize_zeal() function.
-  const int end_of_call_addr = load_options_call_addr + 5;
-  const int jump_value = reinterpret_cast<int>(&initialize_zeal) - end_of_call_addr;
+  const uintptr_t call_site = load_options_call_addr_ghidra + aslr_delta;
+  int *const ptr_jump_value = reinterpret_cast<int *>(call_site + 1);
+
+  const uint8_t opcode_byte = *reinterpret_cast<uint8_t *>(call_site);
+  const int current_displacement = *ptr_jump_value;
+
+  const char *decision_str;
+  bool install = false;
+  if (opcode_byte != 0xe8) {
+    decision_str = "SKIP - opcode at CALL site is not 0xe8 (wrong address?)";
+  } else if (current_displacement != load_options_call_jump_value_unpatched) {
+    decision_str = "SKIP - displacement mismatch (already patched OR wrong address)";
+  } else {
+    decision_str = "INSTALL - signature matches, will patch";
+    install = true;
+  }
+
+#if ZEAL_ROF2_LAYER0_DIAGNOSE
+  char module_path[MAX_PATH] = {0};
+  HMODULE self = nullptr;
+  GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                     (LPCSTR)&handle_process_attach, &self);
+  GetModuleFileNameA(self, module_path, sizeof(module_path));
+
+  char msg[1024];
+  wsprintfA(msg,
+            "Module loaded: %s\r\n"
+            "\r\n"
+            "eqgame.exe runtime base: 0x%08x (preferred: 0x%08x)\r\n"
+            "ASLR delta: 0x%08x\r\n"
+            "\r\n"
+            "CALL site (ghidra 0x%08x -> runtime 0x%08x):\r\n"
+            "  Opcode byte: 0x%02x (expected 0xe8 = near CALL)\r\n"
+            "  Displacement: 0x%08x (expected unpatched: 0x%08x)\r\n"
+            "\r\n"
+            "Decision: %s",
+            module_path,
+            (uintptr_t)eqgame_base,
+            EQGAME_PREFERRED_BASE,
+            aslr_delta,
+            load_options_call_addr_ghidra,
+            call_site,
+            opcode_byte,
+            current_displacement,
+            load_options_call_jump_value_unpatched,
+            decision_str);
+  MessageBoxA(NULL, msg, "Zeal-RoF2 Layer 0 [1/2] DllMain", MB_OK | MB_ICONINFORMATION);
+#endif
+
+  if (!install) return;
+
+  const uintptr_t end_of_call_addr = call_site + 5;
+  const int jump_value = reinterpret_cast<int>(&initialize_zeal) - static_cast<int>(end_of_call_addr);
 
   DWORD old;
-  VirtualProtect((LPVOID)ptr_load_options_call_jump_value, 4, PAGE_EXECUTE_READWRITE, &old);
-  *ptr_load_options_call_jump_value = jump_value;
-  VirtualProtect((LPVOID)ptr_load_options_call_jump_value, 4, old, &old);
-  FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<PVOID *>(ptr_load_options_call_jump_value), 4);
+  VirtualProtect((LPVOID)ptr_jump_value, 4, PAGE_EXECUTE_READWRITE, &old);
+  *ptr_jump_value = jump_value;
+  VirtualProtect((LPVOID)ptr_jump_value, 4, old, &old);
+  FlushInstructionCache(GetCurrentProcess(), reinterpret_cast<PVOID *>(ptr_jump_value), 4);
 }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {
@@ -62,9 +135,9 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
       handle_process_attach();
       break;
     case DLL_PROCESS_DETACH:
-      break;  // The DLL is pinned and is not unloaded until the process terminates.
+      break;  // DLL is pinned; this never fires until process exit.
     default:
-      break;  // Otherwise ignore.
+      break;
   }
   return TRUE;
 }

--- a/Zeal/lmb_pan.cpp
+++ b/Zeal/lmb_pan.cpp
@@ -265,11 +265,16 @@ static const float k_mouse_to_pitch_units = 0.09f;
 
 // Pitch clamp range. cam[0x2c] (a sibling field, not the one we use) is
 // clamped to [0, 30] in mode 5 — circumstantial evidence that EQ pitches
-// live in roughly the [0, 30] range. We allow ±60 here (wider than circum-
-// stantial guess) so first empirical test can see whether cam[0x30] reaches
-// position compute at all; narrow once we know the working range.
-static const float k_pitch_offset_min = -60.0f;
-static const float k_pitch_offset_max =  60.0f;
+// live in roughly the [0, 30] range. We initially allowed ±60 in S15 to
+// confirm cam[0x30] reaches position compute at all; Alex S44 reported
+// hitting the clamp in normal play (vertical pan stall), so bumped to
+// ±90 to give a full quarter-turn each direction. cam[0x30]'s unit is
+// still empirically unconfirmed (FUN_00799140 reads it through a trig
+// vtable so could be radians or degrees); the DIAGNOSE_PER_FRAME log
+// records cam[0x30]_written each frame so we can narrow further once the
+// unit is nailed down.
+static const float k_pitch_offset_min = -90.0f;
+static const float k_pitch_offset_max =  90.0f;
 
 // --- File-log diagnostics ---
 // Why a file log instead of MessageBox: the wrapper hides the cursor on
@@ -469,11 +474,34 @@ static void exit_to_idle_snapping_back() {
 }
 
 static void poll_input() {
+  const bool has_focus = eq_has_foreground_focus();
+
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  // S44 Bug #2 investigation: log every focus-state transition with full
+  // state context. Helps confirm on an alt-tab cycle whether (a) the
+  // focus-loss demotion to HELD (PANNING path) actually fires, and (b) the
+  // first-RMB-after-regain is being seen by poll_input. If RMB-snap-back
+  // is broken post-regain (bug #2), the log will show whether RMB was
+  // even observed. Pair with the existing [post-snap N] log to capture
+  // the full alt-tab → RMB-snap-back → 90-frame-drift sequence.
+  static bool s_prev_has_focus = true;
+  if (has_focus != s_prev_has_focus) {
+    const char *state_name = (g_state == lmb_state::IDLE)    ? "IDLE"
+                           : (g_state == lmb_state::PENDING) ? "PENDING"
+                           : (g_state == lmb_state::PANNING) ? "PANNING"
+                                                              : "HELD";
+    diag_logf("[focus] EQ -> %s (state=%s yaw=%+.3f pitch=%+.3f hides=%d)\n",
+              has_focus ? "FOREGROUND" : "background",
+              state_name, g_yaw_offset, g_pitch_offset, g_hides_applied);
+    s_prev_has_focus = has_focus;
+  }
+#endif
+
   // Focus gate: if EQ is in the background, do nothing — GetAsyncKeyState
   // reads global key state, so clicks in other apps would otherwise enter
   // our state machine. Also release any lingering ClipCursor so the user's
   // other apps work normally.
-  if (!eq_has_foreground_focus()) {
+  if (!has_focus) {
     // Always release ClipCursor on background — cheap idempotent call,
     // ensures we never leave the clip lingering across alt-tab.
     ClipCursor(nullptr);

--- a/Zeal/lmb_pan.cpp
+++ b/Zeal/lmb_pan.cpp
@@ -89,6 +89,13 @@
 // the install popup would otherwise fire every DLL load, and the log file
 // would grow unbounded across play sessions.
 #define ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE 0
+// Sub-flag: the [pan-frame N] per-wrapper-call log fires from inside the
+// camera wrapper, which runs multiple times per visual frame. With the
+// per-call fflush in diag_logf this caused enough synchronous disk I/O to
+// visibly throttle the renderer ("camera feels wild / spins erratically").
+// Default OFF so the lighter state-transition logs can stay enabled. Flip to
+// 1 only when investigating per-frame yaw/pitch math.
+#define ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE_PER_FRAME 0
 
 namespace lmb_pan {
 
@@ -217,6 +224,16 @@ static bool g_pitch_restore_pending = false; // Set on exit; wrapper restores on
 static POINT g_pre_set_cursor = {0, 0};
 static bool g_recenter_pending = false;
 
+// Post-snap-back diagnostic: after RMB triggers a snap-back out of PANNING
+// or PENDING-with-offsets, log the next N wrapper frames. We want to confirm
+// whether EQ's "both buttons held = autorun forward" engages while the user
+// is still physically holding LMB+RMB. If autorun engaged we'll see cam[1..3]
+// (position) drift forward across frames; if not, position stays steady.
+// Also captures the raw GetAsyncKeyState(VK_LBUTTON/VK_RBUTTON) bits so we
+// can confirm Windows still reports both as held post-snap-back.
+static int g_post_snap_log_remaining = 0;
+static const int k_post_snap_log_frames = 90;  // ~1.5s at 60fps
+
 // Pixel-distance threshold before LMB-down commits to a pan (vs being a
 // click). WoW uses a "tiny hidden distance" — just enough to filter hand
 // tremor on a deliberate click, not a deliberate intent gate. Starting at
@@ -266,19 +283,28 @@ static const float k_pitch_offset_max =  60.0f;
 // (before any cursor hide), so it's still safely clickable.
 static FILE *g_diag_log = nullptr;
 
+// NOTE: no per-call fflush. Calling fflush on every line caused a
+// synchronous disk write per call — and the wrapper runs multiple times per
+// visual frame, so when this fires from the per-frame log it visibly
+// throttles the renderer (Bitdefender scanning the appended bytes makes it
+// worse). The stdio default line/full buffering is fine here. Call
+// diag_flush() at meaningful boundaries (install end, snap-back, post-snap
+// finish) if you want the on-disk file caught up immediately.
 static void diag_logf(const char *fmt, ...) {
   if (!g_diag_log) {
     g_diag_log = fopen("D:\\EQEmu\\Full_RoF2\\lmb_pan_diag.log", "a");
     if (!g_diag_log) return;
     const time_t now = time(nullptr);
     fprintf(g_diag_log, "\n=== Zeal.asi load: %s", ctime(&now));
-    fflush(g_diag_log);
   }
   va_list ap;
   va_start(ap, fmt);
   vfprintf(g_diag_log, fmt, ap);
   va_end(ap);
-  fflush(g_diag_log);
+}
+
+static void diag_flush() {
+  if (g_diag_log) fflush(g_diag_log);
 }
 
 // UI hit-test (Session 15). Returns true when the LMB-down event should NOT
@@ -358,15 +384,16 @@ static void enter_panning() {
     g_hides_applied++;
     if (new_count < 0) break;
   }
-  // Multi-monitor safety is handled by the 100px edge-recenter guard in
-  // poll_input (PANNING branch), which warps the cursor back to window center
-  // before it reaches any edge. We deliberately do NOT call ClipCursor here:
-  // EQ's WM_RBUTTONDOWN handler activates camera-turn mode (and likely sets
-  // its own ClipCursor) — if Zeal's clip is already active when that message
-  // arrives, EQ's camera-turn setup fails silently, which prevents the
-  // "both buttons held = move forward" mechanic from firing (the RMB-during-
-  // pan → autorun bug reported after v1.2.1).
-  //
+  // Multi-monitor safety: trap the (hidden) cursor inside the game window
+  // so it can't wander onto a second monitor mid-pan. Released on PANNING
+  // exit (enter_held_keeping_offset / exit_to_idle_snapping_back).
+  {
+    HWND fg = GetForegroundWindow();
+    RECT wr;
+    if (fg && GetWindowRect(fg, &wr)) {
+      ClipCursor(&wr);
+    }
+  }
   // Persistence: do NOT reset g_pitch_offset or g_pitch_snapshotted here.
   // They carry over from any prior HELD state, so re-engaging a pan stacks
   // on top of the previously-held angle. Offsets only reset via RMB
@@ -381,6 +408,7 @@ static void enter_panning() {
 // writes cam[0x30] = g_pitch_base + g_pitch_offset; g_pitch_snapshotted
 // stays true, base stays valid).
 static void enter_held_keeping_offset() {
+  ClipCursor(nullptr);  // release multi-monitor trap from enter_panning()
   SetCursorPos(g_lmb_down_cursor.x, g_lmb_down_cursor.y);
   while (g_hides_applied > 0) {
     ShowCursor(TRUE);
@@ -405,6 +433,26 @@ static void exit_to_idle_snapping_back() {
   diag_logf("[pan-snap-back] RMB triggered; was %s, yaw=%+.3f pitch=%+.3f → 0,0\n",
             from, g_yaw_offset, g_pitch_offset);
 #endif
+  // Release the multi-monitor cursor trap if it was set (only PANNING set it;
+  // HELD already released it). Safe to call even if no clip is active.
+  if (g_state == lmb_state::PANNING) {
+    ClipCursor(nullptr);
+  }
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  // Arm post-snap diagnostic so the next ~90 wrapper frames capture button
+  // state + camera position. Useful for diagnosing the "RMB-during-pan does
+  // not engage EQ's both-buttons-held autorun" bug.
+  //
+  // CRITICAL: no diag_flush() here. This function runs on the renderer/
+  // message-pump thread inside the camera wrapper. A synchronous fflush
+  // here stalls Windows message processing for the duration of the disk
+  // write — EQ's WM_RBUTTONDOWN handler can't run until the flush returns,
+  // and a queue of WM_MOUSEMOVE events piles up. When the renderer
+  // catches up, EQ's RMB-look processes the entire batch in one frame and
+  // the camera spins wildly. Let the OS buffer the writes; the log is
+  // flushed at process exit or when stdio's internal buffer fills.
+  g_post_snap_log_remaining = k_post_snap_log_frames;
+#endif
   if (g_hides_applied > 0) {
     SetCursorPos(g_lmb_down_cursor.x, g_lmb_down_cursor.y);
     while (g_hides_applied > 0) {
@@ -426,9 +474,8 @@ static void poll_input() {
   // our state machine. Also release any lingering ClipCursor so the user's
   // other apps work normally.
   if (!eq_has_foreground_focus()) {
-    // Safety net: release any cursor clip on background (cheap no-op if none
-    // is active; guards against EQ's own camera-turn ClipCursor lingering
-    // across alt-tab). Zeal itself no longer calls ClipCursor during panning.
+    // Always release ClipCursor on background — cheap idempotent call,
+    // ensures we never leave the clip lingering across alt-tab.
     ClipCursor(nullptr);
     if (g_state == lmb_state::PANNING) {
       // Restore cursor visibility (it was hidden in enter_panning). DON'T
@@ -589,6 +636,34 @@ static void __fastcall mode_6_wrapper(void *cam, int /*edx_unused*/, int *entity
 
   char *const cam_bytes = reinterpret_cast<char *>(cam);
 
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  // Post-snap-back diagnostic. Logs button state + camera position for the
+  // first k_post_snap_log_frames frames after each RMB-triggered snap-back.
+  // If EQ's "both buttons = autorun" engaged, cam position will drift forward
+  // across these frames (because the player is actually moving). If it
+  // didn't engage, position will be steady. We also log lmb/rmb raw bits so
+  // we can confirm Windows still reports both as physically held.
+  if (g_post_snap_log_remaining > 0) {
+    const int frame_idx = k_post_snap_log_frames - g_post_snap_log_remaining;
+    const bool lmb_now = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+    const bool rmb_now = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
+    const float px = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_x_offset);
+    const float py = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_y_offset);
+    const float pz = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_z_offset);
+    const char *state_name = (g_state == lmb_state::IDLE)    ? "IDLE"
+                           : (g_state == lmb_state::PENDING) ? "PENDING"
+                           : (g_state == lmb_state::PANNING) ? "PANNING"
+                                                              : "HELD";
+    diag_logf("[post-snap %3d] state=%s lmb=%d rmb=%d  "
+              "cam=(%.3f, %.3f, %.3f)\n",
+              frame_idx, state_name, lmb_now ? 1 : 0, rmb_now ? 1 : 0,
+              px, py, pz);
+    g_post_snap_log_remaining--;
+    // Intentionally no diag_flush here — same renderer-thread-stall reason
+    // as in exit_to_idle_snapping_back. Rely on stdio buffer flush at exit.
+  }
+#endif
+
   // PITCH state machine (Session 15, "Approach A", revised r2 for persistence):
   //   On first PANNING frame:   snapshot cam[0x30] → g_pitch_base.
   //   While PANNING or HELD:    write cam[0x30] = g_pitch_base + g_pitch_offset.
@@ -641,7 +716,7 @@ static void __fastcall mode_6_wrapper(void *cam, int /*edx_unused*/, int *entity
   // Pre-original capture for the per-frame pitch diagnostic. Captures the
   // first k_max_pan_frames_to_log PANNING frames of every pan; counter resets
   // when the pan ends so each pan starts fresh.
-#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE_PER_FRAME
   static int s_pan_frame_log_count = 0;
   static const int k_max_pan_frames_to_log = 200;
   float diag_pre_x = 0.0f, diag_pre_y = 0.0f, diag_pre_z = 0.0f;
@@ -681,7 +756,7 @@ static void __fastcall mode_6_wrapper(void *cam, int /*edx_unused*/, int *entity
     *dat_703_ptr = saved_dat_703;
   }
 
-#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE_PER_FRAME
   if (diag_log_this_frame) {
     const float post_x = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_x_offset);
     const float post_y = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_y_offset);
@@ -746,6 +821,7 @@ bool install(uintptr_t aslr_delta) {
             match ? "YES" : "NO", match ? "INSTALL" : "SKIP (silent no-op)");
   MessageBoxA(NULL, msg, "Zeal-RoF2 R3 / LMB-pan install diagnostic",
               MB_OK | MB_ICONINFORMATION);
+  diag_flush();
 #endif
 
   if (!match) return false;

--- a/Zeal/lmb_pan.cpp
+++ b/Zeal/lmb_pan.cpp
@@ -1,0 +1,281 @@
+#include "lmb_pan.h"
+
+#include <Windows.h>
+
+#include <cstdint>
+
+// Phase 1 / R2 Layer 2 / LMB-pan implementation. See:
+//   memory/PHASE1_CAMERA.md
+//   memory/project_zeal_rof2_addresses.md (Layer 2 section)
+//
+// Session 14 empirical mapping (overriding Session 13's Zeal-inherited labels):
+//   - Mode 6 (S13: "overhead/TotalCameras") = vanilla scroll-out 3rd-person.
+//     Activated by scrolling out from 1st-person; stays in mode 6 for the
+//     entire 3rd-person zoom range. **Our LMB-pan target.**
+//   - Mode 0 (S13: "FirstPerson") = 1st-person view (camera at character head).
+//   - Mode 7 (3/4/7 shared class) = character select.
+//   - Modes 1/2/3/4/8 = F9-cycle alts (mode 2 in particular = where Zeal
+//     upstream installs `ZealCam` — emphatically NOT our target).
+//
+// Hook: chase camera (mode 6) class vtable at Ghidra 0x009d1188, slot 0x08
+// at vtable + 8 = 0x009d1190, storing pointer to FUN_00799140 (the per-frame
+// camera-position compute). We replace the slot with mode_6_wrapper, which
+// polls LMB-no-RMB input → updates g_yaw_offset → optionally applies the
+// offset before chaining to the original.
+//
+// Yaw strategy = "Approach E" (Session 14 design). FUN_00799140 maintains the
+// camera's heading as a delta from entity rotation:
+//   cam[0x38]_new = cam[0x38]_pre + (entity_heading - cam[0x48])    (delta path)
+//   cam[0x38]_new = entity_heading                                  (snap path,
+//                                                                    DAT_00ddf703!=0)
+// then runs the anchor compute using cam[0x38] (not entity_heading) to place
+// the camera behind a virtual direction. By pre-setting cam[0x48] =
+// entity_heading and cam[0x38] = entity_heading + g_yaw_offset, the delta
+// path produces cam[0x38] = entity_heading + g_yaw_offset post-original, and
+// the anchor compute orbits the camera by g_yaw_offset around the entity
+// without ever touching the entity's actual heading.
+//
+// When g_yaw_offset == 0 the wrapper is a pure pass-through (no cam state
+// mutation). Vanilla 3rd-person is byte-identical to no-patch.
+//
+// Snap-path caveat: when DAT_00ddf703 != 0, the original overwrites cam[0x38]
+// with entity_heading and our offset is lost for that frame. Single-frame
+// visual glitch on transitions; likely imperceptible.
+//
+// Input model for this commit (minimal): per-frame poll inside the wrapper.
+// LMB held without RMB → accumulate mouse X delta into g_yaw_offset. LMB
+// released → snap offset to 0 immediately. No persistence after release, no
+// smooth snap-back lerp, no click-vs-pan disambiguation. Those iterate on
+// top once the basic pan motion is verified.
+//
+// Pitch is NOT handled this commit. Mode 6's anchor compute does not read
+// cam[0x2c] (the pitch field used by mode 2); pitch will need a different
+// injection point and is deferred.
+
+#define ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE 1
+
+namespace lmb_pan {
+
+// Mutated by poll_input() each frame the wrapper runs. Defaults 0 = vanilla.
+// Units: EQ heading units (512 = full turn).
+float g_yaw_offset = 0.0f;
+float g_pitch_offset = 0.0f;  // unused this commit (mode 6 pitch deferred)
+
+// Ghidra static addresses (preferred base 0x00400000). ASLR-adjusted at
+// runtime via the delta passed to install().
+static const uintptr_t k_mode_6_vtable_slot_08_ghidra = 0x009d1190;
+static const uintptr_t k_mode_6_slot_08_original_ghidra = 0x00799140;
+
+// Camera-object field offsets, from Session 14 decompile of FUN_00799140.
+static const size_t k_cam_heading_offset = 0x38;              // field [0xe]
+static const size_t k_cam_prev_entity_heading_offset = 0x48;  // field [0x12]
+
+// Entity field offset for heading. entity[0x20] as int* → byte offset 0x80.
+static const size_t k_entity_heading_byte_offset = 0x80;
+
+using slot_08_fn = void(__fastcall *)(void *cam, int edx_unused, int *entity);
+static slot_08_fn g_original = nullptr;
+
+// Stored at install time so the wrapper can read DAT_00ddf703 (the heading-
+// update path selector) without re-deriving the ASLR delta.
+static uintptr_t g_aslr_delta = 0;
+static const uintptr_t k_dat_00ddf703_ghidra = 0x00ddf703;
+
+// Input state machine. Click-vs-pan disambiguation:
+//   IDLE     — LMB not held (or LMB+RMB, which is vanilla autorun).
+//   PENDING  — LMB just pressed alone; not yet hidden cursor or applied yaw.
+//              Waiting for motion threshold to decide pan-vs-click.
+//   PANNING  — Motion threshold crossed; cursor hidden, yaw accumulating.
+//
+// Transitions:
+//   IDLE → PENDING:    LMB pressed, RMB not pressed.
+//   PENDING → IDLE:    LMB released (was a click — no cursor hide, no yaw).
+//   PENDING → IDLE:    RMB pressed (LMB+RMB = autorun, not pan).
+//   PENDING → PANNING: cursor moved >= 4px from LMB-down position.
+//   PANNING → IDLE:    LMB released OR RMB pressed. Restore cursor + snap yaw.
+//
+// No time threshold: holding LMB still without moving doesn't auto-engage
+// pan. That avoids cursor flicker on slow UI clicks (e.g., 200ms button
+// press) that don't intend to pan.
+enum class lmb_state {
+  IDLE,
+  PENDING,
+  PANNING,
+};
+
+static lmb_state g_state = lmb_state::IDLE;
+static POINT g_lmb_down_cursor = {0, 0};  // Where LMB was first pressed (return-to anchor).
+static POINT g_prev_cursor = {0, 0};      // Frame-to-frame ref during PANNING.
+// ShowCursor is reference-counted (per Windows). EQ may have the count
+// pushed above 0; a single ShowCursor(FALSE) only decrements once. We loop
+// until the count goes < 0, tracking how many decrements we applied so we
+// can balance them on release.
+static int g_hides_applied = 0;
+
+// Pixel-distance threshold before LMB-down commits to a pan (vs being a
+// click). WoW uses a "tiny hidden distance" — just enough to filter hand
+// tremor on a deliberate click, not a deliberate intent gate. Starting at
+// 1px (most responsive — single-pixel motion engages). Bump up only if
+// hand-tremor false-positives trigger pans during normal targeting/UI clicks.
+static const int k_pan_pixel_threshold = 1;
+
+// Sensitivity: yaw units per pixel of cursor X movement. EQ uses 512 = full
+// turn, so 1.0 means 100px drag ≈ 70° rotation. Starting high to make the
+// effect obviously visible; tune down if too aggressive.
+static const float k_mouse_to_yaw_units = 1.0f;
+
+// Anti-spike: clamp the per-frame delta to avoid jumps on mode-switch re-
+// entry (wrapper is called only in mode 6; cursor may have moved a lot
+// while we were in a different mode).
+static const int k_max_dx_per_frame = 50;
+
+static void enter_panning() {
+  // Use the LMB-down cursor as the frame-to-frame reference so the motion
+  // that crossed the threshold (and got us into PANNING) is applied as the
+  // first frame's yaw delta — no "lost" pixels at the start of a pan.
+  g_prev_cursor = g_lmb_down_cursor;
+  g_hides_applied = 0;
+  for (int attempts = 0; attempts < 16; ++attempts) {
+    const int new_count = ShowCursor(FALSE);
+    g_hides_applied++;
+    if (new_count < 0) break;
+  }
+  g_state = lmb_state::PANNING;
+}
+
+static void exit_to_idle_restoring_cursor() {
+  SetCursorPos(g_lmb_down_cursor.x, g_lmb_down_cursor.y);
+  while (g_hides_applied > 0) {
+    ShowCursor(TRUE);
+    g_hides_applied--;
+  }
+  g_yaw_offset = 0.0f;
+  g_state = lmb_state::IDLE;
+}
+
+static void poll_input() {
+  const bool lmb = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+  const bool rmb = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
+
+  switch (g_state) {
+    case lmb_state::IDLE:
+      if (lmb && !rmb) {
+        GetCursorPos(&g_lmb_down_cursor);
+        g_state = lmb_state::PENDING;
+      }
+      break;
+    case lmb_state::PENDING:
+      if (!lmb || rmb) {
+        // LMB released before threshold = click (no cursor hide, no yaw).
+        // OR RMB pressed = LMB+RMB autorun (also not pan). Return to IDLE.
+        g_state = lmb_state::IDLE;
+      } else {
+        POINT current;
+        GetCursorPos(&current);
+        int dx = current.x - g_lmb_down_cursor.x;
+        int dy = current.y - g_lmb_down_cursor.y;
+        if (dx < 0) dx = -dx;
+        if (dy < 0) dy = -dy;
+        if (dx >= k_pan_pixel_threshold || dy >= k_pan_pixel_threshold) {
+          enter_panning();
+        }
+      }
+      break;
+    case lmb_state::PANNING:
+      if (!lmb || rmb) {
+        exit_to_idle_restoring_cursor();
+      } else {
+        POINT current;
+        GetCursorPos(&current);
+        int dx = current.x - g_prev_cursor.x;
+        if (dx > k_max_dx_per_frame) dx = k_max_dx_per_frame;
+        else if (dx < -k_max_dx_per_frame) dx = -k_max_dx_per_frame;
+        // WoW spec: mouse RIGHT rotates camera COUNTER-CLOCKWISE (camera to
+        // the player's LEFT). Subtraction, not addition.
+        g_yaw_offset -= static_cast<float>(dx) * k_mouse_to_yaw_units;
+        if (g_yaw_offset > 256.0f) g_yaw_offset -= 512.0f;
+        else if (g_yaw_offset < -256.0f) g_yaw_offset += 512.0f;
+        g_prev_cursor = current;
+      }
+      break;
+  }
+}
+
+static void __fastcall mode_6_wrapper(void *cam, int /*edx_unused*/, int *entity) {
+  poll_input();
+
+  if (g_yaw_offset != 0.0f) {
+    char *const cam_bytes = reinterpret_cast<char *>(cam);
+    const float entity_heading =
+        *reinterpret_cast<float *>(reinterpret_cast<char *>(entity) +
+                                   k_entity_heading_byte_offset);
+
+    // Approach F (Session 14 diagnostic finding): DAT_00ddf703 is 1 in normal
+    // play, which makes FUN_00799140 take the SNAP path:
+    //     cam[0x38] = entity_heading
+    // unconditionally. That overrides our pre-set every frame. To make our
+    // pre-set survive, temporarily force DAT_00ddf703 = 0 so the delta path
+    // runs:
+    //     cam[0x38] = (entity_heading - cam[0x48]) + cam[0x38]_pre
+    //               = (entity_heading - entity_heading) + (entity_heading + offset)
+    //               = entity_heading + offset      ← survives, anchor uses this.
+    // Restore DAT_00ddf703 after the call so other code that depends on it
+    // sees the original value next frame.
+    unsigned char *const dat_703_ptr = reinterpret_cast<unsigned char *>(
+        k_dat_00ddf703_ghidra + g_aslr_delta);
+    const unsigned char saved_dat_703 = *dat_703_ptr;
+    *dat_703_ptr = 0;
+
+    // Force the original's delta math to produce cam[0x38] = entity_heading +
+    // g_yaw_offset.
+    *reinterpret_cast<float *>(cam_bytes + k_cam_prev_entity_heading_offset) =
+        entity_heading;
+    *reinterpret_cast<float *>(cam_bytes + k_cam_heading_offset) =
+        entity_heading + g_yaw_offset;
+
+    g_original(cam, 0, entity);
+
+    *dat_703_ptr = saved_dat_703;
+  } else {
+    g_original(cam, 0, entity);
+  }
+}
+
+bool install(uintptr_t aslr_delta) {
+  g_aslr_delta = aslr_delta;
+
+  const uintptr_t slot_runtime = k_mode_6_vtable_slot_08_ghidra + aslr_delta;
+  const uintptr_t expected_runtime = k_mode_6_slot_08_original_ghidra + aslr_delta;
+  uintptr_t *const slot_ptr = reinterpret_cast<uintptr_t *>(slot_runtime);
+  const uintptr_t actual = *slot_ptr;
+  const bool match = (actual == expected_runtime);
+
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  char msg[1024];
+  wsprintfA(msg,
+            "Mode 6 (vanilla 3rd-person) vtable slot 0x08 patch:\r\n\r\n"
+            "Vtable slot runtime: 0x%08x\r\n"
+            "Expected original (FUN_00799140 + delta): 0x%08x\r\n"
+            "Actual value at slot: 0x%08x\r\n\r\n"
+            "Signature match: %s\r\n"
+            "Decision: %s",
+            (unsigned)slot_runtime, (unsigned)expected_runtime, (unsigned)actual,
+            match ? "YES" : "NO", match ? "INSTALL" : "SKIP (silent no-op)");
+  MessageBoxA(NULL, msg, "Zeal-RoF2 R3 / LMB-pan install diagnostic",
+              MB_OK | MB_ICONINFORMATION);
+#endif
+
+  if (!match) return false;
+
+  g_original = reinterpret_cast<slot_08_fn>(actual);
+
+  DWORD old_protect;
+  VirtualProtect(slot_ptr, sizeof(uintptr_t), PAGE_READWRITE, &old_protect);
+  *slot_ptr = reinterpret_cast<uintptr_t>(&mode_6_wrapper);
+  VirtualProtect(slot_ptr, sizeof(uintptr_t), old_protect, &old_protect);
+  FlushInstructionCache(GetCurrentProcess(), slot_ptr, sizeof(uintptr_t));
+
+  return true;
+}
+
+}  // namespace lmb_pan

--- a/Zeal/lmb_pan.cpp
+++ b/Zeal/lmb_pan.cpp
@@ -1,8 +1,16 @@
+// fopen / ctime are MSVC-deprecated in favor of fopen_s / ctime_s, but the
+// secure variants don't buy us anything for a single-threaded append-only log
+// where the file path is a compile-time constant. Define before any includes.
+#define _CRT_SECURE_NO_WARNINGS
+
 #include "lmb_pan.h"
 
 #include <Windows.h>
 
+#include <cstdarg>
 #include <cstdint>
+#include <cstdio>
+#include <ctime>
 
 // Phase 1 / R2 Layer 2 / LMB-pan implementation. See:
 //   memory/PHASE1_CAMERA.md
@@ -23,8 +31,9 @@
 // polls LMB-no-RMB input → updates g_yaw_offset → optionally applies the
 // offset before chaining to the original.
 //
-// Yaw strategy = "Approach E" (Session 14 design). FUN_00799140 maintains the
-// camera's heading as a delta from entity rotation:
+// Yaw strategy = "Approach F" (Session 14 — supersedes Approach E which left
+// our pre-set cam[0x38] subject to override by the original's snap path).
+// FUN_00799140 maintains the camera's heading as a delta from entity rotation:
 //   cam[0x38]_new = cam[0x38]_pre + (entity_heading - cam[0x48])    (delta path)
 //   cam[0x38]_new = entity_heading                                  (snap path,
 //                                                                    DAT_00ddf703!=0)
@@ -35,31 +44,60 @@
 // the anchor compute orbits the camera by g_yaw_offset around the entity
 // without ever touching the entity's actual heading.
 //
-// When g_yaw_offset == 0 the wrapper is a pure pass-through (no cam state
+// When LMB-pan is not active (g_state == IDLE, g_yaw_offset == 0, no pitch
+// restore pending), the wrapper is a pure pass-through (no cam state
 // mutation). Vanilla 3rd-person is byte-identical to no-patch.
 //
-// Snap-path caveat: when DAT_00ddf703 != 0, the original overwrites cam[0x38]
-// with entity_heading and our offset is lost for that frame. Single-frame
-// visual glitch on transitions; likely imperceptible.
+// Snap-path caveat (yaw): when DAT_00ddf703 != 0, the original overwrites
+// cam[0x38] with entity_heading and our offset is lost for that frame.
+// Single-frame visual glitch on transitions; likely imperceptible.
 //
-// Input model for this commit (minimal): per-frame poll inside the wrapper.
-// LMB held without RMB → accumulate mouse X delta into g_yaw_offset. LMB
-// released → snap offset to 0 immediately. No persistence after release, no
-// smooth snap-back lerp, no click-vs-pan disambiguation. Those iterate on
-// top once the basic pan motion is verified.
+// Input model: per-frame poll inside the wrapper with click-vs-pan
+// disambiguation. State machine (Session 15 r2 spec — supersedes Session 14
+// "no-persistence" spec at user request):
+//   IDLE     — no offset, no LMB held.
+//   PENDING  — LMB pressed; awaiting motion threshold to decide click-vs-pan.
+//   PANNING  — cursor hidden; dx → g_yaw_offset, dy → g_pitch_offset
+//              accumulating each frame.
+//   HELD     — LMB released after a pan; offsets PERSIST so the camera holds
+//              its new angle. Cursor restored to LMB-down position. Vanilla
+//              clicks (target select etc.) still work in HELD.
+// Offsets ONLY reset on RMB press (PANNING→IDLE or HELD→IDLE). That's the
+// explicit snap-back affordance. LMB pressed from HELD re-engages PENDING
+// without resetting offsets — additional pan stacks on the held angle.
+// No smooth snap-back lerp; instant transition on RMB.
 //
-// Pitch is NOT handled this commit. Mode 6's anchor compute does not read
-// cam[0x2c] (the pitch field used by mode 2); pitch will need a different
-// injection point and is deferred.
+// Pitch strategy (Session 15, "Approach A"): cam[0x30] is the pitch input —
+// READ by FUN_00799140 (trig on cam[0x30] feeds Z component via
+// z_target = fStack_c - sin/cos(cam[0x30]) * cam[0x34]) but NEVER WRITTEN
+// by it. So we can pre-set cam[0x30] before chaining and the position
+// compute uses our value. Unlike yaw's cam[0x38] (which the original
+// overwrites every frame from entity_heading via Approach F's delta math),
+// cam[0x30] persists across frames — so we snapshot vanilla pitch on
+// pan-enter into g_pitch_base and restore it on pan-exit, otherwise residual
+// pitch would survive after LMB release. Snapshot/restore happen inside the
+// wrapper since only it has the cam pointer (enter_panning /
+// exit_to_idle_restoring_cursor set flags that the wrapper acts on).
+//
+// Session 14's memory file labeled cam[0x30] "head-height tracker"; the
+// FUN_00799140 decompile (Session 15) corrected that — cam[0x30] is pitch.
+// cam[0x14] = cam[0x30] (or cam[0x30] - 8.5) is the head-height-like output
+// derived from pitch by the original at function tail.
 
-#define ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE 1
+// Set to 1 to enable install-time MessageBoxes + per-pan file logging at
+// D:\EQEmu\Full_RoF2\lmb_pan_diag.log. Friend builds ship with this OFF —
+// the install popup would otherwise fire every DLL load, and the log file
+// would grow unbounded across play sessions.
+#define ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE 0
 
 namespace lmb_pan {
 
 // Mutated by poll_input() each frame the wrapper runs. Defaults 0 = vanilla.
-// Units: EQ heading units (512 = full turn).
+// g_yaw_offset units: EQ heading units (512 = full turn).
+// g_pitch_offset units: same as cam[0x30]'s units (TBD empirically — see
+// k_mouse_to_pitch_units comment).
 float g_yaw_offset = 0.0f;
-float g_pitch_offset = 0.0f;  // unused this commit (mode 6 pitch deferred)
+float g_pitch_offset = 0.0f;
 
 // Ghidra static addresses (preferred base 0x00400000). ASLR-adjusted at
 // runtime via the delta passed to install().
@@ -69,6 +107,13 @@ static const uintptr_t k_mode_6_slot_08_original_ghidra = 0x00799140;
 // Camera-object field offsets, from Session 14 decompile of FUN_00799140.
 static const size_t k_cam_heading_offset = 0x38;              // field [0xe]
 static const size_t k_cam_prev_entity_heading_offset = 0x48;  // field [0x12]
+// Pitch input — fed to trig in the original's Z-math (Session 15 decompile).
+// Read but never written by FUN_00799140.
+static const size_t k_cam_pitch_offset = 0x30;                // field [0xc]
+// Position-output offsets (cam[1..3]), used by the first-pitch-apply diagnostic.
+static const size_t k_cam_pos_x_offset = 0x04;
+static const size_t k_cam_pos_y_offset = 0x08;
+static const size_t k_cam_pos_z_offset = 0x0c;
 
 // Entity field offset for heading. entity[0x20] as int* → byte offset 0x80.
 static const size_t k_entity_heading_byte_offset = 0x80;
@@ -81,18 +126,43 @@ static slot_08_fn g_original = nullptr;
 static uintptr_t g_aslr_delta = 0;
 static const uintptr_t k_dat_00ddf703_ghidra = 0x00ddf703;
 
-// Input state machine. Click-vs-pan disambiguation:
-//   IDLE     — LMB not held (or LMB+RMB, which is vanilla autorun).
-//   PENDING  — LMB just pressed alone; not yet hidden cursor or applied yaw.
-//              Waiting for motion threshold to decide pan-vs-click.
-//   PANNING  — Motion threshold crossed; cursor hidden, yaw accumulating.
+// Runtime shadow of MouseSensitivity bucket (1-8). Session 11 decode:
+//   loadOptions tail copies ini storage DAT_00de0be4 → runtime shadow
+//   DAT_00ddf69c after the [1,8] clamp. procMouse (FUN_00516d40) reads the
+//   shadow and applies mult = ((bucket-1)/7) * 1.5 + 0.5 (= 0.5x..2.0x).
+// We read the same shadow per-frame so LMB-pan tracks RMB-drive: when the
+// user nudges the in-game slider, both pipelines scale together.
+static const uintptr_t k_dat_mouse_sens_bucket_ghidra = 0x00ddf69c;
+
+static float read_sens_mult() {
+  const int raw = *reinterpret_cast<int *>(k_dat_mouse_sens_bucket_ghidra + g_aslr_delta);
+  const int bucket = (raw < 1) ? 1 : (raw > 8 ? 8 : raw);
+  return (static_cast<float>(bucket - 1) / 7.0f) * 1.5f + 0.5f;
+}
+
+// Input state machine. Click-vs-pan disambiguation + persistent offset
+// (Session 15 r2). Offsets reset ONLY on RMB-triggered snap-back; LMB
+// release after a pan transitions to HELD (offset persists).
+//   IDLE     — LMB not held; no offset.
+//   PENDING  — LMB just pressed (from IDLE or HELD); cursor not yet hidden;
+//              no offset application change this frame. Waiting for motion
+//              threshold to decide pan-vs-click.
+//   PANNING  — motion threshold crossed; cursor hidden; offsets accumulating.
+//   HELD     — LMB released after a pan. Cursor restored. Offsets persist.
+//              cam[0x30] still pre-set each frame so the held pitch stays
+//              applied. Vanilla clicks (target select, autorun) still work.
 //
 // Transitions:
-//   IDLE → PENDING:    LMB pressed, RMB not pressed.
-//   PENDING → IDLE:    LMB released (was a click — no cursor hide, no yaw).
-//   PENDING → IDLE:    RMB pressed (LMB+RMB = autorun, not pan).
-//   PENDING → PANNING: cursor moved >= 4px from LMB-down position.
-//   PANNING → IDLE:    LMB released OR RMB pressed. Restore cursor + snap yaw.
+//   IDLE    → PENDING:  LMB pressed, RMB not pressed, [TODO: not over UI].
+//   PENDING → IDLE:     LMB released before threshold (was a click).
+//   PENDING → IDLE:     RMB pressed (LMB+RMB = autorun, not pan).
+//   PENDING → PANNING:  cursor moved ≥ k_pan_pixel_threshold (1 px).
+//   PANNING → HELD:     LMB released. Restore cursor; KEEP offsets.
+//   PANNING → IDLE:     RMB pressed mid-pan. Restore cursor; SNAP-BACK
+//                       offsets to 0; schedule pitch restore.
+//   HELD    → PENDING:  LMB pressed again. Re-engage pan; KEEP offsets so
+//                       further drag stacks on top of the held angle.
+//   HELD    → IDLE:     RMB pressed. SNAP-BACK offsets to 0; pitch restore.
 //
 // No time threshold: holding LMB still without moving doesn't auto-engage
 // pan. That avoids cursor flicker on slow UI clicks (e.g., 200ms button
@@ -101,6 +171,7 @@ enum class lmb_state {
   IDLE,
   PENDING,
   PANNING,
+  HELD,
 };
 
 static lmb_state g_state = lmb_state::IDLE;
@@ -112,6 +183,23 @@ static POINT g_prev_cursor = {0, 0};      // Frame-to-frame ref during PANNING.
 // can balance them on release.
 static int g_hides_applied = 0;
 
+// PITCH state. cam[0x30] persists across frames (the original reads but
+// doesn't write it), so we snapshot vanilla pitch on pan-enter and restore
+// it on pan-exit. Snapshot/restore happen INSIDE the wrapper (where the cam
+// pointer is in scope), gated by flags set elsewhere.
+static float g_pitch_base = 0.0f;       // Snapshot of cam[0x30] on pan-enter.
+static bool g_pitch_snapshotted = false; // True once we've captured g_pitch_base.
+static bool g_pitch_restore_pending = false; // Set on exit; wrapper restores once.
+
+// Cursor-edge recenter state. When cursor approaches game-window edge,
+// SetCursorPos warps it back to window center so pan can continue past the
+// screen-edge OS clamp. Multi-call-per-frame race: SetCursorPos doesn't
+// synchronously update GetCursorPos — secondary calls in the same frame
+// will still see the pre-set position. Track the pre-set position and skip
+// delta processing while the cursor still reports it (race in progress).
+static POINT g_pre_set_cursor = {0, 0};
+static bool g_recenter_pending = false;
+
 // Pixel-distance threshold before LMB-down commits to a pan (vs being a
 // click). WoW uses a "tiny hidden distance" — just enough to filter hand
 // tremor on a deliberate click, not a deliberate intent gate. Starting at
@@ -120,19 +208,132 @@ static int g_hides_applied = 0;
 static const int k_pan_pixel_threshold = 1;
 
 // Sensitivity: yaw units per pixel of cursor X movement. EQ uses 512 = full
-// turn, so 1.0 means 100px drag ≈ 70° rotation. Starting high to make the
-// effect obviously visible; tune down if too aggressive.
-static const float k_mouse_to_yaw_units = 1.0f;
+// turn, so 0.2 means 100px drag ≈ 14° rotation. Calibrated Session 15 to
+// roughly match the in-game RMB-drive feel at a mid-bucket MouseSensitivity
+// slider position; user retunes from here.
+static const float k_mouse_to_yaw_units = 0.2f;
 
 // Anti-spike: clamp the per-frame delta to avoid jumps on mode-switch re-
 // entry (wrapper is called only in mode 6; cursor may have moved a lot
 // while we were in a different mode).
 static const int k_max_dx_per_frame = 50;
+static const int k_max_dy_per_frame = 50;
+
+// Pitch sensitivity — cam[0x30] units per pixel. cam[0x30]'s real unit is
+// still unconfirmed (the FUN_00799140 decompile reads it through a trig
+// vtable so could be radians or degrees), so the ratio to yaw is empirical
+// rather than analytical. Tuning history:
+//   0.5  (Session 14 initial — too fast, not yet validated)
+//   0.1  (Session 15 first cut — felt slightly faster than yaw per-pixel)
+//   0.08 (Session 15 reduce — overshot once RMB-drive was aspect-corrected)
+//   0.09 (Session 15 final — user-confirmed feel after both fixes landed)
+static const float k_mouse_to_pitch_units = 0.09f;
+
+// Pitch clamp range. cam[0x2c] (a sibling field, not the one we use) is
+// clamped to [0, 30] in mode 5 — circumstantial evidence that EQ pitches
+// live in roughly the [0, 30] range. We allow ±60 here (wider than circum-
+// stantial guess) so first empirical test can see whether cam[0x30] reaches
+// position compute at all; narrow once we know the working range.
+static const float k_pitch_offset_min = -60.0f;
+static const float k_pitch_offset_max =  60.0f;
+
+// --- File-log diagnostics ---
+// Why a file log instead of MessageBox: the wrapper hides the cursor on
+// pan-enter (looped ShowCursor(FALSE) to defeat EQ's positive refcount), and
+// MessageBoxA blocks the same thread that owns the cursor state. User sees
+// a modal dialog with no cursor and can't dismiss it without alt-tab / Esc.
+// File log captures per-frame data without UI interference; user reads it
+// after the test instead of trying to click through it during.
+//
+// Install-time MessageBox stays in install() because that runs pre-game
+// (before any cursor hide), so it's still safely clickable.
+static FILE *g_diag_log = nullptr;
+
+static void diag_logf(const char *fmt, ...) {
+  if (!g_diag_log) {
+    g_diag_log = fopen("D:\\EQEmu\\Full_RoF2\\lmb_pan_diag.log", "a");
+    if (!g_diag_log) return;
+    const time_t now = time(nullptr);
+    fprintf(g_diag_log, "\n=== Zeal.asi load: %s", ctime(&now));
+    fflush(g_diag_log);
+  }
+  va_list ap;
+  va_start(ap, fmt);
+  vfprintf(g_diag_log, fmt, ap);
+  va_end(ap);
+  fflush(g_diag_log);
+}
+
+// UI hit-test (Session 15). Returns true when the LMB-down event should NOT
+// engage pan because the cursor is over a vanilla EQ UI window (so the click
+// can reach a slider, button, etc.). Mirrors upstream Zeal's
+// is_game_ui_window_hovered() — reads *WndManager → CXWndManager → Hovered.
+//
+// RoF2 address discovery (Session 15, static analysis of eqgame.exe):
+//   - RTTI ".?AVCXWndManager@@" name at .data file 0x762E88 (VA 0x00B64C88)
+//   - Type Descriptor at VA 0x00B64C80
+//   - Complete Object Locator referencing TD at VA 0x00A51D1C (.rdata)
+//   - CXWndManager base vtable at VA 0x00A1A338 (only one `MOV [ESI], vt`
+//     site in the binary, inside ctor at VA 0x008772D0 — prolog PUSH -1)
+//   - Derived UI manager ctor at VA 0x00666B80 (calls base ctor, then
+//     writes derived vtable 0x009E7728 over [EDI])
+//   - Single caller of derived ctor at VA 0x0048E644; the bytes
+//     immediately following are `MOV [0x015D3D00], EAX` storing the new
+//     object pointer to a .data global → that global IS WndManager.
+//
+// CXWndManager.Hovered offset: empirically 0x70 in RoF2 (Session 15 dumps,
+// second-pass calibration).
+//
+// Upstream 2002's CXWndManager (see game_ui.h) had:
+//   /* 0x0030 */ SidlWnd *Focused;     (after-click sticky)
+//   /* 0x003C */ SidlWnd *Hovered;     (current cursor)
+//
+// First-pass landed on 0x5C, which turned out to be RoF2's Focused (sticky
+// once set, persisted after the user clicked off the UI window — the user
+// confirmed pan stayed blocked even on subsequent world clicks). Second-pass
+// dump comparison across the same 18 events:
+//   - 0x5C/0x64: heap ptr after first UI click, persistent through dumps
+//     12-18 even when subsequent clicks were on world → Focused/Active.
+//   - 0x70:      heap ptr ONLY when cursor over UI at LMB-down time; clears
+//     on world clicks → Hovered (current cursor pointing-at semantics).
+//   - 0x74:      tracks 0x70 most of the time, occasional discrepancies →
+//     likely a secondary mouse-capture field.
+//
+// Class layout shifted ~0x40 bytes between 2002 and RoF2, almost certainly
+// because the base CXWnd class added members in newer expansions.
+static const uintptr_t k_wnd_mgr_global_ghidra = 0x015D3D00;
+static const size_t k_cxwndmgr_hovered_offset = 0x70;
+
+static bool is_mouse_over_ui_window() {
+  void *const mgr =
+      *reinterpret_cast<void **>(k_wnd_mgr_global_ghidra + g_aslr_delta);
+  if (mgr == nullptr) return false;
+  void *const hovered = *reinterpret_cast<void **>(
+      reinterpret_cast<char *>(mgr) + k_cxwndmgr_hovered_offset);
+  const bool over_ui = (hovered != nullptr);
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  // Log first 10 hit-test calls with all four candidate field values so we
+  // can verify 0x70 is still the right choice (vs 0x5C / 0x68 / 0x74) on
+  // re-test. After 10 calls, log goes silent.
+  static int s_diag_count = 0;
+  if (s_diag_count < 10) {
+    s_diag_count++;
+    const unsigned *p = reinterpret_cast<const unsigned *>(mgr);
+    diag_logf("[hit-test #%d] mgr=0x%x  0x5c=%08x 0x64=%08x 0x68=%08x "
+              "0x70=%08x 0x74=%08x  decision=%s\n",
+              s_diag_count, (unsigned)(uintptr_t)mgr,
+              p[0x5C / 4], p[0x64 / 4], p[0x68 / 4],
+              p[0x70 / 4], p[0x74 / 4],
+              over_ui ? "SUPPRESS" : "ALLOW");
+  }
+#endif
+  return over_ui;
+}
 
 static void enter_panning() {
   // Use the LMB-down cursor as the frame-to-frame reference so the motion
   // that crossed the threshold (and got us into PANNING) is applied as the
-  // first frame's yaw delta — no "lost" pixels at the start of a pan.
+  // first frame's yaw/pitch delta — no "lost" pixels at the start of a pan.
   g_prev_cursor = g_lmb_down_cursor;
   g_hides_applied = 0;
   for (int attempts = 0; attempts < 16; ++attempts) {
@@ -140,16 +341,72 @@ static void enter_panning() {
     g_hides_applied++;
     if (new_count < 0) break;
   }
+  // Multi-monitor safety: trap the (hidden) cursor inside the game window
+  // so it can't wander onto a second monitor mid-pan. Released on PANNING
+  // exit (enter_held_keeping_offset / exit_to_idle_snapping_back).
+  {
+    HWND fg = GetForegroundWindow();
+    RECT wr;
+    if (fg && GetWindowRect(fg, &wr)) {
+      ClipCursor(&wr);
+    }
+  }
+  // Persistence: do NOT reset g_pitch_offset or g_pitch_snapshotted here.
+  // They carry over from any prior HELD state, so re-engaging a pan stacks
+  // on top of the previously-held angle. Offsets only reset via RMB
+  // snap-back (exit_to_idle_snapping_back).
+  // Cursor-recenter state: fresh start.
+  g_recenter_pending = false;
   g_state = lmb_state::PANNING;
 }
 
-static void exit_to_idle_restoring_cursor() {
+// Pan-end without snap-back: cursor restored, offsets kept. The held pitch
+// remains applied to cam[0x30] each frame (the wrapper's PANNING/HELD path
+// writes cam[0x30] = g_pitch_base + g_pitch_offset; g_pitch_snapshotted
+// stays true, base stays valid).
+static void enter_held_keeping_offset() {
+  ClipCursor(nullptr);  // release multi-monitor trap from enter_panning()
   SetCursorPos(g_lmb_down_cursor.x, g_lmb_down_cursor.y);
   while (g_hides_applied > 0) {
     ShowCursor(TRUE);
     g_hides_applied--;
   }
+  // Keep g_yaw_offset, g_pitch_offset, g_pitch_base, g_pitch_snapshotted.
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  diag_logf("[pan-held] LMB released; offsets persist (yaw=%+.3f pitch=%+.3f)\n",
+            g_yaw_offset, g_pitch_offset);
+#endif
+  g_state = lmb_state::HELD;
+}
+
+// RMB-triggered snap-back: offsets reset to 0, pitch restored to vanilla.
+// Called from both PANNING (cursor was hidden, restore it) and HELD (cursor
+// already visible). Idempotent w.r.t. cursor hide state.
+static void exit_to_idle_snapping_back() {
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  const char *from = (g_state == lmb_state::PANNING) ? "PANNING"
+                    : (g_state == lmb_state::HELD)    ? "HELD"
+                    : (g_state == lmb_state::PENDING) ? "PENDING" : "IDLE";
+  diag_logf("[pan-snap-back] RMB triggered; was %s, yaw=%+.3f pitch=%+.3f → 0,0\n",
+            from, g_yaw_offset, g_pitch_offset);
+#endif
+  // Release the multi-monitor cursor trap if it was set (only PANNING set it;
+  // HELD already released it). Safe to call even if no clip is active.
+  if (g_state == lmb_state::PANNING) {
+    ClipCursor(nullptr);
+  }
+  if (g_hides_applied > 0) {
+    SetCursorPos(g_lmb_down_cursor.x, g_lmb_down_cursor.y);
+    while (g_hides_applied > 0) {
+      ShowCursor(TRUE);
+      g_hides_applied--;
+    }
+  }
   g_yaw_offset = 0.0f;
+  g_pitch_offset = 0.0f;
+  // Schedule the pitch restore to cam[0x30] = g_pitch_base. Wrapper's next
+  // call will execute it once and clear g_pitch_snapshotted.
+  g_pitch_restore_pending = true;
   g_state = lmb_state::IDLE;
 }
 
@@ -159,16 +416,30 @@ static void poll_input() {
 
   switch (g_state) {
     case lmb_state::IDLE:
-      if (lmb && !rmb) {
+      if (lmb && !rmb && !is_mouse_over_ui_window()) {
         GetCursorPos(&g_lmb_down_cursor);
         g_state = lmb_state::PENDING;
       }
       break;
     case lmb_state::PENDING:
-      if (!lmb || rmb) {
-        // LMB released before threshold = click (no cursor hide, no yaw).
-        // OR RMB pressed = LMB+RMB autorun (also not pan). Return to IDLE.
-        g_state = lmb_state::IDLE;
+      if (rmb) {
+        // LMB+RMB. If we have held offsets (re-engage path from HELD), the
+        // RMB is a snap-back intent. Else just drop to IDLE (vanilla LMB+RMB
+        // autorun, no pan was in progress yet).
+        if (g_yaw_offset != 0.0f || g_pitch_offset != 0.0f) {
+          exit_to_idle_snapping_back();
+        } else {
+          g_state = lmb_state::IDLE;
+        }
+      } else if (!lmb) {
+        // LMB released before threshold = a click. Return to the resting
+        // state that matches our offset: HELD if offsets persist from a
+        // prior pan, IDLE otherwise.
+        if (g_yaw_offset == 0.0f && g_pitch_offset == 0.0f) {
+          g_state = lmb_state::IDLE;
+        } else {
+          g_state = lmb_state::HELD;
+        }
       } else {
         POINT current;
         GetCursorPos(&current);
@@ -182,21 +453,93 @@ static void poll_input() {
       }
       break;
     case lmb_state::PANNING:
-      if (!lmb || rmb) {
-        exit_to_idle_restoring_cursor();
+      if (rmb) {
+        exit_to_idle_snapping_back();
+      } else if (!lmb) {
+        enter_held_keeping_offset();
       } else {
         POINT current;
         GetCursorPos(&current);
-        int dx = current.x - g_prev_cursor.x;
-        if (dx > k_max_dx_per_frame) dx = k_max_dx_per_frame;
-        else if (dx < -k_max_dx_per_frame) dx = -k_max_dx_per_frame;
-        // WoW spec: mouse RIGHT rotates camera COUNTER-CLOCKWISE (camera to
-        // the player's LEFT). Subtraction, not addition.
-        g_yaw_offset -= static_cast<float>(dx) * k_mouse_to_yaw_units;
-        if (g_yaw_offset > 256.0f) g_yaw_offset -= 512.0f;
-        else if (g_yaw_offset < -256.0f) g_yaw_offset += 512.0f;
-        g_prev_cursor = current;
+
+        // Race-aware skip: if we just SetCursorPos in a prior call but the
+        // OS hasn't propagated the new position to GetCursorPos yet, the
+        // cursor will still report its pre-set position. Skip delta-
+        // processing this frame to avoid a phantom large-delta kick.
+        bool race_skip = false;
+        if (g_recenter_pending) {
+          if (current.x == g_pre_set_cursor.x && current.y == g_pre_set_cursor.y) {
+            race_skip = true;  // race in progress
+          } else {
+            g_recenter_pending = false;  // OS has caught up
+          }
+        }
+
+        if (!race_skip) {
+          int dx = current.x - g_prev_cursor.x;
+          int dy = current.y - g_prev_cursor.y;
+          if (dx > k_max_dx_per_frame) dx = k_max_dx_per_frame;
+          else if (dx < -k_max_dx_per_frame) dx = -k_max_dx_per_frame;
+          if (dy > k_max_dy_per_frame) dy = k_max_dy_per_frame;
+          else if (dy < -k_max_dy_per_frame) dy = -k_max_dy_per_frame;
+          // Slider coupling: scale by the same bucket-mult procMouse uses for
+          // RMB-drive. LMB-pan and RMB-drive now track together when the user
+          // adjusts the in-game MouseSensitivity slider.
+          const float sens_mult = read_sens_mult();
+          // YAW. WoW spec: mouse RIGHT rotates camera COUNTER-CLOCKWISE (camera
+          // to the player's LEFT). Subtraction, not addition.
+          g_yaw_offset -= static_cast<float>(dx) * k_mouse_to_yaw_units * sens_mult;
+          if (g_yaw_offset > 256.0f) g_yaw_offset -= 512.0f;
+          else if (g_yaw_offset < -256.0f) g_yaw_offset += 512.0f;
+          // PITCH. WoW spec: mouse DOWN tilts camera UP and OVER the player's
+          // head (bird's-eye, looking down). Z-math from FUN_00799140:
+          //   z_target = fStack_c - sin(cam[0x30]) * cam[0x34]
+          // So decreasing cam[0x30] lifts the camera (less subtraction from
+          // the anchor Z). Pull-down (positive dy) ⇒ camera should go up ⇒
+          // g_pitch_offset DECREASES. Hence subtraction. (Symmetric with the
+          // yaw direction fix above: mouse-right → camera-CCW also uses -=.)
+          g_pitch_offset -= static_cast<float>(dy) * k_mouse_to_pitch_units * sens_mult;
+          if (g_pitch_offset > k_pitch_offset_max) g_pitch_offset = k_pitch_offset_max;
+          else if (g_pitch_offset < k_pitch_offset_min) g_pitch_offset = k_pitch_offset_min;
+          g_prev_cursor = current;
+
+          // Edge guard: if cursor is approaching the game-window edge,
+          // recenter so OS-level cursor clamping doesn't stall future
+          // deltas in that direction. Cursor is hidden during PANNING, so
+          // the warp is invisible to the user.
+          RECT wr;
+          HWND fg = GetForegroundWindow();
+          if (fg && GetWindowRect(fg, &wr)) {
+            const int margin = 100;  // px from edge before recentering
+            if (current.x < wr.left + margin ||
+                current.x > wr.right - margin ||
+                current.y < wr.top + margin ||
+                current.y > wr.bottom - margin) {
+              const POINT center = {
+                  (wr.left + wr.right) / 2,
+                  (wr.top + wr.bottom) / 2};
+              g_pre_set_cursor = current;
+              SetCursorPos(center.x, center.y);
+              g_prev_cursor = center;
+              g_recenter_pending = true;
+            }
+          }
+        }
       }
+      break;
+    case lmb_state::HELD:
+      if (rmb) {
+        // RMB while a pan is held: instant snap-back per spec.
+        exit_to_idle_snapping_back();
+      } else if (lmb && !is_mouse_over_ui_window()) {
+        // LMB pressed from HELD: re-engage. Offsets persist (we DON'T reset
+        // them here or in enter_panning); further drag stacks on the held
+        // angle.
+        GetCursorPos(&g_lmb_down_cursor);
+        g_state = lmb_state::PENDING;
+      }
+      // else: stay in HELD (cursor visible, offsets persistent, pitch
+      // continues being applied each frame via the wrapper's PANNING/HELD
+      // pitch block).
       break;
   }
 }
@@ -204,41 +547,127 @@ static void poll_input() {
 static void __fastcall mode_6_wrapper(void *cam, int /*edx_unused*/, int *entity) {
   poll_input();
 
-  if (g_yaw_offset != 0.0f) {
-    char *const cam_bytes = reinterpret_cast<char *>(cam);
+  char *const cam_bytes = reinterpret_cast<char *>(cam);
+
+  // PITCH state machine (Session 15, "Approach A", revised r2 for persistence):
+  //   On first PANNING frame:   snapshot cam[0x30] → g_pitch_base.
+  //   While PANNING or HELD:    write cam[0x30] = g_pitch_base + g_pitch_offset.
+  //                             (HELD keeps the held pitch applied every frame
+  //                             so the camera doesn't drift back to vanilla.)
+  //   On the wrapper call after RMB snap-back (state→IDLE, restore_pending=true):
+  //                             write cam[0x30] = g_pitch_base once, clear flags.
+  //
+  // cam[0x30] is READ by FUN_00799140 (trig feeds Z component:
+  //   z_target = fStack_c - sin/cos(cam[0x30]) * cam[0x34])
+  // but NEVER WRITTEN by it. Hence pure pre-set works; no snap/delta gate to
+  // mutate around (unlike yaw's DAT_00ddf703). The block is idempotent across
+  // the renderer's multi-call-per-frame pattern (shadows/reflections call
+  // slot 0x08 several times) since each call writes the same value.
+  if (g_state == lmb_state::PANNING || g_state == lmb_state::HELD) {
+    if (!g_pitch_snapshotted) {
+      g_pitch_base = *reinterpret_cast<float *>(cam_bytes + k_cam_pitch_offset);
+      g_pitch_snapshotted = true;
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+      {
+        const int bucket_raw = *reinterpret_cast<int *>(
+            k_dat_mouse_sens_bucket_ghidra + g_aslr_delta);
+        const float sens_mult = read_sens_mult();
+        diag_logf("[pan-enter] cam[0x30]_base=%f  cam[0x38]=%f  "
+                  "cam[1..3]=(%.3f, %.3f, %.3f)  "
+                  "MouseSens bucket=%d (clamped 1..8), sens_mult=%.3f  "
+                  "effective_yaw_per_px=%.4f  effective_pitch_per_px=%.4f\n",
+                  g_pitch_base,
+                  *reinterpret_cast<float *>(cam_bytes + k_cam_heading_offset),
+                  *reinterpret_cast<float *>(cam_bytes + k_cam_pos_x_offset),
+                  *reinterpret_cast<float *>(cam_bytes + k_cam_pos_y_offset),
+                  *reinterpret_cast<float *>(cam_bytes + k_cam_pos_z_offset),
+                  bucket_raw, sens_mult,
+                  k_mouse_to_yaw_units * sens_mult,
+                  k_mouse_to_pitch_units * sens_mult);
+      }
+#endif
+    }
+    *reinterpret_cast<float *>(cam_bytes + k_cam_pitch_offset) =
+        g_pitch_base + g_pitch_offset;
+  } else if (g_pitch_restore_pending) {
+    *reinterpret_cast<float *>(cam_bytes + k_cam_pitch_offset) = g_pitch_base;
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+    diag_logf("[pan-restore] cam[0x30] = %f (base)\n", g_pitch_base);
+#endif
+    g_pitch_restore_pending = false;
+    g_pitch_snapshotted = false;
+  }
+
+  // Pre-original capture for the per-frame pitch diagnostic. Captures the
+  // first k_max_pan_frames_to_log PANNING frames of every pan; counter resets
+  // when the pan ends so each pan starts fresh.
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  static int s_pan_frame_log_count = 0;
+  static const int k_max_pan_frames_to_log = 200;
+  float diag_pre_x = 0.0f, diag_pre_y = 0.0f, diag_pre_z = 0.0f;
+  const bool diag_log_this_frame = (g_state == lmb_state::PANNING) &&
+                                    (s_pan_frame_log_count < k_max_pan_frames_to_log);
+  if (diag_log_this_frame) {
+    diag_pre_x = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_x_offset);
+    diag_pre_y = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_y_offset);
+    diag_pre_z = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_z_offset);
+  }
+#endif
+
+  // YAW: Approach F (Session 14). cam[0x38] gets overwritten by the original
+  // every frame, so we pre-set it AND temporarily force the delta-math path
+  // (DAT_00ddf703 = 0). Restore DAT_00ddf703 after so other code sees its
+  // normal value. Only mutate when offset is non-zero — keeps the vanilla
+  // pass-through path byte-identical when LMB-pan is yaw-idle.
+  unsigned char *const dat_703_ptr = reinterpret_cast<unsigned char *>(
+      k_dat_00ddf703_ghidra + g_aslr_delta);
+  unsigned char saved_dat_703 = 0;
+  const bool yaw_apply = (g_yaw_offset != 0.0f);
+  if (yaw_apply) {
     const float entity_heading =
         *reinterpret_cast<float *>(reinterpret_cast<char *>(entity) +
                                    k_entity_heading_byte_offset);
-
-    // Approach F (Session 14 diagnostic finding): DAT_00ddf703 is 1 in normal
-    // play, which makes FUN_00799140 take the SNAP path:
-    //     cam[0x38] = entity_heading
-    // unconditionally. That overrides our pre-set every frame. To make our
-    // pre-set survive, temporarily force DAT_00ddf703 = 0 so the delta path
-    // runs:
-    //     cam[0x38] = (entity_heading - cam[0x48]) + cam[0x38]_pre
-    //               = (entity_heading - entity_heading) + (entity_heading + offset)
-    //               = entity_heading + offset      ← survives, anchor uses this.
-    // Restore DAT_00ddf703 after the call so other code that depends on it
-    // sees the original value next frame.
-    unsigned char *const dat_703_ptr = reinterpret_cast<unsigned char *>(
-        k_dat_00ddf703_ghidra + g_aslr_delta);
-    const unsigned char saved_dat_703 = *dat_703_ptr;
+    saved_dat_703 = *dat_703_ptr;
     *dat_703_ptr = 0;
-
-    // Force the original's delta math to produce cam[0x38] = entity_heading +
-    // g_yaw_offset.
     *reinterpret_cast<float *>(cam_bytes + k_cam_prev_entity_heading_offset) =
         entity_heading;
     *reinterpret_cast<float *>(cam_bytes + k_cam_heading_offset) =
         entity_heading + g_yaw_offset;
-
-    g_original(cam, 0, entity);
-
-    *dat_703_ptr = saved_dat_703;
-  } else {
-    g_original(cam, 0, entity);
   }
+
+  g_original(cam, 0, entity);
+
+  if (yaw_apply) {
+    *dat_703_ptr = saved_dat_703;
+  }
+
+#if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  if (diag_log_this_frame) {
+    const float post_x = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_x_offset);
+    const float post_y = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_y_offset);
+    const float post_z = *reinterpret_cast<float *>(cam_bytes + k_cam_pos_z_offset);
+    const float cam30_written = *reinterpret_cast<float *>(cam_bytes + k_cam_pitch_offset);
+    const float cam38 = *reinterpret_cast<float *>(cam_bytes + k_cam_heading_offset);
+    diag_logf("[pan-frame %3d] yaw_off=%+8.3f pitch_off=%+8.3f  "
+              "cam[0x30]=%+.4f cam[0x38]=%+.4f  "
+              "pre=(%.2f, %.2f, %.2f) post=(%.2f, %.2f, %.2f)  "
+              "dX=%+.4f dY=%+.4f dZ=%+.4f\n",
+              s_pan_frame_log_count,
+              g_yaw_offset, g_pitch_offset,
+              cam30_written, cam38,
+              diag_pre_x, diag_pre_y, diag_pre_z,
+              post_x, post_y, post_z,
+              post_x - diag_pre_x, post_y - diag_pre_y, post_z - diag_pre_z);
+    s_pan_frame_log_count++;
+  }
+  // Reset the per-pan frame counter once we've fully returned to IDLE
+  // (state IDLE AND no restore pending). Logs a summary line for grep-ability.
+  if (g_state != lmb_state::PANNING && !g_pitch_restore_pending &&
+      s_pan_frame_log_count > 0) {
+    diag_logf("[pan-end] logged %d frames in this pan\n", s_pan_frame_log_count);
+    s_pan_frame_log_count = 0;
+  }
+#endif
 }
 
 bool install(uintptr_t aslr_delta) {
@@ -251,6 +680,18 @@ bool install(uintptr_t aslr_delta) {
   const bool match = (actual == expected_runtime);
 
 #if ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE
+  diag_logf("[install] aslr_delta=0x%08x  slot_runtime=0x%08x  "
+            "expected=0x%08x  actual=0x%08x  match=%s  decision=%s\n",
+            (unsigned)aslr_delta, (unsigned)slot_runtime,
+            (unsigned)expected_runtime, (unsigned)actual,
+            match ? "YES" : "NO", match ? "INSTALL" : "SKIP");
+  diag_logf("[config] k_mouse_to_yaw_units=%f  k_mouse_to_pitch_units=%f  "
+            "k_pitch_clamp=[%f, %f]  k_pan_pixel_threshold=%d  "
+            "slider_coupling=ON (reads DAT_00ddf69c, applies "
+            "(bucket-1)/7*1.5+0.5 mult per procMouse)\n",
+            k_mouse_to_yaw_units, k_mouse_to_pitch_units,
+            k_pitch_offset_min, k_pitch_offset_max, k_pan_pixel_threshold);
+  // Keep the install MessageBox — runs pre-game, cursor is visible, safe.
   char msg[1024];
   wsprintfA(msg,
             "Mode 6 (vanilla 3rd-person) vtable slot 0x08 patch:\r\n\r\n"
@@ -258,7 +699,9 @@ bool install(uintptr_t aslr_delta) {
             "Expected original (FUN_00799140 + delta): 0x%08x\r\n"
             "Actual value at slot: 0x%08x\r\n\r\n"
             "Signature match: %s\r\n"
-            "Decision: %s",
+            "Decision: %s\r\n\r\n"
+            "Diagnostics now go to D:\\EQEmu\\Full_RoF2\\lmb_pan_diag.log\r\n"
+            "(no more mid-pan popups blocking your hidden cursor).",
             (unsigned)slot_runtime, (unsigned)expected_runtime, (unsigned)actual,
             match ? "YES" : "NO", match ? "INSTALL" : "SKIP (silent no-op)");
   MessageBoxA(NULL, msg, "Zeal-RoF2 R3 / LMB-pan install diagnostic",

--- a/Zeal/lmb_pan.cpp
+++ b/Zeal/lmb_pan.cpp
@@ -358,16 +358,15 @@ static void enter_panning() {
     g_hides_applied++;
     if (new_count < 0) break;
   }
-  // Multi-monitor safety: trap the (hidden) cursor inside the game window
-  // so it can't wander onto a second monitor mid-pan. Released on PANNING
-  // exit (enter_held_keeping_offset / exit_to_idle_snapping_back).
-  {
-    HWND fg = GetForegroundWindow();
-    RECT wr;
-    if (fg && GetWindowRect(fg, &wr)) {
-      ClipCursor(&wr);
-    }
-  }
+  // Multi-monitor safety is handled by the 100px edge-recenter guard in
+  // poll_input (PANNING branch), which warps the cursor back to window center
+  // before it reaches any edge. We deliberately do NOT call ClipCursor here:
+  // EQ's WM_RBUTTONDOWN handler activates camera-turn mode (and likely sets
+  // its own ClipCursor) — if Zeal's clip is already active when that message
+  // arrives, EQ's camera-turn setup fails silently, which prevents the
+  // "both buttons held = move forward" mechanic from firing (the RMB-during-
+  // pan → autorun bug reported after v1.2.1).
+  //
   // Persistence: do NOT reset g_pitch_offset or g_pitch_snapshotted here.
   // They carry over from any prior HELD state, so re-engaging a pan stacks
   // on top of the previously-held angle. Offsets only reset via RMB
@@ -382,7 +381,6 @@ static void enter_panning() {
 // writes cam[0x30] = g_pitch_base + g_pitch_offset; g_pitch_snapshotted
 // stays true, base stays valid).
 static void enter_held_keeping_offset() {
-  ClipCursor(nullptr);  // release multi-monitor trap from enter_panning()
   SetCursorPos(g_lmb_down_cursor.x, g_lmb_down_cursor.y);
   while (g_hides_applied > 0) {
     ShowCursor(TRUE);
@@ -407,11 +405,6 @@ static void exit_to_idle_snapping_back() {
   diag_logf("[pan-snap-back] RMB triggered; was %s, yaw=%+.3f pitch=%+.3f → 0,0\n",
             from, g_yaw_offset, g_pitch_offset);
 #endif
-  // Release the multi-monitor cursor trap if it was set (only PANNING set it;
-  // HELD already released it). Safe to call even if no clip is active.
-  if (g_state == lmb_state::PANNING) {
-    ClipCursor(nullptr);
-  }
   if (g_hides_applied > 0) {
     SetCursorPos(g_lmb_down_cursor.x, g_lmb_down_cursor.y);
     while (g_hides_applied > 0) {
@@ -433,8 +426,9 @@ static void poll_input() {
   // our state machine. Also release any lingering ClipCursor so the user's
   // other apps work normally.
   if (!eq_has_foreground_focus()) {
-    // Always release ClipCursor on background — cheap idempotent call,
-    // ensures we never leave the clip lingering across alt-tab.
+    // Safety net: release any cursor clip on background (cheap no-op if none
+    // is active; guards against EQ's own camera-turn ClipCursor lingering
+    // across alt-tab). Zeal itself no longer calls ClipCursor during panning.
     ClipCursor(nullptr);
     if (g_state == lmb_state::PANNING) {
       // Restore cursor visibility (it was hidden in enter_panning). DON'T

--- a/Zeal/lmb_pan.cpp
+++ b/Zeal/lmb_pan.cpp
@@ -140,6 +140,23 @@ static float read_sens_mult() {
   return (static_cast<float>(bucket - 1) / 7.0f) * 1.5f + 0.5f;
 }
 
+// True when EQ's main window (any window in our process) currently has
+// Windows foreground focus. Used to gate input polling so that when EQ is
+// in the background (e.g. user alt-tabbed to another app), we don't:
+//   - read GetAsyncKeyState(VK_LBUTTON) — it's a GLOBAL state, so clicks in
+//     other windows would otherwise drive us into PENDING/PANNING.
+//   - leave ClipCursor active — it would trap the cursor inside the EQ
+//     window even while the user is interacting with other applications
+//     (breaks text selection, screenshot tools, etc. — user-reported bug
+//     after v1.2.0 shipped).
+static bool eq_has_foreground_focus() {
+  const HWND fg = GetForegroundWindow();
+  if (!fg) return false;
+  DWORD fg_pid = 0;
+  GetWindowThreadProcessId(fg, &fg_pid);
+  return fg_pid == GetCurrentProcessId();
+}
+
 // Input state machine. Click-vs-pan disambiguation + persistent offset
 // (Session 15 r2). Offsets reset ONLY on RMB-triggered snap-back; LMB
 // release after a pan transitions to HELD (offset persists).
@@ -411,6 +428,35 @@ static void exit_to_idle_snapping_back() {
 }
 
 static void poll_input() {
+  // Focus gate: if EQ is in the background, do nothing — GetAsyncKeyState
+  // reads global key state, so clicks in other apps would otherwise enter
+  // our state machine. Also release any lingering ClipCursor so the user's
+  // other apps work normally.
+  if (!eq_has_foreground_focus()) {
+    // Always release ClipCursor on background — cheap idempotent call,
+    // ensures we never leave the clip lingering across alt-tab.
+    ClipCursor(nullptr);
+    if (g_state == lmb_state::PANNING) {
+      // Restore cursor visibility (it was hidden in enter_panning). DON'T
+      // SetCursorPos — the user is in another window now, snapping their
+      // cursor would be more disruptive than leaving it where they put it.
+      while (g_hides_applied > 0) {
+        ShowCursor(TRUE);
+        g_hides_applied--;
+      }
+      // Demote to HELD so the camera angle persists. Re-engaging the pan
+      // when the user comes back requires a fresh LMB release+click (the
+      // HELD → PENDING transition fires only on a new LMB-down edge).
+      g_recenter_pending = false;
+      g_state = lmb_state::HELD;
+    } else if (g_state == lmb_state::PENDING) {
+      // No pan committed yet — drop back to IDLE so we don't auto-engage
+      // when focus returns.
+      g_state = lmb_state::IDLE;
+    }
+    return;
+  }
+
   const bool lmb = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
   const bool rmb = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
 

--- a/Zeal/lmb_pan.h
+++ b/Zeal/lmb_pan.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+
+namespace lmb_pan {
+
+// Install the chase-camera vtable slot 0x08 patch. Returns true on success,
+// false if the signature gate failed (slot didn't hold the expected original
+// pointer — unknown eqgame.exe build, or already patched). Must be called
+// after dllmain.cpp's handle_process_attach() has populated aslr_delta.
+bool install(uintptr_t aslr_delta);
+
+// Per-frame offsets applied to the chase camera around the original slot 0x08
+// call. Mutated by the input poll (wired in a follow-up commit). The MVP
+// initial build hardcodes g_yaw_offset to a visible test value to verify the
+// architecture in one launch; input wiring replaces it with the actual
+// LMB-no-RMB-driven state. Units: EQ heading units (512 = full turn).
+extern float g_yaw_offset;
+extern float g_pitch_offset;
+
+}  // namespace lmb_pan


### PR DESCRIPTION
## Summary

Two changes per the S44 4-scope LMB-pan audit (memory/project_zeal_rof2_lmb_pan_audit.md):

- **Bug #7 fix (real fix, defaults on)** — bump pitch clamp from ±60 → ±90 (full quarter-turn each direction). Alex S44-reported the ±60 clamp hitting in normal play (vertical pan stall).
- **Bug #2 alt-tab investigation (DIAGNOSE-gated, defaults off)** — new focus-transition log at the top of `poll_input`. Captures the EDGE of every EQ-foreground-focus change with full state context, so an alt-tab → alt-tab-back → RMB-snap-back log capture reveals whether the focus-loss demotion fires and whether the post-regain RMB is being observed.

Sits on top of `860c2ce` (S44 Tier 3 base — re-adds ClipCursor + post-snap diag + DIAGNOSE flag split; committed during S44 from a 9-day-old uncommitted-on-disk state). Tier 1 fixes (B2 mode-switch leak, A3/B1 focus-loss-with-offsets, B3 UI hit-test mid-PANNING + Focused check) deliberately NOT included — separate PR after the Tier 3 investigation captures data.

## Test plan

### Local build setup (one-time)

```
git pull
git checkout s44/bug7-pitch-clamp-and-bug2-altab-diag
# From a VS2022 Developer PowerShell (x86 env):
msbuild Zeal.sln /p:Configuration=Release /p:Platform=x86
```

Output: `Release\Zeal.asi` (~11.3 MB).

### Scenario A — Bug #7 pitch clamp verification (default flags, no rebuild needed for diag)

- [ ] Drop `Release\Zeal.asi` into `D:\EQEmu\Full_RoF2\` (overwrite existing).
- [ ] Launch EQ, get to a 3rd-person view (scroll out to mode 6).
- [ ] LMB-drag straight UP, hold past where the old clamp stopped (~475 px Y travel at mid-bucket MouseSensitivity). Camera should pan further than it did before.
- [ ] LMB-drag straight DOWN, same test other direction.
- [ ] Report: does the vertical range feel right at ±90? Too much / too little / good?

### Scenario B — Bug #3 autorun engagement test (flip DIAGNOSE flag, rebuild)

Edit `Zeal/lmb_pan.cpp` around line 91:

```cpp
#define ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE 1   // was 0
```

Rebuild + redeploy:

```
msbuild Zeal.sln /p:Configuration=Release /p:Platform=x86
Copy-Item Release\Zeal.asi D:\EQEmu\Full_RoF2\Zeal.asi -Force
Remove-Item D:\EQEmu\Full_RoF2\lmb_pan_diag.log -ErrorAction SilentlyContinue
```

In-game test (3rd-person):
- [ ] Press autorun key (default whatever you have bound — was Num\ in stock).
- [ ] While autorun is going: hold LMB and drag to pan ~100px (commits to PANNING).
- [ ] Release LMB → enters HELD.
- [ ] Press AND HOLD RMB for ~2 seconds (snap-back fires + post-snap diag captures 90 frames).
- [ ] Release RMB.
- [ ] `/quit` (clean exit so the diag log flushes).
- [ ] Send back the contents of `D:\EQEmu\Full_RoF2\lmb_pan_diag.log` — specifically the `[pan-snap-back]` line + the 90 `[post-snap N]` lines that follow.

What I'll look for: does `cam[1..3]` (position) drift across the 90 captured frames? If YES → EQ engaged drive-forward despite our snap-back consuming the buttons → autorun engagement IS firing, the "doesn't engage" report may be a different symptom. If NO → confirms autorun was indeed never engaged → ClipCursor or our snap-back IS interfering with EQ's drive setup; next iter can target the specific mutation.

### Scenario C — Bug #2 alt-tab snap-back test (DIAGNOSE flag still on, no rebuild)

Continue from scenario B (don't disable flag yet):
- [ ] Delete `lmb_pan_diag.log` for a clean capture.
- [ ] In-game 3rd-person.
- [ ] Hold LMB and drag to pan ~100px (PANNING).
- [ ] Keep LMB held, ALT-TAB away to another app (e.g. browser).
- [ ] In the other app, click anywhere (releases LMB physically from Zeal's POV).
- [ ] ALT-TAB back to EQ.
- [ ] Wait ~1 sec.
- [ ] Press RMB once (snap-back should fire if bug is absent; should NOT fire if bug #2 is present).
- [ ] `/quit`.
- [ ] Send back the log — specifically the `[focus]` lines and any `[pan-snap-back]` / `[post-snap]` lines after them.

What I'll look for: did the `[focus]` log show both EDGE transitions (FOREGROUND → background → FOREGROUND)? Did the post-regain RMB press fire a `[pan-snap-back]` line? If snap-back didn't fire → bug confirmed; next iter targets the GetAsyncKeyState-after-focus-regain path. If snap-back DID fire → bug #2 may be a different lag perception.

### Cleanup (after both tests)

Revert the DIAGNOSE flag for friend-ready builds:

```cpp
#define ZEAL_ROF2_R3_LMB_PAN_DIAGNOSE 0   // back to friend-default
```

Rebuild + ship via client-pack release chain when ready.

## Notes

- The DIAGNOSE flag is OFF by default in this PR; friend builds are unaffected by the diag code.
- The Bug #7 pitch clamp bump IS active by default — friends get the wider vertical range on next client-pack release.
- C-7 (Ghidra hunt for EQ's internal SetCapture) is a separate workstream; no code change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
