### PR TITLE
quarmy update

### DIFF
--- a/Zeal/outputfile.cpp
+++ b/Zeal/outputfile.cpp
@@ -354,7 +354,19 @@ void OutputFile::export_quarmy(const std::vector<std::string> &args) {
     }
   }
 
-  // Section 4: CRC32 checksum for tamper detection.
+  // Section 4: Tradeskills (SkillID and current value; 255 = untrained).
+  oss << "SkillID" << t << "Value" << std::endl;
+  constexpr Zeal::GameEnums::SkillType kTradeskills[] = {
+      Zeal::GameEnums::SkillFishing,       Zeal::GameEnums::SkillMakePoison,
+      Zeal::GameEnums::SkillTinkering,     Zeal::GameEnums::SkillResearch,
+      Zeal::GameEnums::SkillAlchemy,       Zeal::GameEnums::SkillBaking,
+      Zeal::GameEnums::SkillTailoring,     Zeal::GameEnums::SkillBlacksmithing,
+      Zeal::GameEnums::SkillFletching,     Zeal::GameEnums::SkillBrewing,
+      Zeal::GameEnums::SkillJewelryMaking, Zeal::GameEnums::SkillPottery};
+  for (auto skill : kTradeskills)
+    oss << static_cast<int>(skill) << t << self->CharInfo->Skills[skill] << std::endl;
+
+  // Section 5: CRC32 checksum for tamper detection.
   std::string content = oss.str();
   mz_ulong crc = mz_crc32(MZ_CRC32_INIT, reinterpret_cast<const unsigned char *>(content.c_str()), content.size());
   content += "Checksum\t" + std::to_string(crc) + "\n";


### PR DESCRIPTION
# Add tradeskill section to quarmy export

- Add 12-row `SkillID\tValue` section to `export_quarmy()` in outputfile.cpp (lines 357–368)
- Emits raw skill values for tradeskills: Fishing, Make Poison, Tinkering, Research, Alchemy, Baking, Tailoring, Blacksmithing, Fletching, Brewing, Jewelry Making, Pottery (255 = untrained)
- Matches server's `EQ::skills::IsTradeskill` in EQMacEmu
- Positioned between AA section and checksum; CRC32 covers new rows automatically
- Update: section numbering (old Section 4 → Section 5)