### PR TITLE
Extended Map Rings (Number Of & Colors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,8 @@ on and off with `/map ring` (or explicitly on or off with `ring on` or `ring off
 the ring radius in the direction of your heading. Up to four radius values can be provided,
 to have multiple rings shown on the map at the same time. If you wish to mix radius numbers,
 with the automatic track range, use the word `track` for the value. Radius values cannot go
-below 10, or above 10000.
+below 10, or above 10000. Ring color settings are respective to the order in which the value
+is entered, not from innermost to outtermost rings.
 
 * Command examples:
   - `/map ring` if visible or a non-tracker, turns ring off
@@ -1054,6 +1055,7 @@ below 10, or above 10000.
   - `/map ring off` turns ring off
   - `/map ring 500` sets the ring around the player at a distance of 500 (all classes)
   - `/map ring 250 track` sets the ring around the player at a distance of 250 AND sets another ring using tracking distance
+  - `/map ring 100 200 300 400` sets four rings around the player at the distances of 100, 200, 300 and 400
 
 #### Showing group and raid members
 The map supports showing the live position of other group and raid members. The group

--- a/README.md
+++ b/README.md
@@ -1042,7 +1042,10 @@ A simple distance ring around the current position is available. The distance ca
 based on the tracking skill for rangers, druids, and bards, so they can simply toggle the ring
 on and off with `/map ring` (or explicitly on or off with `ring on` or `ring off`). The
 `/map ring heading` command toggles on and off a setting to add a line from your position to
-the ring radius in the direction of your heading.
+the ring radius in the direction of your heading. Up to four radius values can be provided,
+to have multiple rings shown on the map at the same time. If you wish to mix radius numbers,
+with the automatic track range, use the word `track` for the value. Radius values cannot go
+below 10, or above 10000.
 
 * Command examples:
   - `/map ring` if visible or a non-tracker, turns ring off
@@ -1050,6 +1053,7 @@ the ring radius in the direction of your heading.
   - `/map ring on` sets the ring at max tracking distance per skill level
   - `/map ring off` turns ring off
   - `/map ring 500` sets the ring around the player at a distance of 500 (all classes)
+  - `/map ring 250 track` sets the ring around the player at a distance of 250 AND sets another ring using tracking distance
 
 #### Showing group and raid members
 The map supports showing the live position of other group and raid members. The group

--- a/Zeal/ui_options.cpp
+++ b/Zeal/ui_options.cpp
@@ -217,6 +217,8 @@ int __fastcall WndNotification(Zeal::GameUI::BasicWnd *wnd, int unused, Zeal::Ga
     if (message == 0x1E && ui->clicked_button) {
       ui->clicked_button->TextColor.ARGB = data | 0xff000000;  // Ensure alpha = 0xff.
       ui->options->SaveColors();
+      ui->options->SaveRingColors();
+      ui->options->SaveHeadingColor();
     }
   }
   return reinterpret_cast<int(__thiscall *)(Zeal::GameUI::BasicWnd * wnd, Zeal::GameUI::BasicWnd * sender, int message,
@@ -274,6 +276,14 @@ static constexpr std::array<ColorButtonEntry, num_color_buttons> color_button_de
     {"MyBitHits", D3DCOLOR_XRGB(0xf9, 0x9b, 0xff)},      // 40: Pink
 }};
 
+static constexpr int num_ring_buttons = 4;
+static constexpr std::array<ColorButtonEntry, num_ring_buttons> ring_button_defaults = {{
+    {"Ring0", D3DCOLOR_XRGB(183, 225, 161)}, // Ring 1, grey-green
+    {"Ring1", D3DCOLOR_XRGB(183, 225, 161)},
+    {"Ring2", D3DCOLOR_XRGB(183, 225, 161)},
+    {"Ring3", D3DCOLOR_XRGB(183, 225, 161)}, // Ring 4
+}};
+
 void ui_options::SaveColors() const {
   IO_ini *ini = ZealService::get_instance()->ini.get();
   for (auto i = 0; i < color_buttons.size(); ++i) {
@@ -298,6 +308,52 @@ void ui_options::LoadColors() {
     color_buttons[i]->TextColor.ARGB =
         ini->exists(section, name) ? ini->getValue<DWORD>(section, name) : color_button_defaults[i].color;
   }
+}
+
+void ui_options::SaveRingColors() const {
+  IO_ini *ini = ZealService::get_instance()->ini.get();
+  for (auto i = 0; i < ring_buttons.size(); ++i) {
+    if (!ring_buttons[i]) continue;
+    ini->setValue("ZealColors", "Ring" + std::to_string(i), std::to_string(ring_buttons[i]->TextColor.ARGB));
+  }
+}
+
+DWORD ui_options::GetRingColor(int index) const {
+  if (index >= 0 && index < ring_buttons.size()) {
+    return ring_buttons[index] ? ring_buttons[index]->TextColor.ARGB : ring_button_defaults[index].color;
+  }
+
+  return D3DCOLOR_XRGB(183, 225, 161);
+}
+
+void ui_options::LoadRingColors() {
+  IO_ini *ini = ZealService::get_instance()->ini.get();
+  const std::string section = "ZealColors";
+  for (int i = 0; i < ring_buttons.size(); ++i) {
+    if (!ring_buttons[i]) continue;
+    std::string name = "Ring" + std::to_string(i);
+    ring_buttons[i]->TextColor.ARGB =
+        ini->exists(section, name) ? ini->getValue<DWORD>(section, name) : ring_button_defaults[i].color;
+  }
+}
+
+void ui_options::SaveHeadingColor() const {
+  IO_ini *ini = ZealService::get_instance()->ini.get();
+  ini->setValue("ZealColors", "HeadingColor", std::to_string(heading_button->TextColor.ARGB));
+}
+
+DWORD ui_options::GetHeadingColor() const { 
+  if (heading_button) return heading_button->TextColor.ARGB;
+
+  return D3DCOLOR_XRGB(183, 255, 161);
+}
+
+void ui_options::LoadHeadingColor() {
+  IO_ini *ini = ZealService::get_instance()->ini.get();
+  const std::string section = "ZealColors";
+  const std::string name = "HeadingColor";
+  if (!heading_button) return;
+  heading_button->TextColor.ARGB = ini->exists(section, name) ? ini->getValue<DWORD>(section, name) : D3DCOLOR_XRGB(183, 255, 161);
 }
 
 void ui_options::InitUI() {
@@ -678,6 +734,7 @@ void ui_options::InitCamera() {
 
 void ui_options::InitMap() {
   if (!wnd) return;
+
   ui->AddCheckboxCallback(wnd, "Zeal_Map", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->zone_map->set_enabled(wnd->Checked, true);
   });
@@ -705,6 +762,13 @@ void ui_options::InitMap() {
   ui->AddCheckboxCallback(wnd, "Zeal_MapShowPlayerHeadings", [](Zeal::GameUI::BasicWnd *wnd) {
     ZealService::get_instance()->zone_map->setting_show_all_player_headings.set(wnd->Checked);
   });
+  ui->AddCheckboxCallback(wnd, "Zeal_MapUseFarRing", [](Zeal::GameUI::BasicWnd *wnd) {
+    ZealService::get_instance()->zone_map->setting_heading_use_far_ring.set(wnd->Checked);
+  });
+  ui->AddCheckboxCallback(wnd, "Zeal_MapHeadingUsesRingColor", [](Zeal::GameUI::BasicWnd *wnd) { 
+    ZealService::get_instance()->zone_map->setting_heading_use_ring_color.set(wnd->Checked);
+  });
+
   ui->AddComboCallback(wnd, "Zeal_MapShowGroup_Combobox", [this](Zeal::GameUI::BasicWnd *wnd, int value) {
     ZealService::get_instance()->zone_map->set_show_group_mode(value);
   });
@@ -752,6 +816,29 @@ void ui_options::InitMap() {
   ui->AddSliderCallback(wnd, "Zeal_MapGridPitch_Slider", [this](Zeal::GameUI::SliderWnd *wnd, int value) {
     ZealService::get_instance()->zone_map->set_grid_pitch(value * ZoneMap::kMaxGridPitch / 100);
   });
+
+  // Like the color buttons, the ring buttons is loaded here with the max number of buttons (nullptr if not present)
+  ring_buttons.clear();
+  for (int i = 0; i < num_ring_buttons; i++) {
+    if (!ring_button_defaults[i].name) {
+      ring_buttons.push_back(nullptr);
+    } else {
+      ring_buttons.push_back(ui->AddButtonCallback(
+          wnd, "Zeal_Ring" + std::to_string(i),
+          [](Zeal::GameUI::BasicWnd *wnd) { Zeal::Game::Windows->ColorPicker->Activate(wnd, wnd->TextColor.ARGB); },
+          false));
+    }
+  }
+
+  LoadRingColors();
+
+  heading_button = ui->AddButtonCallback(
+      wnd, "Zeal_MapHeadingColor",
+      [](Zeal::GameUI::BasicWnd *wnd) { Zeal::Game::Windows->ColorPicker->Activate(wnd, wnd->TextColor.ARGB); },
+      false);
+
+  LoadHeadingColor();
+
   ui->AddLabel(wnd, "Zeal_MapZoom_Value");
   ui->AddLabel(wnd, "Zeal_MapPositionSize_Value");
   ui->AddLabel(wnd, "Zeal_MapMarkerSize_Value");
@@ -1240,6 +1327,9 @@ void ui_options::UpdateOptionsMap() {
   ui->SetChecked("Zeal_MapAddSpeedText", ZealService::get_instance()->zone_map->setting_add_speed_text.get());
   ui->SetChecked("Zeal_MapShowPlayerHeadings",
                  ZealService::get_instance()->zone_map->setting_show_all_player_headings.get());
+  ui->SetChecked("Zeal_MapUseFarRing", ZealService::get_instance()->zone_map->setting_heading_use_far_ring.get());
+  ui->SetChecked("Zeal_MapHeadingUsesRingColor",
+                 ZealService::get_instance()->zone_map->setting_heading_use_ring_color.get());
   ui->SetComboValue("Zeal_MapShowGroup_Combobox", ZealService::get_instance()->zone_map->get_show_group_mode());
   ui->SetComboValue("Zeal_MapBackground_Combobox", ZealService::get_instance()->zone_map->get_background());
   ui->SetComboValue("Zeal_MapAlignment_Combobox", ZealService::get_instance()->zone_map->get_alignment());

--- a/Zeal/ui_options.h
+++ b/Zeal/ui_options.h
@@ -20,6 +20,12 @@ class ui_options {
   void SaveColors() const;
   void LoadColors();
   DWORD GetColor(int index) const;
+  void SaveRingColors() const;
+  void LoadRingColors();
+  void SaveHeadingColor() const;
+  DWORD GetHeadingColor() const;
+  void LoadHeadingColor();
+  DWORD GetRingColor(int index) const;
   void ShowInviteDialog(const char *raid_invite_name = nullptr, bool cross_zone = false) const;
   void HideInviteDialog() const;
   void PlayInviteSound() const;
@@ -69,6 +75,8 @@ class ui_options {
 
   Zeal::GameUI::SidlWnd *wnd = nullptr;
   std::vector<Zeal::GameUI::BasicWnd *> color_buttons;
+  std::vector<Zeal::GameUI::BasicWnd *> ring_buttons;
+  Zeal::GameUI::BasicWnd*  heading_button;
   UIManager *const ui;
   std::vector<std::pair<int, std::string>> sound_list;  // WavePlay index table.
   char ini_autojoin_name[16 + 30 + 2];                  // Space for "ChannelAutoJoin_" + self->name + null.

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -1,1294 +1,1109 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <XML ID="EQInterfaceDefinitionLanguage">
-	<Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
-	<Button item="Zeal_Map">
-		<ScreenID>Zeal_Map</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>14</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Toggles the map overlay</TooltipReference>
-		<Text>Enabled</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Zeal Map Background Combobox -->
-	<Label item="Zeal_MapBackground_Label">
-		<ScreenID>Zeal_MapBackground_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>43</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Background</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Combobox item="Zeal_MapBackground_Combobox">
-		<ScreenID>Zeal_MapBackground_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>10</X>
-			<Y>63</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>None</Choices>
-		<Choices>Dark</Choices>
-		<Choices>Light</Choices>
-		<Choices>Tan</Choices>
-	</Combobox>
-	<!-- Zeal Map Background Alpha -->
-	<Label item="Zeal_MapBackgroundAlpha_Label">
-		<ScreenID>Zeal_MapBackgroundAlpha_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>100</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Background alpha</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Slider item="Zeal_MapBackgroundAlpha_Slider">
-		<ScreenID>Zeal_MapBackgroundAlpha_Slider</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>120</Y>
-		</Location>
-		<Size>
-			<CX>100</CX>
-			<CY>16</CY>
-		</Size>
-		<SliderArt>SDT_DefSlider</SliderArt>
-	</Slider>
-	<Label item="Zeal_MapBackgroundAlpha_Value">
-		<ScreenID>Zeal_MapBackgroundAlpha_Value</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>110</X>
-			<Y>120</Y>
-		</Location>
-		<Size>
-			<CX>40</CX>
-			<CY>16</CY>
-		</Size>
-		<Text>0</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>true</AlignRight>
-	</Label>
-	<!-- Zeal Map Faded ZLevel Alpha -->
-	<Label item="Zeal_MapFadedZLevelAlpha_Label">
-		<ScreenID>Zeal_MapFadedZLevelAlpha_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>142</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Faded Z-level alpha</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Slider item="Zeal_MapFadedZLevelAlpha_Slider">
-		<ScreenID>Zeal_MapFadedZLevelAlpha_Slider</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>162</Y>
-		</Location>
-		<Size>
-			<CX>100</CX>
-			<CY>16</CY>
-		</Size>
-		<SliderArt>SDT_DefSlider</SliderArt>
-	</Slider>
-	<Label item="Zeal_MapFadedZLevelAlpha_Value">
-		<ScreenID>Zeal_MapFadedZLevelAlpha_Value</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>110</X>
-			<Y>162</Y>
-		</Location>
-		<Size>
-			<CX>40</CX>
-			<CY>16</CY>
-		</Size>
-		<Text>0</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>true</AlignRight>
-	</Label>
-	<!-- Zeal Map AutoFade Enable-->
-	<Button item="Zeal_MapAutoFadeEnable">
-		<ScreenID>Zeal_MapAutoFadeEnable</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>184</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Defaults to z-level autofade mode</TooltipReference>
-		<Text>Default to Z Autofade</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Zeal Map Alignment Combobox -->
-	<Label item="Zeal_MapAlignment_Label">
-		<ScreenID>Zeal_MapAlignment_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>214</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Alignment</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Combobox item="Zeal_MapAlignment_Combobox">
-		<ScreenID>Zeal_MapAlignment_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>10</X>
-			<Y>234</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>Top Left</Choices>
-		<Choices>Top Center</Choices>
-		<Choices>Top Right</Choices>
-	</Combobox>
-	<!-- Zeal Map Labels Combobox -->
-	<Label item="Zeal_MapLabels_Label">
-		<ScreenID>Zeal_MapLabels_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>269</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Labels</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Combobox item="Zeal_MapLabels_Combobox">
-		<ScreenID>Zeal_MapLabels_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>10</X>
-			<Y>289</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>Off</Choices>
-		<Choices>Summary</Choices>
-		<Choices>All</Choices>
-		<Choices>Marker only</Choices>
-	</Combobox>
-	<!-- Zeal Map ShowGroup Combobox -->
-	<Label item="Zeal_MapShowGroup_Label">
-		<ScreenID>Zeal_MapShowGroup_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>324</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Show group members</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Combobox item="Zeal_MapShowGroup_Combobox">
-		<ScreenID>Zeal_MapShowGroup_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>10</X>
-			<Y>344</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>Off</Choices>
-		<Choices>Markers only</Choices>
-		<Choices>Markers and numbers</Choices>
-		<Choices>Markers and names</Choices>
-	</Combobox>
-	<!-- Zeal Map Show Raid Members-->
-	<Button item="Zeal_MapShowRaid">
-		<ScreenID>Zeal_MapShowRaid</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>379</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Shows raid members on map</TooltipReference>
-		<Text>Show Raid</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Zeal Map Show Player Headings-->
-	<Button item="Zeal_MapShowPlayerHeadings">
-		<ScreenID>Zeal_MapShowPlayerHeadings</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>401</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Shows all player headings</TooltipReference>
-		<Text>Show Headings</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Zeal Map Names Length -->
-	<Label item="Zeal_MapNamesLength_Label">
-		<ScreenID>Zeal_MapNamesLength_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>431</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Member names length</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Slider item="Zeal_MapNamesLength_Slider">
-		<ScreenID>Zeal_MapNamesLength_Slider</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>451</Y>
-		</Location>
-		<Size>
-			<CX>100</CX>
-			<CY>16</CY>
-		</Size>
-		<SliderArt>SDT_DefSlider</SliderArt>
-	</Slider>
-	<Label item="Zeal_MapNamesLength_Value">
-		<ScreenID>Zeal_MapNamesLength_Value</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>110</X>
-			<Y>451</Y>
-		</Location>
-		<Size>
-			<CX>40</CX>
-			<CY>16</CY>
-		</Size>
-		<Text>0</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>true</AlignRight>
-	</Label>
-	<!-- Zeal Map Show Grid-->
-	<Button item="Zeal_MapShowGrid">
-		<ScreenID>Zeal_MapShowGrid</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>474</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Shows grid lines on map</TooltipReference>
-		<Text>Show grid lines</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Zeal Map Grid Pitch -->
-	<Label item="Zeal_MapGridPitch_Label">
-		<ScreenID>Zeal_MapGridPitch_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>504</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Grid line pitch</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Slider item="Zeal_MapGridPitch_Slider">
-		<ScreenID>Zeal_MapGridPitch_Slider</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>10</X>
-			<Y>524</Y>
-		</Location>
-		<Size>
-			<CX>100</CX>
-			<CY>16</CY>
-		</Size>
-		<SliderArt>SDT_DefSlider</SliderArt>
-	</Slider>
-	<Label item="Zeal_MapGridPitch_Value">
-		<ScreenID>Zeal_MapGridPitch_Value</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>110</X>
-			<Y>524</Y>
-		</Location>
-		<Size>
-			<CX>40</CX>
-			<CY>16</CY>
-		</Size>
-		<Text>0</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>true</AlignRight>
-	</Label>
-	<!-- Zeal Map Keybinds Reminder -->
-	<Label item="Zeal_MapKeyBinds_Label">
-		<ScreenID>Zeal_MapKeyBinds_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>5</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>32</CY>
-		</Size>
-		<Text>See Keyboard-&gt;UI for Map Keybinds (recommended)</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<!-- Zeal Map Sizing Reminder -->
-	<Label item="Zeal_MapSizing_Label">
-		<ScreenID>Zeal_MapSizing_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>43</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>32</CY>
-		</Size>
-		<Text>Use unlocked interactive mode to resize/move map.</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<!-- Zeal Map Interactive Enable-->
-	<Button item="Zeal_MapInteractiveEnable">
-		<ScreenID>Zeal_MapInteractiveEnable</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>95</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Enables windowed mode for internal map</TooltipReference>
-		<Text>Interactive Enable</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Zeal Map External Window Enable-->
-	<Button item="Zeal_MapExternalWindow">
-		<ScreenID>Zeal_MapExternalWindow</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>125</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Shows map in an external window</TooltipReference>
-		<Text>External Window</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<!-- Zeal Map Position Size -->
-	<Label item="Zeal_MapPositionSize_Label">
-		<ScreenID>Zeal_MapPositionSize_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>156</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Position size</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Slider item="Zeal_MapPositionSize_Slider">
-		<ScreenID>Zeal_MapPositionSize_Slider</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>176</Y>
-		</Location>
-		<Size>
-			<CX>100</CX>
-			<CY>16</CY>
-		</Size>
-		<SliderArt>SDT_DefSlider</SliderArt>
-	</Slider>
-	<Label item="Zeal_MapPositionSize_Value">
-		<ScreenID>Zeal_MapPositionSize_Value</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>297</X>
-			<Y>176</Y>
-		</Location>
-		<Size>
-			<CX>50</CX>
-			<CY>16</CY>
-		</Size>
-		<Text>0</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>true</AlignRight>
-	</Label>
-	<!-- Zeal Map Marker Size -->
-	<Label item="Zeal_MapMarkerSize_Label">
-		<ScreenID>Zeal_MapMarkerSize_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>198</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Marker size</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Slider item="Zeal_MapMarkerSize_Slider">
-		<ScreenID>Zeal_MapMarkerSize_Slider</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>218</Y>
-		</Location>
-		<Size>
-			<CX>100</CX>
-			<CY>16</CY>
-		</Size>
-		<SliderArt>SDT_DefSlider</SliderArt>
-	</Slider>
-	<Label item="Zeal_MapMarkerSize_Value">
-		<ScreenID>Zeal_MapMarkerSize_Value</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>297</X>
-			<Y>218</Y>
-		</Location>
-		<Size>
-			<CX>50</CX>
-			<CY>16</CY>
-		</Size>
-		<Text>0</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>true</AlignRight>
-	</Label>
-	<!-- Zeal Map Zoom -->
-	<Label item="Zeal_MapZoom_Label">
-		<ScreenID>Zeal_MapZoom_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>240</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Zoom</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Slider item="Zeal_MapZoom_Slider">
-		<ScreenID>Zeal_MapZoom_Slider</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>260</Y>
-		</Location>
-		<Size>
-			<CX>100</CX>
-			<CY>16</CY>
-		</Size>
-		<SliderArt>SDT_DefSlider</SliderArt>
-	</Slider>
-	<Label item="Zeal_MapZoom_Value">
-		<ScreenID>Zeal_MapZoom_Value</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>297</X>
-			<Y>260</Y>
-		</Location>
-		<Size>
-			<CX>50</CX>
-			<CY>16</CY>
-		</Size>
-		<Text>0</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>true</AlignRight>
-	</Label>
-	<!-- Zeal Default Zoom Combobox -->
-	<Label item="Zeal_MapZoomDefault_Label">
-		<ScreenID>Zeal_MapZoomDefault_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>292</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Default Zoom</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Combobox item="Zeal_MapZoomDefault_Combobox">
-		<ScreenID>Zeal_MapZoomDefault_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>197</X>
-			<Y>312</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>100% (1x)</Choices>
-		<Choices>200% (2x)</Choices>
-		<Choices>400% (4x)</Choices>
-		<Choices>800% (8x)</Choices>
-	</Combobox>
-	<!-- Zeal Map Font Combobox -->
-	<Label item="Zeal_MapFont_Label">
-		<ScreenID>Zeal_MapFont_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>347</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Font</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Combobox item="Zeal_MapFont_Combobox">
-		<ScreenID>Zeal_MapFont_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>197</X>
-			<Y>367</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>default</Choices>
-	</Combobox>
-	<!-- Zeal Map Data Mode Combobox -->
-	<Label item="Zeal_MapDataMode_Label">
-		<ScreenID>Zeal_MapDataMode_Label</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>402</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>14</CY>
-		</Size>
-		<Text>Map data source</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<NoWrap>true</NoWrap>
-		<AlignCenter>false</AlignCenter>
-		<AlignRight>false</AlignRight>
-	</Label>
-	<Combobox item="Zeal_MapDataMode_Combobox">
-		<ScreenID>Zeal_MapDataMode_Combobox</ScreenID>
-		<DrawTemplate>WDT_Inner</DrawTemplate>
-		<Location>
-			<X>197</X>
-			<Y>422</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>24</CY>
-		</Size>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ListHeight>70</ListHeight>
-		<Button>BDT_Combo</Button>
-		<Style_Border>true</Style_Border>
-		<Choices>Internal only</Choices>
-		<Choices>Both</Choices>
-		<Choices>External</Choices>
-		<Choices>Both - No Internal POI</Choices>
-	</Combobox>
-	<Button item="Zeal_MapAddLocText">
-		<ScreenID>Zeal_MapAddLocText</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>458</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Adds location coordinates to map</TooltipReference>
-		<Text>Add /loc text</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<Button item="Zeal_MapAddSpeedText">
-		<ScreenID>Zeal_MapAddSpeedText</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>480</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<TooltipReference>Adds current normalized speed to map</TooltipReference>
-		<Text>Add speed text</Text>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<Button item="Zeal_Ring0">
-		<ScreenID>Zeal_Ring0</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>502</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>false</Style_Checkbox>
-		<Text>Ring 1 Color</Text>
-		<TooltipReference>Color for first ring value</TooltipReference>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<Button item="Zeal_Ring1">
-		<ScreenID>Zeal_Ring1</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>524</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>false</Style_Checkbox>
-		<Text>Ring 2 Color</Text>
-		<TooltipReference>Color for second ring value</TooltipReference>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<Button item="Zeal_Ring2">
-		<ScreenID>Zeal_Ring2</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>546</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>false</Style_Checkbox>
-		<Text>Ring 3 Color</Text>
-		<TooltipReference>Color for third ring value</TooltipReference>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<Button item="Zeal_Ring3">
-		<ScreenID>Zeal_Ring3</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>568</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>false</Style_Checkbox>
-		<Text>Ring 4 Color</Text>
-		<TooltipReference>Color for fourth ring value</TooltipReference>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<Button item="Zeal_MapUseFarRing">
-		<ScreenID>Zeal_MapUseFarRing</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>590</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<Text>Heading Line Uses Far</Text>
-		<TooltipReference>Heading line uses furthest (pressed) or closest (unpressed) ring size</TooltipReference>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
-	<Button item="Zeal_MapHeadingColor">
-		<ScreenID>Zeal_MapHeadingColor</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<Location>
-			<X>197</X>
-			<Y>612</Y>
-		</Location>
-		<Size>
-			<CX>150</CX>
-			<CY>20</CY>
-		</Size>
-		<Style_VScroll>false</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<Style_Checkbox>true</Style_Checkbox>
-		<Text>Heading Color</Text>
-		<TooltipReference>Heading line color</TooltipReference>
-		<TextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TextColor>
-		<ButtonDrawTemplate>
-			<Normal>A_BtnNormal</Normal>
-			<Pressed>A_BtnPressed</Pressed>
-			<Flyby>A_BtnFlyby</Flyby>
-			<Disabled>A_BtnDisabled</Disabled>
-			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-		</ButtonDrawTemplate>
-	</Button>
+  <Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
+<Button item="Zeal_Map">
+    <ScreenID>Zeal_Map</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>14</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Toggles the map overlay</TooltipReference>
+    <Text>Enabled</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Map Background Combobox -->
+  <Label item="Zeal_MapBackground_Label">
+    <ScreenID>Zeal_MapBackground_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>43</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Background</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapBackground_Combobox">
+    <ScreenID>Zeal_MapBackground_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>10</X>
+      <Y>63</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>None</Choices>
+    <Choices>Dark</Choices>
+    <Choices>Light</Choices>
+    <Choices>Tan</Choices>
+  </Combobox>  
+  <!-- Zeal Map Background Alpha -->
+  <Label item="Zeal_MapBackgroundAlpha_Label">
+    <ScreenID>Zeal_MapBackgroundAlpha_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>100</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Background alpha</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapBackgroundAlpha_Slider">
+    <ScreenID>Zeal_MapBackgroundAlpha_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>120</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapBackgroundAlpha_Value">
+    <ScreenID>Zeal_MapBackgroundAlpha_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>110</X>
+      <Y>120</Y>
+    </Location>
+    <Size>
+      <CX>40</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Faded ZLevel Alpha -->
+  <Label item="Zeal_MapFadedZLevelAlpha_Label">
+    <ScreenID>Zeal_MapFadedZLevelAlpha_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>142</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Faded Z-level alpha</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapFadedZLevelAlpha_Slider">
+    <ScreenID>Zeal_MapFadedZLevelAlpha_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>162</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapFadedZLevelAlpha_Value">
+    <ScreenID>Zeal_MapFadedZLevelAlpha_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>110</X>
+      <Y>162</Y>
+    </Location>
+    <Size>
+      <CX>40</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map AutoFade Enable-->
+  <Button item="Zeal_MapAutoFadeEnable">
+    <ScreenID>Zeal_MapAutoFadeEnable</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>184</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Defaults to z-level autofade mode</TooltipReference>
+    <Text>Default to Z Autofade</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Map Alignment Combobox -->
+  <Label item="Zeal_MapAlignment_Label">
+    <ScreenID>Zeal_MapAlignment_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>214</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Alignment</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapAlignment_Combobox">
+    <ScreenID>Zeal_MapAlignment_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>10</X>
+      <Y>234</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>Top Left</Choices>
+    <Choices>Top Center</Choices>
+    <Choices>Top Right</Choices>
+  </Combobox>
+  <!-- Zeal Map Labels Combobox -->
+  <Label item="Zeal_MapLabels_Label">
+    <ScreenID>Zeal_MapLabels_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>269</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Labels</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapLabels_Combobox">
+    <ScreenID>Zeal_MapLabels_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>10</X>
+      <Y>289</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>Off</Choices>
+    <Choices>Summary</Choices>
+    <Choices>All</Choices>
+    <Choices>Marker only</Choices>
+  </Combobox>
+  <!-- Zeal Map ShowGroup Combobox -->
+  <Label item="Zeal_MapShowGroup_Label">
+    <ScreenID>Zeal_MapShowGroup_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>324</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Show group members</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapShowGroup_Combobox">
+    <ScreenID>Zeal_MapShowGroup_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>10</X>
+      <Y>344</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>Off</Choices>
+    <Choices>Markers only</Choices>
+    <Choices>Markers and numbers</Choices>
+    <Choices>Markers and names</Choices>
+  </Combobox>  
+  <!-- Zeal Map Show Raid Members-->
+  <Button item="Zeal_MapShowRaid">
+    <ScreenID>Zeal_MapShowRaid</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>379</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shows raid members on map</TooltipReference>
+    <Text>Show Raid</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Map Show Player Headings-->
+  <Button item="Zeal_MapShowPlayerHeadings">
+    <ScreenID>Zeal_MapShowPlayerHeadings</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>401</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shows all player headings</TooltipReference>
+    <Text>Show Headings</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Map Names Length -->
+  <Label item="Zeal_MapNamesLength_Label">
+    <ScreenID>Zeal_MapNamesLength_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>431</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Member names length</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapNamesLength_Slider">
+    <ScreenID>Zeal_MapNamesLength_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>451</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapNamesLength_Value">
+    <ScreenID>Zeal_MapNamesLength_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>110</X>
+      <Y>451</Y>
+    </Location>
+    <Size>
+      <CX>40</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Show Grid-->
+  <Button item="Zeal_MapShowGrid">
+    <ScreenID>Zeal_MapShowGrid</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>474</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Shows grid lines on map</TooltipReference>
+    <Text>Show grid lines</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Map Grid Pitch -->
+  <Label item="Zeal_MapGridPitch_Label">
+    <ScreenID>Zeal_MapGridPitch_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>504</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Grid line pitch</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapGridPitch_Slider">
+    <ScreenID>Zeal_MapGridPitch_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>10</X>
+      <Y>524</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapGridPitch_Value">
+    <ScreenID>Zeal_MapGridPitch_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>110</X>
+      <Y>524</Y>
+    </Location>
+    <Size>
+      <CX>40</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Keybinds Reminder -->
+  <Label item="Zeal_MapKeyBinds_Label">
+    <ScreenID>Zeal_MapKeyBinds_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>5</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>32</CY>
+    </Size>
+    <Text>See Keyboard-&gt;UI for Map Keybinds (recommended)</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <!-- Zeal Map Sizing Reminder -->
+  <Label item="Zeal_MapSizing_Label">
+    <ScreenID>Zeal_MapSizing_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>43</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>32</CY>
+    </Size>
+    <Text>Use unlocked interactive mode to resize/move map.</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <!-- Zeal Map Interactive Enable-->
+  <Button item="Zeal_MapInteractiveEnable">
+    <ScreenID>Zeal_MapInteractiveEnable</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>95</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Enables windowed mode for internal map</TooltipReference>
+    <Text>Interactive Enable</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <!-- Zeal Map External Window Enable-->
+    <Button item="Zeal_MapExternalWindow">
+      <ScreenID>Zeal_MapExternalWindow</ScreenID>
+      <RelativePosition>true</RelativePosition>
+      <Location>
+        <X>197</X>
+        <Y>125</Y>
+      </Location>
+      <Size>
+        <CX>150</CX>
+        <CY>20</CY>
+      </Size>
+      <Style_VScroll>false</Style_VScroll>
+      <Style_HScroll>false</Style_HScroll>
+      <Style_Transparent>false</Style_Transparent>
+      <Style_Checkbox>true</Style_Checkbox>
+      <TooltipReference>Shows map in an external window</TooltipReference>
+      <Text>External Window</Text>
+      <TextColor>
+        <R>255</R>
+        <G>255</G>
+        <B>255</B>
+      </TextColor>
+      <ButtonDrawTemplate>
+        <Normal>A_BtnNormal</Normal>
+        <Pressed>A_BtnPressed</Pressed>
+        <Flyby>A_BtnFlyby</Flyby>
+        <Disabled>A_BtnDisabled</Disabled>
+        <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+      </ButtonDrawTemplate>
+    </Button>
+  <!-- Zeal Map Position Size -->
+  <Label item="Zeal_MapPositionSize_Label">
+    <ScreenID>Zeal_MapPositionSize_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>156</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Position size</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapPositionSize_Slider">
+    <ScreenID>Zeal_MapPositionSize_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>176</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapPositionSize_Value">
+    <ScreenID>Zeal_MapPositionSize_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>176</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Marker Size -->
+  <Label item="Zeal_MapMarkerSize_Label">
+    <ScreenID>Zeal_MapMarkerSize_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>198</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Marker size</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapMarkerSize_Slider">
+    <ScreenID>Zeal_MapMarkerSize_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>218</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapMarkerSize_Value">
+    <ScreenID>Zeal_MapMarkerSize_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>218</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Map Zoom -->
+  <Label item="Zeal_MapZoom_Label">
+    <ScreenID>Zeal_MapZoom_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>240</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Zoom</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Slider item="Zeal_MapZoom_Slider">
+    <ScreenID>Zeal_MapZoom_Slider</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>260</Y>
+    </Location>
+    <Size>
+      <CX>100</CX>
+      <CY>16</CY>
+    </Size>
+    <SliderArt>SDT_DefSlider</SliderArt>
+  </Slider>
+  <Label item="Zeal_MapZoom_Value">
+    <ScreenID>Zeal_MapZoom_Value</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>297</X>
+      <Y>260</Y>
+    </Location>
+    <Size>
+      <CX>50</CX>
+      <CY>16</CY>
+    </Size>
+    <Text>0</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>true</AlignRight>
+  </Label>
+  <!-- Zeal Default Zoom Combobox -->
+  <Label item="Zeal_MapZoomDefault_Label">
+    <ScreenID>Zeal_MapZoomDefault_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>292</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Default Zoom</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapZoomDefault_Combobox">
+    <ScreenID>Zeal_MapZoomDefault_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>197</X>
+      <Y>312</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>100% (1x)</Choices>
+    <Choices>200% (2x)</Choices>
+    <Choices>400% (4x)</Choices>
+    <Choices>800% (8x)</Choices>
+  </Combobox>
+  <!-- Zeal Map Font Combobox -->
+  <Label item="Zeal_MapFont_Label">
+    <ScreenID>Zeal_MapFont_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>347</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Font</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapFont_Combobox">
+    <ScreenID>Zeal_MapFont_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>197</X>
+      <Y>367</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>default</Choices>
+  </Combobox>
+  <!-- Zeal Map Data Mode Combobox -->
+  <Label item="Zeal_MapDataMode_Label">
+    <ScreenID>Zeal_MapDataMode_Label</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>402</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>14</CY>
+    </Size>
+    <Text>Map data source</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <NoWrap>true</NoWrap>
+    <AlignCenter>false</AlignCenter>
+    <AlignRight>false</AlignRight>
+  </Label>
+  <Combobox item="Zeal_MapDataMode_Combobox">
+    <ScreenID>Zeal_MapDataMode_Combobox</ScreenID>
+    <DrawTemplate>WDT_Inner</DrawTemplate>
+    <Location>
+      <X>197</X>
+      <Y>422</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>24</CY>
+    </Size>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ListHeight>70</ListHeight>
+    <Button>BDT_Combo</Button>
+    <Style_Border>true</Style_Border>
+    <Choices>Internal only</Choices>
+    <Choices>Both</Choices>
+    <Choices>External</Choices>
+	<Choices>Both - No Internal POI</Choices>
+  </Combobox>
+  <Button item="Zeal_MapAddLocText">
+    <ScreenID>Zeal_MapAddLocText</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>458</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Adds location coordinates to map</TooltipReference>
+    <Text>Add /loc text</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_MapAddSpeedText">
+    <ScreenID>Zeal_MapAddSpeedText</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>480</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <TooltipReference>Adds current normalized speed to map</TooltipReference>
+    <Text>Add speed text</Text>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 
-	<!-- *** Zeal Map Tab *** -->
-	<Page item="Tab_Map">
-		<ScreenID>Tab_Map</ScreenID>
-		<RelativePosition>true</RelativePosition>
-		<!-- Pages are sized and positioned by their parent tab -->
-		<Style_VScroll>true</Style_VScroll>
-		<Style_HScroll>false</Style_HScroll>
-		<Style_Transparent>false</Style_Transparent>
-		<DrawTemplate>WDT_Def</DrawTemplate>
-		<TabText>Map</TabText>
-		<TabTextColor>
-			<R>255</R>
-			<G>255</G>
-			<B>255</B>
-		</TabTextColor>
-		<TabTextActiveColor>
-			<R>255</R>
-			<G>255</G>
-			<B>0</B>
-		</TabTextActiveColor>
-		<Style_Sizable>true</Style_Sizable>
-		<Pieces>Zeal_Map</Pieces>
-		<Pieces>Zeal_MapShowRaid</Pieces>
-		<Pieces>Zeal_MapShowPlayerHeadings</Pieces>
-		<Pieces>Zeal_MapShowGrid</Pieces>
-		<Pieces>Zeal_MapInteractiveEnable</Pieces>
-		<Pieces>Zeal_MapExternalWindow</Pieces>
-		<Pieces>Zeal_MapPositionSize_Label</Pieces>
-		<Pieces>Zeal_MapPositionSize_Slider</Pieces>
-		<Pieces>Zeal_MapPositionSize_Value</Pieces>
-		<Pieces>Zeal_MapMarkerSize_Label</Pieces>
-		<Pieces>Zeal_MapMarkerSize_Slider</Pieces>
-		<Pieces>Zeal_MapMarkerSize_Value</Pieces>
-		<Pieces>Zeal_MapZoom_Label</Pieces>
-		<Pieces>Zeal_MapZoom_Slider</Pieces>
-		<Pieces>Zeal_MapZoom_Value</Pieces>
-		<Pieces>Zeal_MapKeyBinds_Label</Pieces>
-		<Pieces>Zeal_MapSizing_Label</Pieces>
-		<Pieces>Zeal_MapLabels_Label</Pieces>
-		<Pieces>Zeal_MapLabels_Combobox</Pieces>
-		<Pieces>Zeal_MapBackgroundAlpha_Label</Pieces>
-		<Pieces>Zeal_MapBackgroundAlpha_Slider</Pieces>
-		<Pieces>Zeal_MapBackgroundAlpha_Value</Pieces>
-		<Pieces>Zeal_MapFadedZLevelAlpha_Label</Pieces>
-		<Pieces>Zeal_MapFadedZLevelAlpha_Slider</Pieces>
-		<Pieces>Zeal_MapFadedZLevelAlpha_Value</Pieces>
-		<Pieces>Zeal_MapAutoFadeEnable</Pieces>
-		<Pieces>Zeal_MapAddLocText</Pieces>
-		<Pieces>Zeal_MapAddSpeedText</Pieces>
-		<Pieces>Zeal_Ring0</Pieces>
-		<Pieces>Zeal_Ring1</Pieces>
-		<Pieces>Zeal_Ring2</Pieces>
-		<Pieces>Zeal_Ring3</Pieces>
-		<Pieces>Zeal_MapUseFarRing</Pieces>
-		<Pieces>Zeal_MapNamesLength_Label</Pieces>
-		<Pieces>Zeal_MapNamesLength_Slider</Pieces>
-		<Pieces>Zeal_MapNamesLength_Value</Pieces>
-		<Pieces>Zeal_MapGridPitch_Label</Pieces>
-		<Pieces>Zeal_MapGridPitch_Slider</Pieces>
-		<Pieces>Zeal_MapGridPitch_Value</Pieces>
-		<Pieces>Zeal_MapDataMode_Label</Pieces>
-		<Pieces>Zeal_MapDataMode_Combobox</Pieces>
-		<Pieces>Zeal_MapFont_Label</Pieces>
-		<Pieces>Zeal_MapFont_Combobox</Pieces>
-		<Pieces>Zeal_MapZoomDefault_Label</Pieces>
-		<Pieces>Zeal_MapZoomDefault_Combobox</Pieces>
-		<Pieces>Zeal_MapShowGroup_Label</Pieces>
-		<Pieces>Zeal_MapShowGroup_Combobox</Pieces>
-		<Pieces>Zeal_MapAlignment_Label</Pieces>
-		<Pieces>Zeal_MapAlignment_Combobox</Pieces>
-		<Pieces>Zeal_MapBackground_Label</Pieces>
-		<Pieces>Zeal_MapBackground_Combobox</Pieces>
-		<Location>
-			<X>0</X>
-			<Y>22</Y>
-		</Location>
-		<Size>
-			<CX>380</CX>
-			<CY>339</CY>
-		</Size>
-	</Page>
-</XML>
+  <!-- *** Zeal Map Tab *** -->
+  <Page item="Tab_Map">
+    <ScreenID>Tab_Map</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <!-- Pages are sized and positioned by their parent tab -->
+    <Style_VScroll>true</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <DrawTemplate>WDT_Def</DrawTemplate>
+    <TabText>Map</TabText>
+    <TabTextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TabTextColor>
+    <TabTextActiveColor>
+      <R>255</R>
+      <G>255</G>
+      <B>0</B>
+    </TabTextActiveColor>
+    <Style_Sizable>true</Style_Sizable>
+    <Pieces>Zeal_Map</Pieces>
+    <Pieces>Zeal_MapShowRaid</Pieces>
+    <Pieces>Zeal_MapShowPlayerHeadings</Pieces>
+    <Pieces>Zeal_MapShowGrid</Pieces>
+    <Pieces>Zeal_MapInteractiveEnable</Pieces>
+    <Pieces>Zeal_MapExternalWindow</Pieces>
+    <Pieces>Zeal_MapPositionSize_Label</Pieces>
+    <Pieces>Zeal_MapPositionSize_Slider</Pieces>
+    <Pieces>Zeal_MapPositionSize_Value</Pieces>
+    <Pieces>Zeal_MapMarkerSize_Label</Pieces>
+    <Pieces>Zeal_MapMarkerSize_Slider</Pieces>
+    <Pieces>Zeal_MapMarkerSize_Value</Pieces>
+    <Pieces>Zeal_MapZoom_Label</Pieces>
+    <Pieces>Zeal_MapZoom_Slider</Pieces>
+    <Pieces>Zeal_MapZoom_Value</Pieces>
+    <Pieces>Zeal_MapKeyBinds_Label</Pieces>
+    <Pieces>Zeal_MapSizing_Label</Pieces>
+    <Pieces>Zeal_MapLabels_Label</Pieces>
+    <Pieces>Zeal_MapLabels_Combobox</Pieces>
+    <Pieces>Zeal_MapBackgroundAlpha_Label</Pieces>
+    <Pieces>Zeal_MapBackgroundAlpha_Slider</Pieces>
+    <Pieces>Zeal_MapBackgroundAlpha_Value</Pieces>
+    <Pieces>Zeal_MapFadedZLevelAlpha_Label</Pieces>
+    <Pieces>Zeal_MapFadedZLevelAlpha_Slider</Pieces>
+    <Pieces>Zeal_MapFadedZLevelAlpha_Value</Pieces>
+    <Pieces>Zeal_MapAutoFadeEnable</Pieces>
+    <Pieces>Zeal_MapAddLocText</Pieces>
+    <Pieces>Zeal_MapAddSpeedText</Pieces>
+    <Pieces>Zeal_MapNamesLength_Label</Pieces>
+    <Pieces>Zeal_MapNamesLength_Slider</Pieces>
+    <Pieces>Zeal_MapNamesLength_Value</Pieces>
+    <Pieces>Zeal_MapGridPitch_Label</Pieces>
+    <Pieces>Zeal_MapGridPitch_Slider</Pieces>
+    <Pieces>Zeal_MapGridPitch_Value</Pieces>
+    <Pieces>Zeal_MapDataMode_Label</Pieces>
+    <Pieces>Zeal_MapDataMode_Combobox</Pieces>
+    <Pieces>Zeal_MapFont_Label</Pieces>
+    <Pieces>Zeal_MapFont_Combobox</Pieces>
+    <Pieces>Zeal_MapZoomDefault_Label</Pieces>
+    <Pieces>Zeal_MapZoomDefault_Combobox</Pieces>
+    <Pieces>Zeal_MapShowGroup_Label</Pieces>
+    <Pieces>Zeal_MapShowGroup_Combobox</Pieces>
+    <Pieces>Zeal_MapAlignment_Label</Pieces>
+    <Pieces>Zeal_MapAlignment_Combobox</Pieces>
+    <Pieces>Zeal_MapBackground_Label</Pieces>
+    <Pieces>Zeal_MapBackground_Combobox</Pieces>
+    <Location>
+      <X>0</X>
+      <Y>22</Y>
+    </Location>
+    <Size>
+      <CX>380</CX>
+      <CY>339</CY>
+    </Size>
+  </Page>
+  </XML>

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -1029,6 +1029,216 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_Ring0">
+    <ScreenID>Zeal_Ring0</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>197</X>
+    <Y>502</Y>
+  </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 1 Color</Text>
+    <TooltipReference>Color for first ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Ring1">
+    <ScreenID>Zeal_Ring1</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>197</X>
+    <Y>524</Y>
+  </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 2 Color</Text>
+    <TooltipReference>Color for second ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Ring2">
+    <ScreenID>Zeal_Ring2</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>197</X>
+    <Y>546</Y>
+  </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 3 Color</Text>
+    <TooltipReference>Color for third ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Ring3">
+    <ScreenID>Zeal_Ring3</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>197</X>
+    <Y>568</Y>
+  </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 4 Color</Text>
+    <TooltipReference>Color for fourth ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_MapUseFarRing">
+    <ScreenID>Zeal_MapUseFarRing</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>590</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <Text>Heading Line Uses Far</Text>
+    <TooltipReference>Heading line uses furthest (pressed) or closest (unpressed) ring size</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_MapHeadingColor">
+    <ScreenID>Zeal_MapHeadingColor</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>612</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Heading Color</Text>
+    <TooltipReference>Heading line color</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_MapHeadingUsesRingColor">
+    <ScreenID>Zeal_MapHeadingUsesRingColor</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>197</X>
+      <Y>634</Y>
+    </Location>
+    <Size>
+      <CX>150</CX>
+      <CY>20</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <Text>Heading Uses Ring Color</Text>
+    <TooltipReference>Heading line uses color from ring</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 
   <!-- *** Zeal Map Tab *** -->
   <Page item="Tab_Map">
@@ -1079,6 +1289,13 @@
     <Pieces>Zeal_MapAutoFadeEnable</Pieces>
     <Pieces>Zeal_MapAddLocText</Pieces>
     <Pieces>Zeal_MapAddSpeedText</Pieces>
+	<Pieces>Zeal_Ring0</Pieces>
+	<Pieces>Zeal_Ring1</Pieces>
+	<Pieces>Zeal_Ring2</Pieces>
+	<Pieces>Zeal_Ring3</Pieces>
+	<Pieces>Zeal_MapUseFarRing</Pieces>
+	<Pieces>Zeal_MapHeadingColor</Pieces>
+	<Pieces>Zeal_MapHeadingUsesRingColor</Pieces>
     <Pieces>Zeal_MapNamesLength_Label</Pieces>
     <Pieces>Zeal_MapNamesLength_Slider</Pieces>
     <Pieces>Zeal_MapNamesLength_Value</Pieces>

--- a/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/EQUI_Tab_Map.xml
@@ -1,1109 +1,1294 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <XML ID="EQInterfaceDefinitionLanguage">
-  <Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
-<Button item="Zeal_Map">
-    <ScreenID>Zeal_Map</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>14</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Toggles the map overlay</TooltipReference>
-    <Text>Enabled</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  <!-- Zeal Map Background Combobox -->
-  <Label item="Zeal_MapBackground_Label">
-    <ScreenID>Zeal_MapBackground_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>43</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Background</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Combobox item="Zeal_MapBackground_Combobox">
-    <ScreenID>Zeal_MapBackground_Combobox</ScreenID>
-    <DrawTemplate>WDT_Inner</DrawTemplate>
-    <Location>
-      <X>10</X>
-      <Y>63</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>24</CY>
-    </Size>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ListHeight>70</ListHeight>
-    <Button>BDT_Combo</Button>
-    <Style_Border>true</Style_Border>
-    <Choices>None</Choices>
-    <Choices>Dark</Choices>
-    <Choices>Light</Choices>
-    <Choices>Tan</Choices>
-  </Combobox>  
-  <!-- Zeal Map Background Alpha -->
-  <Label item="Zeal_MapBackgroundAlpha_Label">
-    <ScreenID>Zeal_MapBackgroundAlpha_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>100</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Background alpha</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Slider item="Zeal_MapBackgroundAlpha_Slider">
-    <ScreenID>Zeal_MapBackgroundAlpha_Slider</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>120</Y>
-    </Location>
-    <Size>
-      <CX>100</CX>
-      <CY>16</CY>
-    </Size>
-    <SliderArt>SDT_DefSlider</SliderArt>
-  </Slider>
-  <Label item="Zeal_MapBackgroundAlpha_Value">
-    <ScreenID>Zeal_MapBackgroundAlpha_Value</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>110</X>
-      <Y>120</Y>
-    </Location>
-    <Size>
-      <CX>40</CX>
-      <CY>16</CY>
-    </Size>
-    <Text>0</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>true</AlignRight>
-  </Label>
-  <!-- Zeal Map Faded ZLevel Alpha -->
-  <Label item="Zeal_MapFadedZLevelAlpha_Label">
-    <ScreenID>Zeal_MapFadedZLevelAlpha_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>142</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Faded Z-level alpha</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Slider item="Zeal_MapFadedZLevelAlpha_Slider">
-    <ScreenID>Zeal_MapFadedZLevelAlpha_Slider</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>162</Y>
-    </Location>
-    <Size>
-      <CX>100</CX>
-      <CY>16</CY>
-    </Size>
-    <SliderArt>SDT_DefSlider</SliderArt>
-  </Slider>
-  <Label item="Zeal_MapFadedZLevelAlpha_Value">
-    <ScreenID>Zeal_MapFadedZLevelAlpha_Value</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>110</X>
-      <Y>162</Y>
-    </Location>
-    <Size>
-      <CX>40</CX>
-      <CY>16</CY>
-    </Size>
-    <Text>0</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>true</AlignRight>
-  </Label>
-  <!-- Zeal Map AutoFade Enable-->
-  <Button item="Zeal_MapAutoFadeEnable">
-    <ScreenID>Zeal_MapAutoFadeEnable</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>184</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Defaults to z-level autofade mode</TooltipReference>
-    <Text>Default to Z Autofade</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  <!-- Zeal Map Alignment Combobox -->
-  <Label item="Zeal_MapAlignment_Label">
-    <ScreenID>Zeal_MapAlignment_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>214</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Alignment</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Combobox item="Zeal_MapAlignment_Combobox">
-    <ScreenID>Zeal_MapAlignment_Combobox</ScreenID>
-    <DrawTemplate>WDT_Inner</DrawTemplate>
-    <Location>
-      <X>10</X>
-      <Y>234</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>24</CY>
-    </Size>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ListHeight>70</ListHeight>
-    <Button>BDT_Combo</Button>
-    <Style_Border>true</Style_Border>
-    <Choices>Top Left</Choices>
-    <Choices>Top Center</Choices>
-    <Choices>Top Right</Choices>
-  </Combobox>
-  <!-- Zeal Map Labels Combobox -->
-  <Label item="Zeal_MapLabels_Label">
-    <ScreenID>Zeal_MapLabels_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>269</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Labels</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Combobox item="Zeal_MapLabels_Combobox">
-    <ScreenID>Zeal_MapLabels_Combobox</ScreenID>
-    <DrawTemplate>WDT_Inner</DrawTemplate>
-    <Location>
-      <X>10</X>
-      <Y>289</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>24</CY>
-    </Size>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ListHeight>70</ListHeight>
-    <Button>BDT_Combo</Button>
-    <Style_Border>true</Style_Border>
-    <Choices>Off</Choices>
-    <Choices>Summary</Choices>
-    <Choices>All</Choices>
-    <Choices>Marker only</Choices>
-  </Combobox>
-  <!-- Zeal Map ShowGroup Combobox -->
-  <Label item="Zeal_MapShowGroup_Label">
-    <ScreenID>Zeal_MapShowGroup_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>324</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Show group members</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Combobox item="Zeal_MapShowGroup_Combobox">
-    <ScreenID>Zeal_MapShowGroup_Combobox</ScreenID>
-    <DrawTemplate>WDT_Inner</DrawTemplate>
-    <Location>
-      <X>10</X>
-      <Y>344</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>24</CY>
-    </Size>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ListHeight>70</ListHeight>
-    <Button>BDT_Combo</Button>
-    <Style_Border>true</Style_Border>
-    <Choices>Off</Choices>
-    <Choices>Markers only</Choices>
-    <Choices>Markers and numbers</Choices>
-    <Choices>Markers and names</Choices>
-  </Combobox>  
-  <!-- Zeal Map Show Raid Members-->
-  <Button item="Zeal_MapShowRaid">
-    <ScreenID>Zeal_MapShowRaid</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>379</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Shows raid members on map</TooltipReference>
-    <Text>Show Raid</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  <!-- Zeal Map Show Player Headings-->
-  <Button item="Zeal_MapShowPlayerHeadings">
-    <ScreenID>Zeal_MapShowPlayerHeadings</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>401</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Shows all player headings</TooltipReference>
-    <Text>Show Headings</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  <!-- Zeal Map Names Length -->
-  <Label item="Zeal_MapNamesLength_Label">
-    <ScreenID>Zeal_MapNamesLength_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>431</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Member names length</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Slider item="Zeal_MapNamesLength_Slider">
-    <ScreenID>Zeal_MapNamesLength_Slider</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>451</Y>
-    </Location>
-    <Size>
-      <CX>100</CX>
-      <CY>16</CY>
-    </Size>
-    <SliderArt>SDT_DefSlider</SliderArt>
-  </Slider>
-  <Label item="Zeal_MapNamesLength_Value">
-    <ScreenID>Zeal_MapNamesLength_Value</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>110</X>
-      <Y>451</Y>
-    </Location>
-    <Size>
-      <CX>40</CX>
-      <CY>16</CY>
-    </Size>
-    <Text>0</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>true</AlignRight>
-  </Label>
-  <!-- Zeal Map Show Grid-->
-  <Button item="Zeal_MapShowGrid">
-    <ScreenID>Zeal_MapShowGrid</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>474</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Shows grid lines on map</TooltipReference>
-    <Text>Show grid lines</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  <!-- Zeal Map Grid Pitch -->
-  <Label item="Zeal_MapGridPitch_Label">
-    <ScreenID>Zeal_MapGridPitch_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>504</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Grid line pitch</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Slider item="Zeal_MapGridPitch_Slider">
-    <ScreenID>Zeal_MapGridPitch_Slider</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>10</X>
-      <Y>524</Y>
-    </Location>
-    <Size>
-      <CX>100</CX>
-      <CY>16</CY>
-    </Size>
-    <SliderArt>SDT_DefSlider</SliderArt>
-  </Slider>
-  <Label item="Zeal_MapGridPitch_Value">
-    <ScreenID>Zeal_MapGridPitch_Value</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>110</X>
-      <Y>524</Y>
-    </Location>
-    <Size>
-      <CX>40</CX>
-      <CY>16</CY>
-    </Size>
-    <Text>0</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>true</AlignRight>
-  </Label>
-  <!-- Zeal Map Keybinds Reminder -->
-  <Label item="Zeal_MapKeyBinds_Label">
-    <ScreenID>Zeal_MapKeyBinds_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>5</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>32</CY>
-    </Size>
-    <Text>See Keyboard-&gt;UI for Map Keybinds (recommended)</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <!-- Zeal Map Sizing Reminder -->
-  <Label item="Zeal_MapSizing_Label">
-    <ScreenID>Zeal_MapSizing_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>43</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>32</CY>
-    </Size>
-    <Text>Use unlocked interactive mode to resize/move map.</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <!-- Zeal Map Interactive Enable-->
-  <Button item="Zeal_MapInteractiveEnable">
-    <ScreenID>Zeal_MapInteractiveEnable</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>95</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Enables windowed mode for internal map</TooltipReference>
-    <Text>Interactive Enable</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  <!-- Zeal Map External Window Enable-->
-    <Button item="Zeal_MapExternalWindow">
-      <ScreenID>Zeal_MapExternalWindow</ScreenID>
-      <RelativePosition>true</RelativePosition>
-      <Location>
-        <X>197</X>
-        <Y>125</Y>
-      </Location>
-      <Size>
-        <CX>150</CX>
-        <CY>20</CY>
-      </Size>
-      <Style_VScroll>false</Style_VScroll>
-      <Style_HScroll>false</Style_HScroll>
-      <Style_Transparent>false</Style_Transparent>
-      <Style_Checkbox>true</Style_Checkbox>
-      <TooltipReference>Shows map in an external window</TooltipReference>
-      <Text>External Window</Text>
-      <TextColor>
-        <R>255</R>
-        <G>255</G>
-        <B>255</B>
-      </TextColor>
-      <ButtonDrawTemplate>
-        <Normal>A_BtnNormal</Normal>
-        <Pressed>A_BtnPressed</Pressed>
-        <Flyby>A_BtnFlyby</Flyby>
-        <Disabled>A_BtnDisabled</Disabled>
-        <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-      </ButtonDrawTemplate>
-    </Button>
-  <!-- Zeal Map Position Size -->
-  <Label item="Zeal_MapPositionSize_Label">
-    <ScreenID>Zeal_MapPositionSize_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>156</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Position size</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Slider item="Zeal_MapPositionSize_Slider">
-    <ScreenID>Zeal_MapPositionSize_Slider</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>176</Y>
-    </Location>
-    <Size>
-      <CX>100</CX>
-      <CY>16</CY>
-    </Size>
-    <SliderArt>SDT_DefSlider</SliderArt>
-  </Slider>
-  <Label item="Zeal_MapPositionSize_Value">
-    <ScreenID>Zeal_MapPositionSize_Value</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>297</X>
-      <Y>176</Y>
-    </Location>
-    <Size>
-      <CX>50</CX>
-      <CY>16</CY>
-    </Size>
-    <Text>0</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>true</AlignRight>
-  </Label>
-  <!-- Zeal Map Marker Size -->
-  <Label item="Zeal_MapMarkerSize_Label">
-    <ScreenID>Zeal_MapMarkerSize_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>198</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Marker size</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Slider item="Zeal_MapMarkerSize_Slider">
-    <ScreenID>Zeal_MapMarkerSize_Slider</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>218</Y>
-    </Location>
-    <Size>
-      <CX>100</CX>
-      <CY>16</CY>
-    </Size>
-    <SliderArt>SDT_DefSlider</SliderArt>
-  </Slider>
-  <Label item="Zeal_MapMarkerSize_Value">
-    <ScreenID>Zeal_MapMarkerSize_Value</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>297</X>
-      <Y>218</Y>
-    </Location>
-    <Size>
-      <CX>50</CX>
-      <CY>16</CY>
-    </Size>
-    <Text>0</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>true</AlignRight>
-  </Label>
-  <!-- Zeal Map Zoom -->
-  <Label item="Zeal_MapZoom_Label">
-    <ScreenID>Zeal_MapZoom_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>240</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Zoom</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Slider item="Zeal_MapZoom_Slider">
-    <ScreenID>Zeal_MapZoom_Slider</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>260</Y>
-    </Location>
-    <Size>
-      <CX>100</CX>
-      <CY>16</CY>
-    </Size>
-    <SliderArt>SDT_DefSlider</SliderArt>
-  </Slider>
-  <Label item="Zeal_MapZoom_Value">
-    <ScreenID>Zeal_MapZoom_Value</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>297</X>
-      <Y>260</Y>
-    </Location>
-    <Size>
-      <CX>50</CX>
-      <CY>16</CY>
-    </Size>
-    <Text>0</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>true</AlignRight>
-  </Label>
-  <!-- Zeal Default Zoom Combobox -->
-  <Label item="Zeal_MapZoomDefault_Label">
-    <ScreenID>Zeal_MapZoomDefault_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>292</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Default Zoom</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Combobox item="Zeal_MapZoomDefault_Combobox">
-    <ScreenID>Zeal_MapZoomDefault_Combobox</ScreenID>
-    <DrawTemplate>WDT_Inner</DrawTemplate>
-    <Location>
-      <X>197</X>
-      <Y>312</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>24</CY>
-    </Size>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ListHeight>70</ListHeight>
-    <Button>BDT_Combo</Button>
-    <Style_Border>true</Style_Border>
-    <Choices>100% (1x)</Choices>
-    <Choices>200% (2x)</Choices>
-    <Choices>400% (4x)</Choices>
-    <Choices>800% (8x)</Choices>
-  </Combobox>
-  <!-- Zeal Map Font Combobox -->
-  <Label item="Zeal_MapFont_Label">
-    <ScreenID>Zeal_MapFont_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>347</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Font</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Combobox item="Zeal_MapFont_Combobox">
-    <ScreenID>Zeal_MapFont_Combobox</ScreenID>
-    <DrawTemplate>WDT_Inner</DrawTemplate>
-    <Location>
-      <X>197</X>
-      <Y>367</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>24</CY>
-    </Size>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ListHeight>70</ListHeight>
-    <Button>BDT_Combo</Button>
-    <Style_Border>true</Style_Border>
-    <Choices>default</Choices>
-  </Combobox>
-  <!-- Zeal Map Data Mode Combobox -->
-  <Label item="Zeal_MapDataMode_Label">
-    <ScreenID>Zeal_MapDataMode_Label</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>402</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>14</CY>
-    </Size>
-    <Text>Map data source</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <NoWrap>true</NoWrap>
-    <AlignCenter>false</AlignCenter>
-    <AlignRight>false</AlignRight>
-  </Label>
-  <Combobox item="Zeal_MapDataMode_Combobox">
-    <ScreenID>Zeal_MapDataMode_Combobox</ScreenID>
-    <DrawTemplate>WDT_Inner</DrawTemplate>
-    <Location>
-      <X>197</X>
-      <Y>422</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>24</CY>
-    </Size>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ListHeight>70</ListHeight>
-    <Button>BDT_Combo</Button>
-    <Style_Border>true</Style_Border>
-    <Choices>Internal only</Choices>
-    <Choices>Both</Choices>
-    <Choices>External</Choices>
-	<Choices>Both - No Internal POI</Choices>
-  </Combobox>
-  <Button item="Zeal_MapAddLocText">
-    <ScreenID>Zeal_MapAddLocText</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>458</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Adds location coordinates to map</TooltipReference>
-    <Text>Add /loc text</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
-  <Button item="Zeal_MapAddSpeedText">
-    <ScreenID>Zeal_MapAddSpeedText</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <Location>
-      <X>197</X>
-      <Y>480</Y>
-    </Location>
-    <Size>
-      <CX>150</CX>
-      <CY>20</CY>
-    </Size>
-    <Style_VScroll>false</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <Style_Checkbox>true</Style_Checkbox>
-    <TooltipReference>Adds current normalized speed to map</TooltipReference>
-    <Text>Add speed text</Text>
-    <TextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TextColor>
-    <ButtonDrawTemplate>
-      <Normal>A_BtnNormal</Normal>
-      <Pressed>A_BtnPressed</Pressed>
-      <Flyby>A_BtnFlyby</Flyby>
-      <Disabled>A_BtnDisabled</Disabled>
-      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
-    </ButtonDrawTemplate>
-  </Button>
+	<Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
+	<Button item="Zeal_Map">
+		<ScreenID>Zeal_Map</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>14</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Toggles the map overlay</TooltipReference>
+		<Text>Enabled</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<!-- Zeal Map Background Combobox -->
+	<Label item="Zeal_MapBackground_Label">
+		<ScreenID>Zeal_MapBackground_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>43</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Background</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Combobox item="Zeal_MapBackground_Combobox">
+		<ScreenID>Zeal_MapBackground_Combobox</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>10</X>
+			<Y>63</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>24</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ListHeight>70</ListHeight>
+		<Button>BDT_Combo</Button>
+		<Style_Border>true</Style_Border>
+		<Choices>None</Choices>
+		<Choices>Dark</Choices>
+		<Choices>Light</Choices>
+		<Choices>Tan</Choices>
+	</Combobox>
+	<!-- Zeal Map Background Alpha -->
+	<Label item="Zeal_MapBackgroundAlpha_Label">
+		<ScreenID>Zeal_MapBackgroundAlpha_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>100</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Background alpha</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Slider item="Zeal_MapBackgroundAlpha_Slider">
+		<ScreenID>Zeal_MapBackgroundAlpha_Slider</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>120</Y>
+		</Location>
+		<Size>
+			<CX>100</CX>
+			<CY>16</CY>
+		</Size>
+		<SliderArt>SDT_DefSlider</SliderArt>
+	</Slider>
+	<Label item="Zeal_MapBackgroundAlpha_Value">
+		<ScreenID>Zeal_MapBackgroundAlpha_Value</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>110</X>
+			<Y>120</Y>
+		</Location>
+		<Size>
+			<CX>40</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>0</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>true</AlignRight>
+	</Label>
+	<!-- Zeal Map Faded ZLevel Alpha -->
+	<Label item="Zeal_MapFadedZLevelAlpha_Label">
+		<ScreenID>Zeal_MapFadedZLevelAlpha_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>142</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Faded Z-level alpha</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Slider item="Zeal_MapFadedZLevelAlpha_Slider">
+		<ScreenID>Zeal_MapFadedZLevelAlpha_Slider</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>162</Y>
+		</Location>
+		<Size>
+			<CX>100</CX>
+			<CY>16</CY>
+		</Size>
+		<SliderArt>SDT_DefSlider</SliderArt>
+	</Slider>
+	<Label item="Zeal_MapFadedZLevelAlpha_Value">
+		<ScreenID>Zeal_MapFadedZLevelAlpha_Value</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>110</X>
+			<Y>162</Y>
+		</Location>
+		<Size>
+			<CX>40</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>0</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>true</AlignRight>
+	</Label>
+	<!-- Zeal Map AutoFade Enable-->
+	<Button item="Zeal_MapAutoFadeEnable">
+		<ScreenID>Zeal_MapAutoFadeEnable</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>184</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Defaults to z-level autofade mode</TooltipReference>
+		<Text>Default to Z Autofade</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<!-- Zeal Map Alignment Combobox -->
+	<Label item="Zeal_MapAlignment_Label">
+		<ScreenID>Zeal_MapAlignment_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>214</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Alignment</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Combobox item="Zeal_MapAlignment_Combobox">
+		<ScreenID>Zeal_MapAlignment_Combobox</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>10</X>
+			<Y>234</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>24</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ListHeight>70</ListHeight>
+		<Button>BDT_Combo</Button>
+		<Style_Border>true</Style_Border>
+		<Choices>Top Left</Choices>
+		<Choices>Top Center</Choices>
+		<Choices>Top Right</Choices>
+	</Combobox>
+	<!-- Zeal Map Labels Combobox -->
+	<Label item="Zeal_MapLabels_Label">
+		<ScreenID>Zeal_MapLabels_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>269</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Labels</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Combobox item="Zeal_MapLabels_Combobox">
+		<ScreenID>Zeal_MapLabels_Combobox</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>10</X>
+			<Y>289</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>24</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ListHeight>70</ListHeight>
+		<Button>BDT_Combo</Button>
+		<Style_Border>true</Style_Border>
+		<Choices>Off</Choices>
+		<Choices>Summary</Choices>
+		<Choices>All</Choices>
+		<Choices>Marker only</Choices>
+	</Combobox>
+	<!-- Zeal Map ShowGroup Combobox -->
+	<Label item="Zeal_MapShowGroup_Label">
+		<ScreenID>Zeal_MapShowGroup_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>324</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Show group members</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Combobox item="Zeal_MapShowGroup_Combobox">
+		<ScreenID>Zeal_MapShowGroup_Combobox</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>10</X>
+			<Y>344</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>24</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ListHeight>70</ListHeight>
+		<Button>BDT_Combo</Button>
+		<Style_Border>true</Style_Border>
+		<Choices>Off</Choices>
+		<Choices>Markers only</Choices>
+		<Choices>Markers and numbers</Choices>
+		<Choices>Markers and names</Choices>
+	</Combobox>
+	<!-- Zeal Map Show Raid Members-->
+	<Button item="Zeal_MapShowRaid">
+		<ScreenID>Zeal_MapShowRaid</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>379</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Shows raid members on map</TooltipReference>
+		<Text>Show Raid</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<!-- Zeal Map Show Player Headings-->
+	<Button item="Zeal_MapShowPlayerHeadings">
+		<ScreenID>Zeal_MapShowPlayerHeadings</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>401</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Shows all player headings</TooltipReference>
+		<Text>Show Headings</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<!-- Zeal Map Names Length -->
+	<Label item="Zeal_MapNamesLength_Label">
+		<ScreenID>Zeal_MapNamesLength_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>431</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Member names length</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Slider item="Zeal_MapNamesLength_Slider">
+		<ScreenID>Zeal_MapNamesLength_Slider</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>451</Y>
+		</Location>
+		<Size>
+			<CX>100</CX>
+			<CY>16</CY>
+		</Size>
+		<SliderArt>SDT_DefSlider</SliderArt>
+	</Slider>
+	<Label item="Zeal_MapNamesLength_Value">
+		<ScreenID>Zeal_MapNamesLength_Value</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>110</X>
+			<Y>451</Y>
+		</Location>
+		<Size>
+			<CX>40</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>0</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>true</AlignRight>
+	</Label>
+	<!-- Zeal Map Show Grid-->
+	<Button item="Zeal_MapShowGrid">
+		<ScreenID>Zeal_MapShowGrid</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>474</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Shows grid lines on map</TooltipReference>
+		<Text>Show grid lines</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<!-- Zeal Map Grid Pitch -->
+	<Label item="Zeal_MapGridPitch_Label">
+		<ScreenID>Zeal_MapGridPitch_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>504</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Grid line pitch</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Slider item="Zeal_MapGridPitch_Slider">
+		<ScreenID>Zeal_MapGridPitch_Slider</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>10</X>
+			<Y>524</Y>
+		</Location>
+		<Size>
+			<CX>100</CX>
+			<CY>16</CY>
+		</Size>
+		<SliderArt>SDT_DefSlider</SliderArt>
+	</Slider>
+	<Label item="Zeal_MapGridPitch_Value">
+		<ScreenID>Zeal_MapGridPitch_Value</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>110</X>
+			<Y>524</Y>
+		</Location>
+		<Size>
+			<CX>40</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>0</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>true</AlignRight>
+	</Label>
+	<!-- Zeal Map Keybinds Reminder -->
+	<Label item="Zeal_MapKeyBinds_Label">
+		<ScreenID>Zeal_MapKeyBinds_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>5</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>32</CY>
+		</Size>
+		<Text>See Keyboard-&gt;UI for Map Keybinds (recommended)</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<!-- Zeal Map Sizing Reminder -->
+	<Label item="Zeal_MapSizing_Label">
+		<ScreenID>Zeal_MapSizing_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>43</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>32</CY>
+		</Size>
+		<Text>Use unlocked interactive mode to resize/move map.</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<!-- Zeal Map Interactive Enable-->
+	<Button item="Zeal_MapInteractiveEnable">
+		<ScreenID>Zeal_MapInteractiveEnable</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>95</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Enables windowed mode for internal map</TooltipReference>
+		<Text>Interactive Enable</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<!-- Zeal Map External Window Enable-->
+	<Button item="Zeal_MapExternalWindow">
+		<ScreenID>Zeal_MapExternalWindow</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>125</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Shows map in an external window</TooltipReference>
+		<Text>External Window</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<!-- Zeal Map Position Size -->
+	<Label item="Zeal_MapPositionSize_Label">
+		<ScreenID>Zeal_MapPositionSize_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>156</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Position size</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Slider item="Zeal_MapPositionSize_Slider">
+		<ScreenID>Zeal_MapPositionSize_Slider</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>176</Y>
+		</Location>
+		<Size>
+			<CX>100</CX>
+			<CY>16</CY>
+		</Size>
+		<SliderArt>SDT_DefSlider</SliderArt>
+	</Slider>
+	<Label item="Zeal_MapPositionSize_Value">
+		<ScreenID>Zeal_MapPositionSize_Value</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>297</X>
+			<Y>176</Y>
+		</Location>
+		<Size>
+			<CX>50</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>0</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>true</AlignRight>
+	</Label>
+	<!-- Zeal Map Marker Size -->
+	<Label item="Zeal_MapMarkerSize_Label">
+		<ScreenID>Zeal_MapMarkerSize_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>198</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Marker size</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Slider item="Zeal_MapMarkerSize_Slider">
+		<ScreenID>Zeal_MapMarkerSize_Slider</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>218</Y>
+		</Location>
+		<Size>
+			<CX>100</CX>
+			<CY>16</CY>
+		</Size>
+		<SliderArt>SDT_DefSlider</SliderArt>
+	</Slider>
+	<Label item="Zeal_MapMarkerSize_Value">
+		<ScreenID>Zeal_MapMarkerSize_Value</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>297</X>
+			<Y>218</Y>
+		</Location>
+		<Size>
+			<CX>50</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>0</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>true</AlignRight>
+	</Label>
+	<!-- Zeal Map Zoom -->
+	<Label item="Zeal_MapZoom_Label">
+		<ScreenID>Zeal_MapZoom_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>240</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Zoom</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Slider item="Zeal_MapZoom_Slider">
+		<ScreenID>Zeal_MapZoom_Slider</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>260</Y>
+		</Location>
+		<Size>
+			<CX>100</CX>
+			<CY>16</CY>
+		</Size>
+		<SliderArt>SDT_DefSlider</SliderArt>
+	</Slider>
+	<Label item="Zeal_MapZoom_Value">
+		<ScreenID>Zeal_MapZoom_Value</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>297</X>
+			<Y>260</Y>
+		</Location>
+		<Size>
+			<CX>50</CX>
+			<CY>16</CY>
+		</Size>
+		<Text>0</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>true</AlignRight>
+	</Label>
+	<!-- Zeal Default Zoom Combobox -->
+	<Label item="Zeal_MapZoomDefault_Label">
+		<ScreenID>Zeal_MapZoomDefault_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>292</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Default Zoom</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Combobox item="Zeal_MapZoomDefault_Combobox">
+		<ScreenID>Zeal_MapZoomDefault_Combobox</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>197</X>
+			<Y>312</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>24</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ListHeight>70</ListHeight>
+		<Button>BDT_Combo</Button>
+		<Style_Border>true</Style_Border>
+		<Choices>100% (1x)</Choices>
+		<Choices>200% (2x)</Choices>
+		<Choices>400% (4x)</Choices>
+		<Choices>800% (8x)</Choices>
+	</Combobox>
+	<!-- Zeal Map Font Combobox -->
+	<Label item="Zeal_MapFont_Label">
+		<ScreenID>Zeal_MapFont_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>347</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Font</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Combobox item="Zeal_MapFont_Combobox">
+		<ScreenID>Zeal_MapFont_Combobox</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>197</X>
+			<Y>367</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>24</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ListHeight>70</ListHeight>
+		<Button>BDT_Combo</Button>
+		<Style_Border>true</Style_Border>
+		<Choices>default</Choices>
+	</Combobox>
+	<!-- Zeal Map Data Mode Combobox -->
+	<Label item="Zeal_MapDataMode_Label">
+		<ScreenID>Zeal_MapDataMode_Label</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>402</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>14</CY>
+		</Size>
+		<Text>Map data source</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<NoWrap>true</NoWrap>
+		<AlignCenter>false</AlignCenter>
+		<AlignRight>false</AlignRight>
+	</Label>
+	<Combobox item="Zeal_MapDataMode_Combobox">
+		<ScreenID>Zeal_MapDataMode_Combobox</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>197</X>
+			<Y>422</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>24</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ListHeight>70</ListHeight>
+		<Button>BDT_Combo</Button>
+		<Style_Border>true</Style_Border>
+		<Choices>Internal only</Choices>
+		<Choices>Both</Choices>
+		<Choices>External</Choices>
+		<Choices>Both - No Internal POI</Choices>
+	</Combobox>
+	<Button item="Zeal_MapAddLocText">
+		<ScreenID>Zeal_MapAddLocText</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>458</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Adds location coordinates to map</TooltipReference>
+		<Text>Add /loc text</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_MapAddSpeedText">
+		<ScreenID>Zeal_MapAddSpeedText</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>480</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<TooltipReference>Adds current normalized speed to map</TooltipReference>
+		<Text>Add speed text</Text>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_Ring0">
+		<ScreenID>Zeal_Ring0</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>502</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>false</Style_Checkbox>
+		<Text>Ring 1 Color</Text>
+		<TooltipReference>Color for first ring value</TooltipReference>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_Ring1">
+		<ScreenID>Zeal_Ring1</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>524</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>false</Style_Checkbox>
+		<Text>Ring 2 Color</Text>
+		<TooltipReference>Color for second ring value</TooltipReference>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_Ring2">
+		<ScreenID>Zeal_Ring2</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>546</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>false</Style_Checkbox>
+		<Text>Ring 3 Color</Text>
+		<TooltipReference>Color for third ring value</TooltipReference>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_Ring3">
+		<ScreenID>Zeal_Ring3</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>568</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>false</Style_Checkbox>
+		<Text>Ring 4 Color</Text>
+		<TooltipReference>Color for fourth ring value</TooltipReference>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_MapUseFarRing">
+		<ScreenID>Zeal_MapUseFarRing</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>590</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<Text>Heading Line Uses Far</Text>
+		<TooltipReference>Heading line uses furthest (pressed) or closest (unpressed) ring size</TooltipReference>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
+	<Button item="Zeal_MapHeadingColor">
+		<ScreenID>Zeal_MapHeadingColor</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<Location>
+			<X>197</X>
+			<Y>612</Y>
+		</Location>
+		<Size>
+			<CX>150</CX>
+			<CY>20</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Style_Checkbox>true</Style_Checkbox>
+		<Text>Heading Color</Text>
+		<TooltipReference>Heading line color</TooltipReference>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<ButtonDrawTemplate>
+			<Normal>A_BtnNormal</Normal>
+			<Pressed>A_BtnPressed</Pressed>
+			<Flyby>A_BtnFlyby</Flyby>
+			<Disabled>A_BtnDisabled</Disabled>
+			<PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+		</ButtonDrawTemplate>
+	</Button>
 
-  <!-- *** Zeal Map Tab *** -->
-  <Page item="Tab_Map">
-    <ScreenID>Tab_Map</ScreenID>
-    <RelativePosition>true</RelativePosition>
-    <!-- Pages are sized and positioned by their parent tab -->
-    <Style_VScroll>true</Style_VScroll>
-    <Style_HScroll>false</Style_HScroll>
-    <Style_Transparent>false</Style_Transparent>
-    <DrawTemplate>WDT_Def</DrawTemplate>
-    <TabText>Map</TabText>
-    <TabTextColor>
-      <R>255</R>
-      <G>255</G>
-      <B>255</B>
-    </TabTextColor>
-    <TabTextActiveColor>
-      <R>255</R>
-      <G>255</G>
-      <B>0</B>
-    </TabTextActiveColor>
-    <Style_Sizable>true</Style_Sizable>
-    <Pieces>Zeal_Map</Pieces>
-    <Pieces>Zeal_MapShowRaid</Pieces>
-    <Pieces>Zeal_MapShowPlayerHeadings</Pieces>
-    <Pieces>Zeal_MapShowGrid</Pieces>
-    <Pieces>Zeal_MapInteractiveEnable</Pieces>
-    <Pieces>Zeal_MapExternalWindow</Pieces>
-    <Pieces>Zeal_MapPositionSize_Label</Pieces>
-    <Pieces>Zeal_MapPositionSize_Slider</Pieces>
-    <Pieces>Zeal_MapPositionSize_Value</Pieces>
-    <Pieces>Zeal_MapMarkerSize_Label</Pieces>
-    <Pieces>Zeal_MapMarkerSize_Slider</Pieces>
-    <Pieces>Zeal_MapMarkerSize_Value</Pieces>
-    <Pieces>Zeal_MapZoom_Label</Pieces>
-    <Pieces>Zeal_MapZoom_Slider</Pieces>
-    <Pieces>Zeal_MapZoom_Value</Pieces>
-    <Pieces>Zeal_MapKeyBinds_Label</Pieces>
-    <Pieces>Zeal_MapSizing_Label</Pieces>
-    <Pieces>Zeal_MapLabels_Label</Pieces>
-    <Pieces>Zeal_MapLabels_Combobox</Pieces>
-    <Pieces>Zeal_MapBackgroundAlpha_Label</Pieces>
-    <Pieces>Zeal_MapBackgroundAlpha_Slider</Pieces>
-    <Pieces>Zeal_MapBackgroundAlpha_Value</Pieces>
-    <Pieces>Zeal_MapFadedZLevelAlpha_Label</Pieces>
-    <Pieces>Zeal_MapFadedZLevelAlpha_Slider</Pieces>
-    <Pieces>Zeal_MapFadedZLevelAlpha_Value</Pieces>
-    <Pieces>Zeal_MapAutoFadeEnable</Pieces>
-    <Pieces>Zeal_MapAddLocText</Pieces>
-    <Pieces>Zeal_MapAddSpeedText</Pieces>
-    <Pieces>Zeal_MapNamesLength_Label</Pieces>
-    <Pieces>Zeal_MapNamesLength_Slider</Pieces>
-    <Pieces>Zeal_MapNamesLength_Value</Pieces>
-    <Pieces>Zeal_MapGridPitch_Label</Pieces>
-    <Pieces>Zeal_MapGridPitch_Slider</Pieces>
-    <Pieces>Zeal_MapGridPitch_Value</Pieces>
-    <Pieces>Zeal_MapDataMode_Label</Pieces>
-    <Pieces>Zeal_MapDataMode_Combobox</Pieces>
-    <Pieces>Zeal_MapFont_Label</Pieces>
-    <Pieces>Zeal_MapFont_Combobox</Pieces>
-    <Pieces>Zeal_MapZoomDefault_Label</Pieces>
-    <Pieces>Zeal_MapZoomDefault_Combobox</Pieces>
-    <Pieces>Zeal_MapShowGroup_Label</Pieces>
-    <Pieces>Zeal_MapShowGroup_Combobox</Pieces>
-    <Pieces>Zeal_MapAlignment_Label</Pieces>
-    <Pieces>Zeal_MapAlignment_Combobox</Pieces>
-    <Pieces>Zeal_MapBackground_Label</Pieces>
-    <Pieces>Zeal_MapBackground_Combobox</Pieces>
-    <Location>
-      <X>0</X>
-      <Y>22</Y>
-    </Location>
-    <Size>
-      <CX>380</CX>
-      <CY>339</CY>
-    </Size>
-  </Page>
-  </XML>
+	<!-- *** Zeal Map Tab *** -->
+	<Page item="Tab_Map">
+		<ScreenID>Tab_Map</ScreenID>
+		<RelativePosition>true</RelativePosition>
+		<!-- Pages are sized and positioned by their parent tab -->
+		<Style_VScroll>true</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<DrawTemplate>WDT_Def</DrawTemplate>
+		<TabText>Map</TabText>
+		<TabTextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TabTextColor>
+		<TabTextActiveColor>
+			<R>255</R>
+			<G>255</G>
+			<B>0</B>
+		</TabTextActiveColor>
+		<Style_Sizable>true</Style_Sizable>
+		<Pieces>Zeal_Map</Pieces>
+		<Pieces>Zeal_MapShowRaid</Pieces>
+		<Pieces>Zeal_MapShowPlayerHeadings</Pieces>
+		<Pieces>Zeal_MapShowGrid</Pieces>
+		<Pieces>Zeal_MapInteractiveEnable</Pieces>
+		<Pieces>Zeal_MapExternalWindow</Pieces>
+		<Pieces>Zeal_MapPositionSize_Label</Pieces>
+		<Pieces>Zeal_MapPositionSize_Slider</Pieces>
+		<Pieces>Zeal_MapPositionSize_Value</Pieces>
+		<Pieces>Zeal_MapMarkerSize_Label</Pieces>
+		<Pieces>Zeal_MapMarkerSize_Slider</Pieces>
+		<Pieces>Zeal_MapMarkerSize_Value</Pieces>
+		<Pieces>Zeal_MapZoom_Label</Pieces>
+		<Pieces>Zeal_MapZoom_Slider</Pieces>
+		<Pieces>Zeal_MapZoom_Value</Pieces>
+		<Pieces>Zeal_MapKeyBinds_Label</Pieces>
+		<Pieces>Zeal_MapSizing_Label</Pieces>
+		<Pieces>Zeal_MapLabels_Label</Pieces>
+		<Pieces>Zeal_MapLabels_Combobox</Pieces>
+		<Pieces>Zeal_MapBackgroundAlpha_Label</Pieces>
+		<Pieces>Zeal_MapBackgroundAlpha_Slider</Pieces>
+		<Pieces>Zeal_MapBackgroundAlpha_Value</Pieces>
+		<Pieces>Zeal_MapFadedZLevelAlpha_Label</Pieces>
+		<Pieces>Zeal_MapFadedZLevelAlpha_Slider</Pieces>
+		<Pieces>Zeal_MapFadedZLevelAlpha_Value</Pieces>
+		<Pieces>Zeal_MapAutoFadeEnable</Pieces>
+		<Pieces>Zeal_MapAddLocText</Pieces>
+		<Pieces>Zeal_MapAddSpeedText</Pieces>
+		<Pieces>Zeal_Ring0</Pieces>
+		<Pieces>Zeal_Ring1</Pieces>
+		<Pieces>Zeal_Ring2</Pieces>
+		<Pieces>Zeal_Ring3</Pieces>
+		<Pieces>Zeal_MapUseFarRing</Pieces>
+		<Pieces>Zeal_MapNamesLength_Label</Pieces>
+		<Pieces>Zeal_MapNamesLength_Slider</Pieces>
+		<Pieces>Zeal_MapNamesLength_Value</Pieces>
+		<Pieces>Zeal_MapGridPitch_Label</Pieces>
+		<Pieces>Zeal_MapGridPitch_Slider</Pieces>
+		<Pieces>Zeal_MapGridPitch_Value</Pieces>
+		<Pieces>Zeal_MapDataMode_Label</Pieces>
+		<Pieces>Zeal_MapDataMode_Combobox</Pieces>
+		<Pieces>Zeal_MapFont_Label</Pieces>
+		<Pieces>Zeal_MapFont_Combobox</Pieces>
+		<Pieces>Zeal_MapZoomDefault_Label</Pieces>
+		<Pieces>Zeal_MapZoomDefault_Combobox</Pieces>
+		<Pieces>Zeal_MapShowGroup_Label</Pieces>
+		<Pieces>Zeal_MapShowGroup_Combobox</Pieces>
+		<Pieces>Zeal_MapAlignment_Label</Pieces>
+		<Pieces>Zeal_MapAlignment_Combobox</Pieces>
+		<Pieces>Zeal_MapBackground_Label</Pieces>
+		<Pieces>Zeal_MapBackground_Combobox</Pieces>
+		<Location>
+			<X>0</X>
+			<Y>22</Y>
+		</Location>
+		<Size>
+			<CX>380</CX>
+			<CY>339</CY>
+		</Size>
+	</Page>
+</XML>

--- a/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Map.xml
+++ b/Zeal/uifiles/zeal/big_xml/EQUI_Tab_Map.xml
@@ -1029,6 +1029,216 @@
       <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
     </ButtonDrawTemplate>
   </Button>
+  <Button item="Zeal_Ring0">
+    <ScreenID>Zeal_Ring0</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>394</X>
+    <Y>1004</Y>
+  </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 1 Color</Text>
+    <TooltipReference>Color for first ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Ring1">
+    <ScreenID>Zeal_Ring1</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>394</X>
+    <Y>1048</Y>
+  </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 2 Color</Text>
+    <TooltipReference>Color for second ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Ring2">
+    <ScreenID>Zeal_Ring2</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>394</X>
+    <Y>1092</Y>
+  </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 3 Color</Text>
+    <TooltipReference>Color for third ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_Ring3">
+    <ScreenID>Zeal_Ring3</ScreenID>
+    <RelativePosition>true</RelativePosition>
+  <Location>
+    <X>394</X>
+    <Y>1136</Y>
+  </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Ring 4 Color</Text>
+    <TooltipReference>Color for fourth ring value</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_MapUseFarRing">
+    <ScreenID>Zeal_MapUseFarRing</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>394</X>
+      <Y>1180</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <Text>Heading Line Uses Far</Text>
+    <TooltipReference>Heading line uses furthest (pressed) or closest (unpressed) ring size</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_MapHeadingColor">
+    <ScreenID>Zeal_MapHeadingColor</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>394</X>
+      <Y>1224</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>false</Style_Checkbox>
+    <Text>Heading Color</Text>
+    <TooltipReference>Heading line color</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
+  <Button item="Zeal_MapHeadingUsesRingColor">
+    <ScreenID>Zeal_MapHeadingUsesRingColor</ScreenID>
+    <RelativePosition>true</RelativePosition>
+    <Location>
+      <X>394</X>
+      <Y>1268</Y>
+    </Location>
+    <Size>
+      <CX>300</CX>
+      <CY>40</CY>
+    </Size>
+    <Style_VScroll>false</Style_VScroll>
+    <Style_HScroll>false</Style_HScroll>
+    <Style_Transparent>false</Style_Transparent>
+    <Style_Checkbox>true</Style_Checkbox>
+    <Text>Heading Uses Ring Color</Text>
+    <TooltipReference>Heading line uses color from ring</TooltipReference>
+    <TextColor>
+      <R>255</R>
+      <G>255</G>
+      <B>255</B>
+    </TextColor>
+    <ButtonDrawTemplate>
+      <Normal>A_BtnNormal</Normal>
+      <Pressed>A_BtnPressed</Pressed>
+      <Flyby>A_BtnFlyby</Flyby>
+      <Disabled>A_BtnDisabled</Disabled>
+      <PressedFlyby>A_BtnPressedFlyby</PressedFlyby>
+    </ButtonDrawTemplate>
+  </Button>
 
   
   <Page item="Tab_Map">
@@ -1079,6 +1289,13 @@
     <Pieces>Zeal_MapAutoFadeEnable</Pieces>
     <Pieces>Zeal_MapAddLocText</Pieces>
     <Pieces>Zeal_MapAddSpeedText</Pieces>
+	<Pieces>Zeal_Ring0</Pieces>
+	<Pieces>Zeal_Ring1</Pieces>
+	<Pieces>Zeal_Ring2</Pieces>
+	<Pieces>Zeal_Ring3</Pieces>
+	<Pieces>Zeal_MapUseFarRing</Pieces>
+	<Pieces>Zeal_MapHeadingColor</Pieces>
+	<Pieces>Zeal_MapHeadingUsesRingColor</Pieces>
     <Pieces>Zeal_MapNamesLength_Label</Pieces>
     <Pieces>Zeal_MapNamesLength_Slider</Pieces>
     <Pieces>Zeal_MapNamesLength_Value</Pieces>

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -88,8 +88,8 @@ static constexpr int kPositionVertices = kPositionCount * 3;            // Fixed
 static constexpr int kRaidMaxMembers = Zeal::GameStructures::RaidInfo::kRaidMaxMembers;
 static constexpr int kRaidPositionVertices = 3;  // Simple single triangle default option.
 static constexpr int kMaxDynamicLabels = 10;
-static constexpr int kMaxRadiusSize = 10000;
-static constexpr int kMinRadiusSize = 10;
+static constexpr int kMaxRadiusSize = 10000;                     // Maximum ring radius
+static constexpr int kMinRadiusSize = 10;                        // Minimum ring radius
 static constexpr int kRingLineSegments = 72;                     // Every 5 degrees.
 static constexpr int kRingVertices = kRingLineSegments + 1 + 2;  // N + 1 for D3DPT_LINESTRIP and optional heading line.
 static constexpr int kMaxNonAllyTriangles = 500;                 // Markers use 1 or 2 triangles each.
@@ -2867,9 +2867,8 @@ void ZoneMap::parse_ring(const std::vector<std::string> &args) {
     setting_show_ring_heading.toggle();
   } else if (args.size() > 2 && args.size() <= 6) {
     map_ring_radius.clear();
-     // || !Zeal::String::tryParse(args[2], &ring_radius) || !set_ring_radius(ring_radius, false)
     for (int i = 2; i < args.size(); ++i) {
-      if (Zeal::String::tryParse(args[i], &ring_radius)) {
+      if (Zeal::String::tryParse(args[i], &ring_radius, true)) {
         set_ring_radius(ring_radius, false);
       } else if (args[i] == "track") {
         ring_radius = get_tracking_distance();

--- a/Zeal/zone_map.cpp
+++ b/Zeal/zone_map.cpp
@@ -88,6 +88,8 @@ static constexpr int kPositionVertices = kPositionCount * 3;            // Fixed
 static constexpr int kRaidMaxMembers = Zeal::GameStructures::RaidInfo::kRaidMaxMembers;
 static constexpr int kRaidPositionVertices = 3;  // Simple single triangle default option.
 static constexpr int kMaxDynamicLabels = 10;
+static constexpr int kMaxRadiusSize = 10000;
+static constexpr int kMinRadiusSize = 10;
 static constexpr int kRingLineSegments = 72;                     // Every 5 degrees.
 static constexpr int kRingVertices = kRingLineSegments + 1 + 2;  // N + 1 for D3DPT_LINESTRIP and optional heading line.
 static constexpr int kMaxNonAllyTriangles = 500;                 // Markers use 1 or 2 triangles each.
@@ -1360,25 +1362,42 @@ void ZoneMap::add_non_ally_position_vertices(std::vector<MapVertex> &vertices,
 }
 
 void ZoneMap::add_ring_vertices(std::vector<MapVertex> &vertices) const {
-  if (map_ring_radius <= 0 || !Zeal::Game::get_self()) return;
+  if (map_ring_radius.size() == 0 || !Zeal::Game::get_self()) return;
 
   Vec3 position = Zeal::Game::get_self()->Position;
 
   // Note: The vertices below are not getting clipped to the map area and
   // are simply disappearing when out of the viewport.
   // Generate kRingLineSegments + 1 vertices.
-  auto color = D3DCOLOR_XRGB(183, 225, 161);  // Light grey green.
   const float angle_increment = static_cast<float>(2 * M_PI / kRingLineSegments);
-  float angle_rad = 0;
-  for (int i = 0; i <= kRingLineSegments; ++i) {
-    if (i == kRingLineSegments) angle_rad = 0;  // Ensure it closes precisely with final line point.
-    float x0 = map_ring_radius * cosf(angle_rad);
-    float y0 = map_ring_radius * sinf(angle_rad);
-    vertices.push_back(MapVertex{.x = x0 + -position.y,  // Note y,x,z and negation.
-                                 .y = y0 + -position.x,
-                                 .z = 0.5f,
-                                 .color = color});
-    angle_rad += angle_increment;  // Advance to next point.
+  int heading_radius = (setting_heading_use_far_ring.get()) ? kMinRadiusSize : kMaxRadiusSize;
+  auto heading_color = ZealService::get_instance()->ui->options->GetRingColor(0);
+  for (int j = 0; j < map_ring_radius.size(); ++j) {
+    auto color = ZealService::get_instance()->ui->options->GetRingColor(j);
+    float angle_rad = 0;
+    int radius = map_ring_radius[j];
+    if (setting_heading_use_far_ring.get() && radius > heading_radius) {
+      heading_radius = radius;
+      heading_color = color;
+    } else if (!setting_heading_use_far_ring.get() && radius < heading_radius) {
+      heading_radius = radius;
+      heading_color = color;
+    }
+
+    for (int i = 0; i <= kRingLineSegments; ++i) {
+      if (i == kRingLineSegments) angle_rad = 0;  // Ensure it closes precisely with final line point.
+      float x0 = radius * cosf(angle_rad);
+      float y0 = radius * sinf(angle_rad);
+      vertices.push_back(MapVertex{.x = x0 + -position.y,  // Note y,x,z and negation.
+                                   .y = y0 + -position.x,
+                                   .z = 0.5f,
+                                   .color = color});
+      angle_rad += angle_increment;  // Advance to next point.
+    }
+  }
+
+  if (!setting_heading_use_ring_color.get()) {
+    heading_color = ZealService::get_instance()->ui->options->GetHeadingColor();
   }
 
   // Support a special extra line that projects out from your heading. This isn't drawn as a strip.
@@ -1386,16 +1405,16 @@ void ZoneMap::add_ring_vertices(std::vector<MapVertex> &vertices) const {
     // Heading: 0 = N = -y, 128 = W = -x, 256 = S = +y, 384 = E = +x.
     // So: Screen x tracks -sin(heading) and y tracks -cos(heading).
     float direction = static_cast<float>(Zeal::Game::get_self()->Heading * M_PI / 256);  // In radians.
-    float x0 = -map_ring_radius * sinf(direction);
-    float y0 = -map_ring_radius * cosf(direction);
+    float x0 = -heading_radius * sinf(direction);
+    float y0 = -heading_radius * cosf(direction);
     vertices.push_back(MapVertex{.x = x0 + -position.y,  // Note y,x,z and negation.
                                  .y = y0 + -position.x,
                                  .z = 0.5f,
-                                 .color = color});
+                                 .color = heading_color});
     vertices.push_back(MapVertex{.x = -position.y,  // Note y,x,z and negation.
                                  .y = -position.x,
                                  .z = 0.5f,
-                                 .color = color});
+                                 .color = heading_color});
   }
 }
 
@@ -1453,7 +1472,11 @@ void ZoneMap::render_positions(IDirect3DDevice8 &device) {
   if (ring_vertex_count) {
     // An optional single heading line is appended to the end of the vertex list.
     int ring_lines = ring_vertex_count - 1 - (setting_show_ring_heading.get() ? 2 : 0);
-    device.DrawPrimitive(D3DPT_LINESTRIP, 0, ring_lines);  // N - 1 strip lines.
+    for (int i = 0; i < map_ring_radius.size(); ++i) {
+      // each ring is kRingLineSegments long
+      int startIdx = (kRingLineSegments + 1) * i;
+      device.DrawPrimitive(D3DPT_LINESTRIP, startIdx, kRingLineSegments);
+    }
     if (setting_show_ring_heading.get()) device.DrawPrimitive(D3DPT_LINELIST, ring_vertex_count - 2, 1);
   }
 
@@ -2026,8 +2049,8 @@ static int get_tracking_distance() {
 }
 
 bool ZoneMap::set_ring_radius(int new_radius, bool update_default) {
-  if (new_radius) new_radius = max(10, min(10000, new_radius));  // Just clamp non-zero.
-  map_ring_radius = new_radius;
+  if (new_radius) new_radius = max(kMinRadiusSize, min(kMaxRadiusSize, new_radius));  // Just clamp non-zero.
+  map_ring_radius.push_back(new_radius);
 
   // Skip storing preferences for now.
   // if (update_default && ZealService::get_instance() && ZealService::get_instance()->ini)
@@ -2342,7 +2365,7 @@ void ZoneMap::load_ini(IO_ini *ini) {
   position_size = ini->getValue<float>("Zeal", "MapPositionSize");
   marker_size = ini->getValue<float>("Zeal", "MapMarkerSize");
   font_filename = ini->getValue<std::string>("Zeal", "MapFontFilename");
-
+  
   // Sanity clamp ini values.
   map_grid_pitch = max(100, min(kMaxGridPitch, map_grid_pitch));
   map_name_length = max(3, min(kMaxNameLength, map_name_length));
@@ -2830,9 +2853,11 @@ void ZoneMap::parse_grid(const std::vector<std::string> &args) {
 
 void ZoneMap::parse_ring(const std::vector<std::string> &args) {
   int ring_radius = 0;
-  if ((args.size() == 2 && map_ring_radius) || (args.size() == 3 && args[2] == "off")) {
-    set_ring_radius(0, false);  // Toggle or force off.
+  if ((args.size() == 2 && map_ring_radius.size() >= 1) || (args.size() == 3 && args[2] == "off")) {
+      // map ring & size > 1 || map ring off
+    map_ring_radius.clear();
   } else if (args.size() == 2 || (args.size() == 3 && args[2] == "on")) {
+    map_ring_radius.clear();
     int ring_radius = get_tracking_distance();  // Toggle / Enable with auto-range.
     if (ring_radius)
       set_ring_radius(ring_radius, false);
@@ -2840,7 +2865,18 @@ void ZoneMap::parse_ring(const std::vector<std::string> &args) {
       Zeal::Game::print_chat("Use /map ring <radius> to turn on with zero tracking skill");
   } else if (args.size() == 3 && args[2] == "heading") {
     setting_show_ring_heading.toggle();
-  } else if (args.size() != 3 || !Zeal::String::tryParse(args[2], &ring_radius) || !set_ring_radius(ring_radius, false))
+  } else if (args.size() > 2 && args.size() <= 6) {
+    map_ring_radius.clear();
+     // || !Zeal::String::tryParse(args[2], &ring_radius) || !set_ring_radius(ring_radius, false)
+    for (int i = 2; i < args.size(); ++i) {
+      if (Zeal::String::tryParse(args[i], &ring_radius)) {
+        set_ring_radius(ring_radius, false);
+      } else if (args[i] == "track") {
+        ring_radius = get_tracking_distance();
+        set_ring_radius(ring_radius, false);
+      }
+    }
+  } else if (args.size() < 3 || args.size() > 6)
     Zeal::Game::print_chat(
         "Usage: /map ring [radius#, on, off, heading] (blank disables or uses calculated track range)");
 }
@@ -3098,7 +3134,7 @@ void ZoneMap::reset_zone_state() {
   dynamic_labels_list.clear();
   map_level_index = default_to_zlevel_autofade ? -1 : 0;
   zoom_factor = kDefaultZoomFactors[map_zoom_default_index];  // Reset for consistent behavior.
-  map_ring_radius = 0;                                        // Disable since skill-based range is zone dependent.
+  map_ring_radius.clear();                                    // Disable since skill-based range is zone dependent.
   manual_on_move_trigger = false;
   reset_mouse();
   enable_autocenter();

--- a/Zeal/zone_map.h
+++ b/Zeal/zone_map.h
@@ -87,6 +87,8 @@ class ZoneMap {
   ZealSetting<bool> setting_add_speed_text = {false, "Zeal", "MapAddSpeedText", false};
   ZealSetting<bool> setting_show_all_player_headings = {false, "Zeal", "MapShowPlayerHeadings", false};
   ZealSetting<bool> setting_show_ring_heading = {false, "Zeal", "MapShowRingHeading", false};
+  ZealSetting<bool> setting_heading_use_far_ring = {false, "Zeal", "MapHeadingUseFarRing", false};
+  ZealSetting<bool> setting_heading_use_ring_color = {false, "Zeal", "MapHeadingUseRingColor", false};
 
   bool is_external_enabled() const { return external_enabled; }
 
@@ -321,7 +323,7 @@ class ZoneMap {
   bool map_show_all = false;                // PVP mode level playing field (show everything).
   bool map_show_grid = false;
   int map_grid_pitch = kDefaultGridPitch;  // Pitch when grid is visible.
-  int map_ring_radius = 0;
+  std::vector<int> map_ring_radius = {0};
   int map_name_length = kDefaultNameLength;  // Number of characters in name labels.
   bool map_show_raid = false;
   bool map_show_all_names_override = false;  // Overrides modes to show names of all visible members.


### PR DESCRIPTION
# Brief
There have been times where I wanted to know range for a Complete Heal but also if someones in range for the Remedy line as these differ in range, and was not able to before. I've seen guildies want to be able to have a track range and bow range, myself included. And it appears there was a similar request for multiple rings back in [September on discord](https://discord.com/channels/1133452007412334643/1418606635244453968).

# Details
- `/map ring` now supports up to 4 radii being provided, any radii can be the word `track` to use tracking range calculations.
  - full command: `/map ring radius1 radius2 radius3 radius4`
- Added UI settings for ring colors (Stored in `ZealColors` section in INI)
- Added UI settings for heading line (`/map ring heading`) to use smallest radius or largest radius (Stored in `Zeal` section in INI)
- Added UI settings for heading line to use ring color or player-defined color (Stored in `ZealColors` section in INI)
- Updated README.md with relevant information about the changes to the command

# Notes
There is no sorting of the argument list provided in this manner, so using `/map ring 100 200 300` does:
- 100 - Uses ring 1 color
- 200 - Uses ring 2 color
- 300 - Uses ring 3 color
 However, then using `/map ring 300 100 200` then does:
- 300 - Uses ring 1 color
- 100 - Uses ring 2 color
- 200 - Uses ring 3 color
I'm fine with this, and it could be considered "just an extra feature" - maybe someone wants to use a specific ring color for some reason. Less overhead on sorting the list every time and pre-parsing values for in case user adds `track` range to the listing.

Similarly, `/map ring 0 100` would only show a ring size of 100, as the 0 is ignored and the 100 would use Ring 2 color.