### PR TITLE
Add hotbar/social page 10 keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,8 @@ Manual editing of the ini file is required to copy from old section to the new s
 - Toggle target nameplate color on and off
 - Toggle target nameplate marker on and off
 - Toggle target nameplate health on and off
+- Hotbar Page 10 Slot 1 through Slot 10 (presses a page 10 hotbutton without changing the visible page)
+- Social Page 10 Slot 1 through Slot 12 (runs a page 10 social macro without changing the visible page)
 
 ---
 ### Advanced input (/zealinput) including tab completion

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -102,6 +102,7 @@
     <ClInclude Include="named_pipe.h" />
     <ClInclude Include="nameplate.h" />
     <ClInclude Include="npc_give.h" />
+    <ClInclude Include="page10_binds.h" />
     <ClInclude Include="patches.h" />
     <ClInclude Include="physics.h" />
     <ClInclude Include="target_ring.h" />
@@ -187,6 +188,7 @@
     <ClCompile Include="named_pipe.cpp" />
     <ClCompile Include="nameplate.cpp" />
     <ClCompile Include="npc_give.cpp" />
+    <ClCompile Include="page10_binds.cpp" />
     <ClCompile Include="patches.cpp" />
     <ClCompile Include="physics.cpp" />
     <ClCompile Include="target_ring.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -138,6 +138,9 @@
     <ClInclude Include="melody.h">
       <Filter>Header Files\hooks</Filter>
     </ClInclude>
+    <ClInclude Include="page10_binds.h">
+      <Filter>Header Files\hooks</Filter>
+    </ClInclude>
     <ClInclude Include="camera_math.h">
       <Filter>Header Files\helpers</Filter>
     </ClInclude>
@@ -384,6 +387,9 @@
       <Filter>Source Files\hooks</Filter>
     </ClCompile>
     <ClCompile Include="melody.cpp">
+      <Filter>Source Files\hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="page10_binds.cpp">
       <Filter>Source Files\hooks</Filter>
     </ClCompile>
     <ClCompile Include="string_util.cpp">

--- a/Zeal/game_ui.h
+++ b/Zeal/game_ui.h
@@ -486,6 +486,7 @@ struct RaidWnd : SidlWnd {
 
 struct HotButton : SidlWnd {
   int GetPage() { return *(int *)0x7f69f6; }
+  void SetPage(int page) { *(int *)0x7f69f6 = page; }
 
   BYTE GetType(int button_index) { return *(BYTE *)(0x7f6862 + (button_index + (GetPage() * 0xA))); }
 };

--- a/Zeal/page10_binds.cpp
+++ b/Zeal/page10_binds.cpp
@@ -1,0 +1,101 @@
+#include "page10_binds.h"
+
+#include <cctype>
+#include <cstring>
+
+#include "callbacks.h"
+#include "game_addresses.h"
+#include "game_functions.h"
+#include "game_structures.h"
+#include "game_ui.h"
+#include "io_ini.h"
+#include "zeal.h"
+
+static constexpr int kPage10Index = 9;           // Zero-based index of hotbar / social page 10.
+static constexpr int kSocialLinesPerButton = 5;  // Command lines per social in the client.
+static constexpr int kMaxPauseTicks = 600;       // Client caps social /pause values at 600 (60 seconds).
+static constexpr UINT kCmdHotButton1 = 31;       // Client ExecuteCmd id of the HOT1 keybind.
+
+Page10Binds::Page10Binds(ZealService *zeal) {
+  zeal->callbacks->AddGeneric([this]() { process_queue(); });  // MainLoop.
+  zeal->callbacks->AddGeneric([this]() { command_queue.clear(); }, callback_type::CharacterSelect);
+  zeal->callbacks->AddGeneric([this]() { command_queue.clear(); }, callback_type::DeactivateUI);
+}
+
+// Presses the given page 10 hotbutton by temporarily swapping the active page around the
+// client's ExecuteCmd call, leaving the visible hotbar page unchanged. Note: if the button
+// holds a multi-line social, the client's native macro engine may continue it on later frames
+// after the page has been restored, so lines after the first may not resolve to page 10.
+void Page10Binds::press_hotbutton(int slot) {
+  auto hotbutton_wnd = Zeal::Game::Windows->HotButton;
+  if (!hotbutton_wnd) return;
+
+  const int saved_page = hotbutton_wnd->GetPage();
+  hotbutton_wnd->SetPage(kPage10Index);
+  Zeal::Game::execute_cmd(kCmdHotButton1 + slot, 1, 0);  // Key down.
+  Zeal::Game::execute_cmd(kCmdHotButton1 + slot, 0, 0);  // Key up.
+  hotbutton_wnd->SetPage(saved_page);
+}
+
+// Extracts the command to execute from a social line, handling the client's native
+// "/pause <ticks>[, <command>]" prefix syntax. Returns the command ("" if none) and stores the
+// delay to apply after this line in pause_ticks (tenths of a second).
+static std::string parse_social_line(std::string line, int &pause_ticks) {
+  pause_ticks = 0;
+  constexpr size_t kPauseLength = 6;  // strlen("/pause").
+  if (line.size() >= kPauseLength && _strnicmp(line.c_str(), "/pause", kPauseLength) == 0 &&
+      (line.size() == kPauseLength || !isalpha(static_cast<unsigned char>(line[kPauseLength])))) {
+    pause_ticks = min(max(0, atoi(line.c_str() + kPauseLength)), kMaxPauseTicks);
+    const size_t comma = line.find(',');
+    line = (comma == std::string::npos) ? std::string() : line.substr(comma + 1);
+  }
+  line.erase(0, line.find_first_not_of(" \t"));  // Also erases all of a whitespace-only line.
+  return line;
+}
+
+// Loads the social lines for the page 10 button (1-based) from the character ini and queues
+// them for execution with their accumulated /pause delays. Replaces any pending page 10 social.
+// Note: a macro started natively (hotbar / socials window) is not stopped; the client has no
+// exposed call for that, and pressing a hotbutton while a macro runs is ignored by the client.
+void Page10Binds::execute_social(int button) {
+  const auto *char_info = Zeal::Game::get_char_info();
+  if (!char_info) return;
+
+  command_queue.clear();
+
+  // The client stores per-character settings (including socials) next to the exe.
+  const IO_ini ini(std::string(".\\") + char_info->Name + Zeal::Game::get_host_tag() + ".ini");
+  ULONGLONG execute_time = GetTickCount64();
+  for (int line = 1; line <= kSocialLinesPerButton; ++line) {
+    char key[32];
+    snprintf(key, sizeof(key), "Page10Button%dLine%d", button, line);
+    int pause_ticks = 0;
+    std::string command = parse_social_line(ini.getValue<std::string>("Socials", key), pause_ticks);
+    if (!command.empty()) command_queue.push_back({std::move(command), execute_time});
+    execute_time += static_cast<ULONGLONG>(pause_ticks) * 100;  // /pause is in tenths of a second.
+  }
+}
+
+// Executes queued social lines once their /pause delay has elapsed. Routes through the client's
+// InterpretCommand so lines behave exactly like typed commands (including Zeal commands).
+void Page10Binds::process_queue() {
+  if (command_queue.empty()) return;
+  if (!Zeal::Game::is_in_game() || !Zeal::Game::get_self()) {
+    command_queue.clear();
+    return;
+  }
+
+  const ULONGLONG now = GetTickCount64();
+  while (!command_queue.empty() && command_queue.front().execute_time <= now) {
+    auto *self = Zeal::Game::get_self();  // Re-checked per command in case one tears down state.
+    if (!Zeal::Game::is_in_game() || !self) {
+      command_queue.clear();
+      return;
+    }
+    const std::string command = std::move(command_queue.front().command);
+    command_queue.pop_front();
+    reinterpret_cast<void(__fastcall *)(Zeal::GameStructures::GameClass *, int, Zeal::GameStructures::Entity *,
+                                        const char *)>(Zeal::Game::GameInternal::fn_interpretcmd)(
+        Zeal::Game::get_game(), 0, self, command.c_str());
+  }
+}

--- a/Zeal/page10_binds.h
+++ b/Zeal/page10_binds.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Windows.h>
+
+#include <deque>
+#include <string>
+
+// Activates hotbar page 10 buttons and social page 10 macros without switching the visible
+// hotbar page. This effectively provides extra macro keys backed by the last (rarely used)
+// page of hotbuttons and socials. The bindable keys are registered in ZealService::AddBinds().
+//
+// Social macros are read directly from the character ini ([Socials] Page10Button<N>Line<1-5>)
+// and support the native "/pause <ticks>[, <command>]" syntax. Lines are queued and executed
+// with their pause delays in the MainLoop callback. Note the client only rewrites the ini at
+// camp / exit, so social edits made in-game are not picked up until then.
+class Page10Binds {
+ public:
+  Page10Binds(class ZealService *zeal);
+
+  void press_hotbutton(int slot);   // Presses a page 10 hotbutton (0-based) without changing pages.
+  void execute_social(int button);  // Queues the social lines of a page 10 button (1-based).
+
+ private:
+  struct QueuedCommand {
+    std::string command;
+    ULONGLONG execute_time;  // GetTickCount64() timestamp when the command is due.
+  };
+
+  void process_queue();  // MainLoop callback that executes due commands.
+
+  std::deque<QueuedCommand> command_queue;  // Pending social lines awaiting their /pause delays.
+};

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -43,6 +43,7 @@
 #include "netstat.h"
 #include "npc_give.h"
 #include "outputfile.h"
+#include "page10_binds.h"
 #include "patches.h"
 #include "physics.h"
 #include "player_movement.h"
@@ -138,6 +139,7 @@ ZealService::ZealService() {
   music = MakeCheckedUnique(MusicManager);
   alarm = MakeCheckedUnique(Alarm);
   melody = MakeCheckedUnique(Melody);
+  page10_binds = MakeCheckedUnique(Page10Binds);
   autofire = MakeCheckedUnique(AutoFire);
   netstat = MakeCheckedUnique(Netstat);
   tick = MakeCheckedUnique(Tick);
@@ -1065,4 +1067,25 @@ void ZealService::AddBinds() {
                            }
                          }
                        });
+
+  // Page 10 hotbutton and social binds (page10_binds.cpp). Indices 131 - 152 sit in the unused
+  // gap between the last known client bind (130) and the hidden client binds guarded in binds.cpp.
+  for (int slot = 0; slot < 10; ++slot) {
+    char name[64];
+    snprintf(name, sizeof(name), "Hotbar Page 10 Slot %d", slot + 1);
+    char short_name[64];
+    snprintf(short_name, sizeof(short_name), "HotbarPage10Slot%d", slot + 1);
+    binds_hook->add_bind(131 + slot, name, short_name, key_category::Macros, [this, slot](int key_down) {
+      if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) page10_binds->press_hotbutton(slot);
+    });
+  }
+  for (int button = 0; button < 12; ++button) {
+    char name[64];
+    snprintf(name, sizeof(name), "Social Page 10 Slot %d", button + 1);
+    char short_name[64];
+    snprintf(short_name, sizeof(short_name), "SocialPage10Slot%d", button + 1);
+    binds_hook->add_bind(141 + button, name, short_name, key_category::Macros, [this, button](int key_down) {
+      if (key_down && !Zeal::Game::GameInternal::UI_ChatInputCheck()) page10_binds->execute_social(button + 1);
+    });
+  }
 }

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -59,6 +59,7 @@ class ZealService {
   std::unique_ptr<class MusicManager> music = nullptr;
   std::unique_ptr<class Alarm> alarm = nullptr;
   std::unique_ptr<class Melody> melody = nullptr;
+  std::unique_ptr<class Page10Binds> page10_binds = nullptr;
   std::unique_ptr<class AutoFire> autofire = nullptr;
   std::unique_ptr<class Netstat> netstat = nullptr;
   std::unique_ptr<class Tick> tick = nullptr;


### PR DESCRIPTION
Added 22 bindable keys that activate hotbar buttons on page 10 and social macros on page 10 without changing the visible hotbar. 

Implementation: new page10_binds module; binds registered inline in ZealService::AddBinds(). Social lines are read from the character's ini and then executed through InterpretCommand. Included native /pause syntax support (clamped to 600 ticks). 

1 open question on the bind indices.. I used 131-152. Its mentioned existing convention starts at 211 to stay clear of unverified client ids, but 211-255 is nearly full. Happy to relocate if needed.
