### PR TITLE
Add /tellconsent retry and suppress tell windows

### DIFF
--- a/Zeal/chat.cpp
+++ b/Zeal/chat.cpp
@@ -942,10 +942,22 @@ static bool CheckForConsentWhoMatch(const std::string name, std::string &who, sh
 }
 
 void Chat::AddOutputText(Zeal::GameUI::ChatWnd *wnd, std::string &msg, short &channel) {
+
+  // Add an auto-handler to fix when the /tellconsent toggles consent off instead of on.
+  if (channel == CHATCOLOR_WHITE && EnableAutoConsent.get() && !consented_name.empty()) {
+    if (msg.starts_with("You have given ") && msg.ends_with( consented_name + " permission to drag your corpse.") ) {
+      consented_name = ""; // Granted, clear so doesn't toggle off.
+    } else if (msg.starts_with("You have denied ") && msg.ends_with( consented_name + " permission to drag your corpse.") ) {
+      Zeal::Game::do_consent(consented_name.c_str());  // Retry to attempt to toggle back on.
+      consented_name = "";
+    }
+  }
+
   if (channel == USERCOLOR_TELL && EnableAutoConsent.get()) {
     std::string name = GetConsentMeTellName(msg);
     if (!name.empty()) {
       if (CheckForImmediateConsentPermission(name)) {
+        consented_name = name;
         Zeal::Game::do_consent(name.c_str());
         channel = CHATCOLOR_DEFAULT;
         msg = name + " sent a tell that triggered Zeal auto-consent.";
@@ -959,6 +971,7 @@ void Chat::AddOutputText(Zeal::GameUI::ChatWnd *wnd, std::string &msg, short &ch
   if (channel == USERCOLOR_WHO && EnableAutoConsent.get() && IsConsentWhoPending()) {
     // Note: The call will modify the msg (suppress or update) and channel based on matching.
     if (CheckForConsentWhoMatch(pending_consent_name, msg, channel)) {
+      consented_name = pending_consent_name;
       Zeal::Game::do_consent(pending_consent_name.c_str());
     }
   }

--- a/Zeal/chat.h
+++ b/Zeal/chat.h
@@ -83,4 +83,5 @@ class Chat {
   std::function<bool(int key, bool down, int modifier)> key_press_callback;
   DWORD pending_consent_timeout_ms = 0;
   std::string pending_consent_name;
+  std::string consented_name;  // Name of last player auto-consented (used to handle one retry on a denial)
 };

--- a/Zeal/game_packets.h
+++ b/Zeal/game_packets.h
@@ -9,6 +9,7 @@ enum opcodes {
   ZoneSpawns = 0x415f,
   DeathDamage = 0x404A,
   Damage = 0x4058,
+  ConsentResponse = 0x40D5,
   PrintNonMeleeDamage = 0x4236,
   CorpseDrag = 0x4114,
   CorpseDrop = 0x1337,
@@ -151,5 +152,13 @@ struct ItemViewRequest_Struct {
   /*000*/ short item_id;
   /*002*/ char item_name[64];
 };
+
+struct ConsentResponse_Struct {
+	char grantname[64];
+	char ownername[64];
+	UINT8 permission;
+	char zonename[32];
+};
+
 }  // namespace Packets
 }  // namespace Zeal

--- a/Zeal/tellwindows.cpp
+++ b/Zeal/tellwindows.cpp
@@ -253,11 +253,21 @@ void TellWindows::AddOutputText(Zeal::GameUI::ChatWnd *&wnd, std::string &msg, s
   {
     std::string name = GetName(msg);
     if (name.length()) {
-      UpdateMostRecentList(name);
       name[0] = std::toupper(name[0]);
       Zeal::GameUI::ChatWnd *tell_window = ZealService::get_instance()->tells->FindTellWnd(name);
+
+      // Prevent autoconsent trigger tells from triggering new tell windows by routing to default chat.
+      const bool use_abc = (ZealService::get_instance()->chat_hook->UseAbbreviatedChat.get() != 0);
+      if (!tell_window && channel == USERCOLOR_ECHO_TELL && 
+          ZealService::get_instance()->chat_hook->EnableAutoConsent.get() && msg.ends_with( use_abc ? "Consent me" : "'Consent me'") ) {
+        channel = CHATCOLOR_DEFAULT;
+        msg = "You sent an autoconsent trigger tell to " + name;
+        return;
+     }
+
+      UpdateMostRecentList(name);
       // Modify msg if abbreviated chat is enabled
-      if (ZealService::get_instance()->chat_hook->UseAbbreviatedChat.get()) msg = abbreviateTell(std::string(msg));
+      if (use_abc) msg = abbreviateTell(std::string(msg));
       replaceNameLinks(msg);
       if (!tell_window) {
         std::string WinName = TellWindowIdentifier + name;


### PR DESCRIPTION
- Modified /tellconsent and the response to perform one retry if a do_consent() toggled previously granted consent off
- Modified /tellconsent so it will not open a new tell window just to send a /tellconsent message if the sender has /autoconsent on