### PR TITLE
Bump to v1.4.5 with a short term "fix" to windows update induced crashing

### DIFF
--- a/Zeal/crash_handler.cpp
+++ b/Zeal/crash_handler.cpp
@@ -29,7 +29,8 @@ std::vector<DWORD> nonCrashExceptionCodes = {
     STATUS_STACK_OVERFLOW,         // 0xC00000FD, Stack overflow occurred but might be recoverable
     0x406D1388,                    // Exception used to set thread names for debugging
     0x80000007,                    // Used to wake up the system debugger
-    0xe06d7363                     // C++ exception, funny enough in ascii this code is 'MSC'
+    0xe06d7363,                    // C++ exception, funny enough in ascii this code is 'MSC'
+    0x000006ef,                    // Generated in the midi system after Windows update KB101650.
 };
 
 // Define a map to store exception codes and their descriptions

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#define ZEAL_VERSION "1.4.4"
+#define ZEAL_VERSION "1.4.5"
 #ifndef ZEAL_BUILD_VERSION               // Set by github actions
 #define ZEAL_BUILD_VERSION "UNOFFICIAL"  // Local build
 #endif


### PR DESCRIPTION
- Windows update KB101650 has caused the client to crash with 0x6ef kernelbase.dll exception codes while apparently trying to close an invalid midi driver session. The client does not appear to crash from this code w/out Zeal but it was triggering Zeal's crash handler shutdown routine
- This workaround adds that exception code to the ignore list of the Zeal crash handler.  Client stability and midi functionality to be determined, but that may be Zeal independent

A debugger on a system with that update shows these debug statements and the backtrace showed the crash handler later triggering on a failure to close a midi session in a midiShortOut call from mss32.dll:

```
The thread 35364 has exited with code 0 (0x0).
0 Removed
Clean UI UIMANAGER
The thread 9064 has exited with code 0 (0x0).
avcore\midi2\libs\midisrvtransportlib\midisrvtransport.cpp(319)\wdmaud2.drv!64B13B56: (caller: 64B13A4B) ReturnHr(6577) tid(7cb8) 80070005 Access is denied.
avcore\midi2\libs\midisrvtransportlib\midisrvtransport.cpp(319)\wdmaud2.drv!64B13A64: (caller: 64B0C943) ReturnHr(6578) tid(7cb8) 80070005 Access is denied.
avcore\midi2\client\winmm\midisrvports.cpp(183)\wdmaud2.drv!64B0C982: (caller: 64B11839) ReturnHr(6579) tid(7cb8) 80070005 Access is denied.
Exception thrown at 0x77239F54 (KernelBase.dll) in eqgame.exe: 0x000006EF: A null context handle was passed from the client to the host during a remote procedure call.
```