### PR TITLE
Add opt-in OTLP/HTTP telemetry exporter, built on opentelemetry-cpp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+# CI build workflow that compiles the project and uploads artifacts for testing.
+# Download artifacts from the Actions tab after a successful build.
+
+name: Build
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
+env:
+  SOLUTION_FILE_PATH: ./Zeal.sln
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and upload artifacts
+    runs-on: windows-2022
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v3
+
+      - name: Parse the git short hash
+        id: parse_git
+        shell: bash
+        run: |
+          SHORT_HASH=$(git rev-parse --short "$GITHUB_SHA")
+          echo short_hash=$SHORT_HASH >> $GITHUB_OUTPUT
+
+      - name: Extract ZEAL_VERSION from source
+        id: zeal_version
+        shell: bash
+        env:
+          SED_PARAMS: 's/^[^"]*"\([^"]*\)".*/\1/'
+        run: |
+          ZEAL_VERSION=$(grep '#define ZEAL_VERSION' Zeal/zeal.h | sed "$SED_PARAMS")
+          echo version=v$ZEAL_VERSION >> $GITHUB_OUTPUT
+
+      # The exporter hand-builds OTLP JSON, so validate our payload shapes against the official
+      # opentelemetry-proto schema — catches "valid JSON, invalid OTLP" before it can ship.
+      - name: Validate OTLP payload shapes against the official schema
+        shell: bash
+        run: |
+          python -m pip install --quiet opentelemetry-proto
+          python ci/otlp_validate.py ci/fixtures/*.json
+
+      - name: Build
+        env:
+          ZEAL_BUILD_VERSION: ${{ steps.parse_git.outputs.short_hash }}
+        run: |
+          msbuild /m /p:Configuration=Release /p:Platform=x86 /p:zeal_build_version=$env:ZEAL_BUILD_VERSION /p:LanguageStandard=stdcpp20 $env:SOLUTION_FILE_PATH /p:ExportHeader="" /p:ScanDependencies=""
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: zeal-${{ steps.zeal_version.outputs.version }}-${{ steps.parse_git.outputs.short_hash }}
+          path: |
+            Release/Zeal.asi
+            Release/Zeal.pdb
+            Zeal/uifiles
+            README.md

--- a/.github/workflows/zeal-otel-sdk-spike.yml
+++ b/.github/workflows/zeal-otel-sdk-spike.yml
@@ -1,0 +1,181 @@
+# Spike: link the OpenTelemetry C++ SDK into Zeal itself, over the WinHTTP transport.
+#
+# spike/otel-winhttp proved the SDK builds for x86 with curl off and a WinHTTP client supplied. That
+# was a standalone executable. This asks the harder question: does it link into the injected game
+# DLL - 32-bit, static CRT, alongside a 2003 d3dx8.lib - and produce a loadable Zeal.asi?
+#
+# Everything must be /MT here: Zeal is MultiThreaded, so the -md triplet used by the standalone
+# spike would fail on the CRT before anything interesting happened.
+name: OTel SDK build
+
+on:
+  pull_request:
+    paths:
+      - 'Zeal/telemetry.*'
+      - 'Zeal/instrumentation.*'
+      - 'Zeal/otlp_*'
+      - 'Zeal/Zeal.vcxproj'
+      - 'spike/**'
+      - '.github/workflows/zeal-otel-sdk-spike.yml'
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-2022
+    env:
+      OTEL_CPP_VERSION: v1.28.0
+      TRIPLET: x86-windows-static   # static CRT (/MT), unlike the -md triplet used standalone
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: microsoft/setup-msbuild@v3
+
+      # The SDK build is ~25 minutes and depends only on the pinned version and triplet, while the
+      # interesting failures are all in the Zeal link that follows it. Cache it so iterating on the
+      # link costs minutes rather than half-hours.
+      - name: Restore the built SDK
+        id: sdk-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ${{ runner.temp }}/otel-install
+            C:/vcpkg/installed/x86-windows-static
+          key: otel-${{ env.OTEL_CPP_VERSION }}-${{ env.TRIPLET }}-mt-v1
+
+      - name: Fetch opentelemetry-cpp
+        if: steps.sdk-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          git clone --depth 1 --branch $env:OTEL_CPP_VERSION --recurse-submodules `
+            https://github.com/open-telemetry/opentelemetry-cpp.git (Join-Path $env:RUNNER_TEMP 'otel-cpp')
+
+      - name: protobuf and abseil with the static CRT, no zlib
+        if: steps.sdk-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install "protobuf:$env:TRIPLET" "abseil:$env:TRIPLET"
+          if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed" }
+
+      - name: Point the build at the SDK (cached or freshly built)
+        shell: pwsh
+        run: |
+          echo "VCPKG_INSTALL=$env:VCPKG_INSTALLATION_ROOT\installed\$env:TRIPLET" >> $env:GITHUB_ENV
+          echo "OTEL_INSTALL=$(Join-Path $env:RUNNER_TEMP 'otel-install')" >> $env:GITHUB_ENV
+
+      - name: Build the SDK (x86, /MT, curl off)
+        if: steps.sdk-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $src = Join-Path $env:RUNNER_TEMP 'otel-cpp'
+          $bld = Join-Path $env:RUNNER_TEMP 'otel-build'
+          $inst = Join-Path $env:RUNNER_TEMP 'otel-install'
+          $args = @(
+            '-S', $src, '-B', $bld, '-G', 'Visual Studio 17 2022', '-A', 'Win32',
+            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake",
+            "-DVCPKG_TARGET_TRIPLET=$env:TRIPLET",
+            "-DCMAKE_INSTALL_PREFIX=$inst",
+            '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded',   # match Zeal's /MT
+            '-DWITH_OTLP_HTTP=ON', '-DWITH_HTTP_CLIENT_CURL=OFF', '-DWITH_OTLP_GRPC=OFF',
+            '-DWITH_EXAMPLES=OFF', '-DBUILD_TESTING=OFF', '-DWITH_BENCHMARK=OFF',
+            '-DWITH_FUNC_TESTS=OFF', '-DOPENTELEMETRY_INSTALL=ON', '-DWITH_ABSEIL=ON'
+          )
+          & cmake @args
+          if ($LASTEXITCODE -ne 0) { throw "configure failed" }
+          $cache = Join-Path $bld 'CMakeCache.txt'
+          $curl = (Select-String -Path $cache -Pattern '^WITH_HTTP_CLIENT_CURL:').Line
+          if ($curl -notmatch '=OFF') { throw "curl still on: $curl" }
+          Write-Host "  $curl"
+          & cmake --build $bld --config Release --target install -- /m
+          if ($LASTEXITCODE -ne 0) { throw "SDK build failed" }
+
+      # cache@v4 only saves on success, and every failure so far has been in the link that follows -
+      # so the 25-minute SDK build was repeated each time. Save it as soon as it exists.
+      - name: Save the SDK to cache
+        if: steps.sdk-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ runner.temp }}/otel-install
+            C:/vcpkg/installed/x86-windows-static
+          key: otel-${{ env.OTEL_CPP_VERSION }}-${{ env.TRIPLET }}-mt-v1
+
+      # The in-game crash happened under Wine, while this same transport passes on real Windows.
+      # Publishing the standalone test lets the Wine path be reproduced outside the game, instead of
+      # costing a player their session each time.
+      - name: Build the standalone smoke test (x86, /MT) for Wine testing
+        shell: pwsh
+        run: |
+          $bld = Join-Path $env:RUNNER_TEMP 'spike-x86'
+          # protoc is a host tool: vcpkg keeps it in the x64 tree, which the cache (x86 static only)
+          # does not carry. Only find_package needs it - the Zeal link uses prebuilt archives.
+          $protoc = Get-ChildItem 'C:\\vcpkg\\installed' -Recurse -Filter protoc.exe -ErrorAction SilentlyContinue |
+                    Select-Object -First 1
+          if (-not $protoc) {
+            & "$env:VCPKG_INSTALLATION_ROOT\\vcpkg.exe" install protobuf
+            $protoc = Get-ChildItem 'C:\\vcpkg\\installed' -Recurse -Filter protoc.exe -ErrorAction SilentlyContinue |
+                      Select-Object -First 1
+          }
+          if (-not $protoc) { throw "no protoc.exe found" }
+          Write-Host "protoc: $($protoc.FullName)"
+          $cargs = @(
+            "-DProtobuf_PROTOC_EXECUTABLE=$($protoc.FullName)",
+            '-S', '.\\spike\\winhttp-client', '-B', $bld, '-G', 'Visual Studio 17 2022', '-A', 'Win32',
+            "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\\scripts\\buildsystems\\vcpkg.cmake",
+            "-DVCPKG_TARGET_TRIPLET=$env:TRIPLET",
+            "-DCMAKE_PREFIX_PATH=$env:OTEL_INSTALL",
+            '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded'
+          )
+          & cmake @cargs
+          if ($LASTEXITCODE -ne 0) { throw "smoke test configure failed" }
+          & cmake --build $bld --config Release
+          if ($LASTEXITCODE -ne 0) { throw "smoke test build failed" }
+          $exe = Get-ChildItem $bld -Recurse -Filter smoke_test.exe | Select-Object -First 1
+          New-Item -ItemType Directory -Force -Path .\\smoke-out | Out-Null
+          Copy-Item $exe.FullName .\\smoke-out\\
+          Write-Host "smoke_test.exe: $([math]::Round($exe.Length/1MB,2)) MB"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: winhttp-smoke-x86
+          path: smoke-out/smoke_test.exe
+
+      - name: Build Zeal with the SDK linked in
+        shell: pwsh
+        run: |
+          # Write the archive list to a props file the project imports. Passing it via /p: meant
+          # MSBuild split it on ';' and fed the linker a junk input; a file avoids that entirely.
+          $otel = (Get-ChildItem "$env:OTEL_INSTALL\lib" -Filter *.lib | ForEach-Object { $_.Name })
+          $vcpkg = (Get-ChildItem "$env:VCPKG_INSTALL\lib" -Filter *.lib | ForEach-Object { $_.Name })
+          Write-Host "linking $($otel.Count) SDK archives and $($vcpkg.Count) vcpkg archives"
+          $libs = (($otel + $vcpkg) -join ';')
+          $xml = '<?xml version="1.0" encoding="utf-8"?><Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">' +
+                 '<PropertyGroup><OTEL_LIBS>' + $libs + ';</OTEL_LIBS></PropertyGroup></Project>'
+          Set-Content -Path .\spike\zeal-sdk\otel_libs.generated.props -Value $xml -Encoding UTF8
+
+          # The real question: does all of this link into a 32-bit /MT DLL that already carries
+          # d3dx8.lib? Failure here is the answer, whatever it says.
+          $env:ZEAL_OTEL_SDK = '1'
+          & msbuild /m /p:Configuration=Release /p:Platform=x86 /p:LanguageStandard=stdcpp20 `
+            /p:ZEAL_OTEL_SDK=1 /p:OTEL_INSTALL="$env:OTEL_INSTALL" /p:VCPKG_INSTALL="$env:VCPKG_INSTALL" `
+            /p:ExportHeader="" /p:ScanDependencies="" .\Zeal.sln
+          if ($LASTEXITCODE -ne 0) { throw "Zeal build with the SDK failed" }
+
+      - name: Report what it costs
+        shell: pwsh
+        run: |
+          $asi = Get-Item .\Release\Zeal.asi
+          $mb = [math]::Round($asi.Length / 1MB, 2)
+          Write-Host "Zeal.asi with the SDK: $mb MB"
+          Write-Host "(the shipping hand-rolled build is about 11.2 MB - the difference is the"
+          Write-Host " decision this spike exists to inform)"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: zeal-otel-sdk-winhttp
+          path: |
+            Release/Zeal.asi
+            Release/Zeal.pdb

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -22,6 +22,8 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <!-- Opt-in: imported only when ZEAL_OTEL_SDK=1, so the default build is untouched. -->
+  <Import Project="$(SolutionDir)spike\zeal-sdk\otel_sdk.props" Condition="'$(ZEAL_OTEL_SDK)'=='1'" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
@@ -60,7 +62,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>winmm.lib;Dbghelp.lib;winhttp.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;Dbghelp.lib;winhttp.lib;crypt32.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
@@ -104,6 +106,9 @@
     <ClInclude Include="everquest_semconv.h" />
     <ClInclude Include="npc_give.h" />
     <ClInclude Include="otlp_exporter.h" />
+    <ClInclude Include="otlp_client.h" />
+    <ClInclude Include="telemetry.h" />
+    <ClInclude Include="instrumentation.h" />
     <ClInclude Include="page10_binds.h" />
     <ClInclude Include="patches.h" />
     <ClInclude Include="physics.h" />
@@ -191,6 +196,10 @@
     <ClCompile Include="nameplate.cpp" />
     <ClCompile Include="npc_give.cpp" />
     <ClCompile Include="otlp_exporter.cpp" />
+    <ClCompile Include="otlp_client.cpp" />
+    <ClCompile Include="telemetry.cpp" Condition="'$(ZEAL_OTEL_SDK)'=='1'" />
+    <ClCompile Include="instrumentation.cpp" Condition="'$(ZEAL_OTEL_SDK)'=='1'" />
+    <ClCompile Include="..\spike\winhttp-client\winhttp_client.cpp" Condition="'$(ZEAL_OTEL_SDK)'=='1'" />
     <ClCompile Include="page10_binds.cpp" />
     <ClCompile Include="patches.cpp" />
     <ClCompile Include="physics.cpp" />

--- a/Zeal/Zeal.vcxproj
+++ b/Zeal/Zeal.vcxproj
@@ -60,7 +60,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>winmm.lib;Dbghelp.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;Dbghelp.lib;winhttp.lib;legacy_stdio_definitions.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>
@@ -101,7 +101,9 @@
     <ClInclude Include="miniz.h" />
     <ClInclude Include="named_pipe.h" />
     <ClInclude Include="nameplate.h" />
+    <ClInclude Include="everquest_semconv.h" />
     <ClInclude Include="npc_give.h" />
+    <ClInclude Include="otlp_exporter.h" />
     <ClInclude Include="page10_binds.h" />
     <ClInclude Include="patches.h" />
     <ClInclude Include="physics.h" />
@@ -188,6 +190,7 @@
     <ClCompile Include="named_pipe.cpp" />
     <ClCompile Include="nameplate.cpp" />
     <ClCompile Include="npc_give.cpp" />
+    <ClCompile Include="otlp_exporter.cpp" />
     <ClCompile Include="page10_binds.cpp" />
     <ClCompile Include="patches.cpp" />
     <ClCompile Include="physics.cpp" />

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -177,6 +177,12 @@
     <ClInclude Include="named_pipe.h">
       <Filter>Header Files\other</Filter>
     </ClInclude>
+    <ClInclude Include="otlp_exporter.h">
+      <Filter>Header Files\other</Filter>
+    </ClInclude>
+    <ClInclude Include="everquest_semconv.h">
+      <Filter>Header Files\other</Filter>
+    </ClInclude>
     <ClInclude Include="instruction_length.h">
       <Filter>Header Files\memory</Filter>
     </ClInclude>
@@ -420,6 +426,9 @@
       <Filter>Source Files\ui</Filter>
     </ClCompile>
     <ClCompile Include="named_pipe.cpp">
+      <Filter>Source Files\other</Filter>
+    </ClCompile>
+    <ClCompile Include="otlp_exporter.cpp">
       <Filter>Source Files\other</Filter>
     </ClCompile>
     <ClCompile Include="physics.cpp">

--- a/Zeal/Zeal.vcxproj.filters
+++ b/Zeal/Zeal.vcxproj.filters
@@ -180,6 +180,15 @@
     <ClInclude Include="otlp_exporter.h">
       <Filter>Header Files\other</Filter>
     </ClInclude>
+    <ClInclude Include="otlp_client.h">
+      <Filter>Header Files\other</Filter>
+    </ClInclude>
+    <ClInclude Include="telemetry.h">
+      <Filter>Header Files\other</Filter>
+    </ClInclude>
+    <ClInclude Include="instrumentation.h">
+      <Filter>Header Files\other</Filter>
+    </ClInclude>
     <ClInclude Include="everquest_semconv.h">
       <Filter>Header Files\other</Filter>
     </ClInclude>
@@ -429,6 +438,18 @@
       <Filter>Source Files\other</Filter>
     </ClCompile>
     <ClCompile Include="otlp_exporter.cpp">
+      <Filter>Source Files\other</Filter>
+    </ClCompile>
+    <ClCompile Include="otlp_client.cpp">
+      <Filter>Source Files\other</Filter>
+    </ClCompile>
+    <ClCompile Include="telemetry.cpp">
+      <Filter>Source Files\other</Filter>
+    </ClCompile>
+    <ClCompile Include="instrumentation.cpp">
+      <Filter>Source Files\other</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spike\winhttp-client\winhttp_client.cpp">
       <Filter>Source Files\other</Filter>
     </ClCompile>
     <ClCompile Include="physics.cpp">

--- a/Zeal/everquest_semconv.h
+++ b/Zeal/everquest_semconv.h
@@ -19,13 +19,15 @@ inline constexpr const char *kEverquestCharacterLevel = "everquest.character.lev
 
 inline constexpr const char *kEverquestCharacterName = "everquest.character.name";
 
-inline constexpr const char *kEverquestCharacterStat = "everquest.character.stat";
+inline constexpr const char *kEverquestCharacterStatName = "everquest.character.stat.name";
 
 inline constexpr const char *kEverquestChatColor = "everquest.chat.color";
 
 inline constexpr const char *kEverquestCombatDamageType = "everquest.combat.damage.type";
 
 inline constexpr const char *kEverquestCombatDirection = "everquest.combat.direction";
+
+inline constexpr const char *kEverquestCombatPetName = "everquest.combat.pet.name";
 
 inline constexpr const char *kEverquestCombatSource = "everquest.combat.source";
 
@@ -41,6 +43,16 @@ inline constexpr const char *kEverquestFightDamageTaken = "everquest.fight.damag
 
 inline constexpr const char *kEverquestFightOutcome = "everquest.fight.outcome";
 
+inline constexpr const char *kEverquestGroupLeader = "everquest.group.leader";
+
+inline constexpr const char *kEverquestHealCasterManaPercent = "everquest.heal.caster.mana.percent";
+
+inline constexpr const char *kEverquestHealChainHandoffMs = "everquest.heal.chain.handoff.ms";
+
+inline constexpr const char *kEverquestHealChainPosition = "everquest.heal.chain.position";
+
+inline constexpr const char *kEverquestRaidTarget = "everquest.raid.target";
+
 inline constexpr const char *kEverquestSpellName = "everquest.spell.name";
 
 inline constexpr const char *kEverquestZoneId = "everquest.zone.id";
@@ -54,9 +66,21 @@ inline constexpr const char *kEverquestCharacterAttackMetric = "everquest.charac
 
 inline constexpr const char *kEverquestCharacterHasteMetric = "everquest.character.haste";
 
+inline constexpr const char *kEverquestCharacterStatMetric = "everquest.character.stat";
+
 inline constexpr const char *kEverquestCombatDamageMetric = "everquest.combat.damage";
 
 inline constexpr const char *kEverquestCombatHealMetric = "everquest.combat.heal";
+
+inline constexpr const char *kEverquestFightActiveMetric = "everquest.fight.active";
+
+inline constexpr const char *kEverquestFightDurationMetric = "everquest.fight.duration";
+
+inline constexpr const char *kEverquestGroupMemberMetric = "everquest.group.member";
+
+inline constexpr const char *kEverquestRaidKillTimestampMetric = "everquest.raid.kill.timestamp";
+
+inline constexpr const char *kEverquestRaidLockoutExpiryMetric = "everquest.raid.lockout.expiry";
 
 
 }  // namespace everquest_semconv

--- a/Zeal/everquest_semconv.h
+++ b/Zeal/everquest_semconv.h
@@ -1,0 +1,62 @@
+// GENERATED FILE — do not edit.
+// Produced by OpenTelemetry Weaver from the everquest-semconv registry:
+//   weaver registry generate -r model --templates templates cpp <out>
+// The registry is the source of truth for these names; a typo here becomes a compile error
+// instead of a silently split timeseries.
+#pragma once
+
+namespace everquest_semconv {
+
+// ---- attributes ----
+
+inline constexpr const char *kEverquestCharacterAaUnspent = "everquest.character.aa.unspent";
+
+inline constexpr const char *kEverquestCharacterClass = "everquest.character.class";
+
+inline constexpr const char *kEverquestCharacterDeity = "everquest.character.deity";
+
+inline constexpr const char *kEverquestCharacterLevel = "everquest.character.level";
+
+inline constexpr const char *kEverquestCharacterName = "everquest.character.name";
+
+inline constexpr const char *kEverquestCharacterStat = "everquest.character.stat";
+
+inline constexpr const char *kEverquestChatColor = "everquest.chat.color";
+
+inline constexpr const char *kEverquestCombatDamageType = "everquest.combat.damage.type";
+
+inline constexpr const char *kEverquestCombatDirection = "everquest.combat.direction";
+
+inline constexpr const char *kEverquestCombatSource = "everquest.combat.source";
+
+inline constexpr const char *kEverquestCombatSourceType = "everquest.combat.source_type";
+
+inline constexpr const char *kEverquestCombatTarget = "everquest.combat.target";
+
+inline constexpr const char *kEverquestDisciplineName = "everquest.discipline.name";
+
+inline constexpr const char *kEverquestFightDamageDealt = "everquest.fight.damage.dealt";
+
+inline constexpr const char *kEverquestFightDamageTaken = "everquest.fight.damage.taken";
+
+inline constexpr const char *kEverquestFightOutcome = "everquest.fight.outcome";
+
+inline constexpr const char *kEverquestSpellName = "everquest.spell.name";
+
+inline constexpr const char *kEverquestZoneId = "everquest.zone.id";
+
+inline constexpr const char *kEverquestZoneName = "everquest.zone.name";
+
+
+// ---- metrics ----
+
+inline constexpr const char *kEverquestCharacterAttackMetric = "everquest.character.attack";
+
+inline constexpr const char *kEverquestCharacterHasteMetric = "everquest.character.haste";
+
+inline constexpr const char *kEverquestCombatDamageMetric = "everquest.combat.damage";
+
+inline constexpr const char *kEverquestCombatHealMetric = "everquest.combat.heal";
+
+
+}  // namespace everquest_semconv

--- a/Zeal/instrumentation.cpp
+++ b/Zeal/instrumentation.cpp
@@ -1,0 +1,394 @@
+#include "instrumentation.h"
+
+#include "everquest_semconv.h"  // generated from the registry: a typo becomes a compile error
+
+// API only - no sdk/ or exporters/ headers. See instrumentation.h.
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+
+#include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/trace/provider.h"
+
+#pragma pop_macro("max")
+#pragma pop_macro("min")
+
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace metrics_api = opentelemetry::metrics;
+namespace trace_api = opentelemetry::trace;
+
+namespace {
+
+// The instrumentation scope: name and version identify *what produced the telemetry*, which is how
+// a consumer tells our measurements from anything else in the process and reports problems against
+// the right thing.
+constexpr const char *kScopeName = "zeal.everquest";
+constexpr const char *kScopeVersion = "1.0.0";
+
+std::mutex g_mutex;
+std::string g_character;
+
+// What the observable gauges report. Sampled on the game thread, read on the SDK's collection
+// thread - which is exactly why asynchronous instruments suit these: the value is behind an
+// accessor, so it is observed when the SDK asks rather than polled on a timer of our own.
+struct CharacterState {
+  std::string zone;
+  // Base stats, observed rather than pushed: the synchronous Gauge the spec would point at here is
+  // gated behind OPENTELEMETRY_ABI_VERSION_NO >= 2, a preview ABI, and moving every instrument in a
+  // client other people run onto unstable interfaces is not worth the distinction. A gauge sampled
+  // on the export interval still shows a clean step when gear changes, which is the question worth
+  // asking of a stat.
+  int stats[7] = {0, 0, 0, 0, 0, 0, 0};
+  long long attack = 0;
+  long long haste = 0;
+  bool have_attack = false;
+  bool have_haste = false;
+  bool valid = false;
+};
+CharacterState g_state;
+
+using Counter = opentelemetry::nostd::shared_ptr<metrics_api::Counter<uint64_t>>;
+
+// Created on first use. If no SDK is registered the API hands back a no-op instrument, which is
+// valid to call - so this never needs a null check at the call site.
+Counter &DamageCounter() {
+  static Counter counter = metrics_api::Provider::GetMeterProvider()
+                               ->GetMeter(kScopeName, kScopeVersion)
+                               ->CreateUInt64Counter(everquest_semconv::kEverquestCombatDamageMetric,
+                                                     "damage dealt or taken", "{hitpoint}");
+  return counter;
+}
+
+// Seconds, as doubles: a fight is not a whole number of seconds and rounding every encounter down
+// would bias every rate upward.
+using DoubleCounter = opentelemetry::nostd::shared_ptr<metrics_api::Counter<double>>;
+
+DoubleCounter &FightDurationCounter() {
+  static DoubleCounter counter = metrics_api::Provider::GetMeterProvider()
+                                     ->GetMeter(kScopeName, kScopeVersion)
+                                     ->CreateDoubleCounter(everquest_semconv::kEverquestFightDurationMetric,
+                                                           "seconds spent fighting a target", "s");
+  return counter;
+}
+
+DoubleCounter &FightActiveCounter() {
+  static DoubleCounter counter = metrics_api::Provider::GetMeterProvider()
+                                     ->GetMeter(kScopeName, kScopeVersion)
+                                     ->CreateDoubleCounter(everquest_semconv::kEverquestFightActiveMetric,
+                                                           "seconds an attacker was dealing damage", "s");
+  return counter;
+}
+
+Counter &HealCounter() {
+  static Counter counter = metrics_api::Provider::GetMeterProvider()
+                               ->GetMeter(kScopeName, kScopeVersion)
+                               ->CreateUInt64Counter(everquest_semconv::kEverquestCombatHealMetric,
+                                                     "hitpoints restored", "{hitpoint}");
+  return counter;
+}
+
+using Attributes = std::vector<std::pair<std::string, opentelemetry::common::AttributeValue>>;
+
+// Complete Heal's cast time. The span's whole value is showing whether these fixed windows overlap.
+constexpr int kCompleteHealCastSeconds = 10;
+// A chain is over once no cleric has announced for this long - two missed casts' worth.
+constexpr int kChainIdleSeconds = 25;
+
+// One open chain span per tank being chained. Children hang off it, so a chain is one trace.
+struct Chain {
+  opentelemetry::nostd::shared_ptr<trace_api::Span> span;
+  std::chrono::steady_clock::time_point last;
+  int casts = 0;
+};
+std::map<std::string, Chain> g_chains;
+
+
+// Outstanding "GO" cues, keyed by the name that was called. A cue older than one cast is stale:
+// whoever it was for either answered or was skipped, and attributing a 30s latency to the next
+// person who happens to share the name would be worse than reporting nothing.
+std::map<std::string, std::chrono::steady_clock::time_point> g_handoff_cues;
+
+std::string LowerName(const std::string &s) {
+  std::string out = s;
+  for (auto &c : out) c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  return out;
+}
+
+opentelemetry::nostd::shared_ptr<trace_api::Tracer> Tracer() {
+  return trace_api::Provider::GetTracerProvider()->GetTracer(kScopeName, kScopeVersion);
+}
+
+// Observing nothing is meaningful: an asynchronous instrument only exports the attribute sets its
+// callback reports, so a character who is not in game simply stops producing points rather than
+// flatlining at a stale value.
+void ObserveGauge(opentelemetry::metrics::ObserverResult result, bool haste) {
+  CharacterState state;
+  std::string character;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    state = g_state;
+    character = g_character;
+  }
+  if (!state.valid || character.empty()) return;
+  if (haste ? !state.have_haste : !state.have_attack) return;
+
+  Attributes attrs = {
+      {everquest_semconv::kEverquestCharacterName, character.c_str()},
+      {everquest_semconv::kEverquestZoneName, state.zone.c_str()},
+  };
+  auto observer = opentelemetry::nostd::get<
+      opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(result);
+  observer->Observe(haste ? state.haste : state.attack,
+                    opentelemetry::common::KeyValueIterableView<Attributes>(attrs));
+}
+
+constexpr const char *kStatNames[7] = {"strength", "stamina",      "dexterity", "agility",
+                                       "wisdom",   "intelligence", "charisma"};
+
+void StatCallback(opentelemetry::metrics::ObserverResult result, void *) {
+  CharacterState state;
+  std::string character;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    state = g_state;
+    character = g_character;
+  }
+  if (!state.valid || character.empty()) return;
+  auto observer = opentelemetry::nostd::get<
+      opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(result);
+  for (int i = 0; i < 7; ++i) {
+    if (state.stats[i] <= 0) continue;  // not sampled yet
+    Attributes attrs = {
+        {everquest_semconv::kEverquestCharacterStatName, kStatNames[i]},
+        {everquest_semconv::kEverquestCharacterName, character.c_str()},
+    };
+    observer->Observe(state.stats[i], opentelemetry::common::KeyValueIterableView<Attributes>(attrs));
+  }
+}
+
+void AttackCallback(opentelemetry::metrics::ObserverResult result, void *) { ObserveGauge(result, false); }
+void HasteCallback(opentelemetry::metrics::ObserverResult result, void *) { ObserveGauge(result, true); }
+
+// Registered once. Holding the instruments alive matters: dropping them would unregister the
+// callbacks and the gauges would silently stop reporting.
+void EnsureGauges() {
+  static auto attack = [] {
+    auto g = metrics_api::Provider::GetMeterProvider()
+                 ->GetMeter(kScopeName, kScopeVersion)
+                 ->CreateInt64ObservableGauge(everquest_semconv::kEverquestCharacterAttackMetric,
+                                              "current offense rating", "1");
+    g->AddCallback(AttackCallback, nullptr);
+    return g;
+  }();
+  static auto haste = [] {
+    auto g = metrics_api::Provider::GetMeterProvider()
+                 ->GetMeter(kScopeName, kScopeVersion)
+                 ->CreateInt64ObservableGauge(everquest_semconv::kEverquestCharacterHasteMetric,
+                                              "total effective melee haste", "%");
+    g->AddCallback(HasteCallback, nullptr);
+    return g;
+  }();
+  static auto stats = [] {
+    auto g = metrics_api::Provider::GetMeterProvider()
+                 ->GetMeter(kScopeName, kScopeVersion)
+                 ->CreateInt64ObservableGauge(everquest_semconv::kEverquestCharacterStatMetric,
+                                              "character base stat", "1");
+    g->AddCallback(StatCallback, nullptr);
+    return g;
+  }();
+  (void)attack;
+  (void)haste;
+  (void)stats;
+}
+
+void Add(Counter &counter, long long amount, Attributes &attrs) {
+  if (amount <= 0) return;
+  std::string character;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    character = g_character;
+  }
+  if (!character.empty()) attrs.push_back({everquest_semconv::kEverquestCharacterName, character.c_str()});
+  counter->Add(static_cast<uint64_t>(amount),
+               opentelemetry::common::KeyValueIterableView<Attributes>(attrs));
+}
+
+}  // namespace
+
+namespace zeal::instrumentation {
+
+void SetCharacter(const std::string &name) {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  g_character = name;
+}
+
+void SetCharacterState(const std::string &zone, long long attack, bool have_attack, long long haste,
+                       bool have_haste) {
+  EnsureGauges();
+  std::lock_guard<std::mutex> lock(g_mutex);
+  g_state.zone = zone;
+  g_state.attack = attack;
+  g_state.have_attack = have_attack;
+  g_state.haste = haste;
+  g_state.have_haste = have_haste;
+  g_state.valid = true;
+}
+
+void RecordDamage(const std::string &source, const std::string &source_type, const std::string &direction,
+                  const std::string &damage_type, const std::string &zone, const std::string &target,
+                  const std::string &group_leader, const std::string &pet, long long amount) {
+  Attributes attrs = {
+      {everquest_semconv::kEverquestCombatSource, source.c_str()},
+      {everquest_semconv::kEverquestCombatSourceType, source_type.c_str()},
+      {everquest_semconv::kEverquestCombatDirection, direction.c_str()},
+      {everquest_semconv::kEverquestCombatDamageType, damage_type.c_str()},
+      {everquest_semconv::kEverquestZoneName, zone.c_str()},
+      {everquest_semconv::kEverquestCombatTarget, target.c_str()},
+  };
+  if (!group_leader.empty()) attrs.push_back({everquest_semconv::kEverquestGroupLeader, group_leader.c_str()});
+  if (!pet.empty()) attrs.push_back({everquest_semconv::kEverquestCombatPetName, pet.c_str()});
+  Add(DamageCounter(), amount, attrs);
+}
+
+void SetCharacterStats(int strength, int stamina, int dexterity, int agility, int wisdom,
+                       int intelligence, int charisma) {
+  EnsureGauges();
+  std::lock_guard<std::mutex> lock(g_mutex);
+  const int values[7] = {strength, stamina, dexterity, agility, wisdom, intelligence, charisma};
+  for (int i = 0; i < 7; ++i) g_state.stats[i] = values[i];
+  g_state.valid = true;
+}
+
+void RecordFightTotals(const std::string &target, const std::string &zone, double duration_s,
+                       const std::vector<std::pair<std::string, double>> &active_seconds_by_source) {
+  if (duration_s <= 0) return;
+  std::string character;
+  {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    character = g_character;
+  }
+
+  Attributes fight = {
+      {everquest_semconv::kEverquestCombatTarget, target.c_str()},
+      {everquest_semconv::kEverquestZoneName, zone.c_str()},
+  };
+  if (!character.empty()) fight.push_back({everquest_semconv::kEverquestCharacterName, character.c_str()});
+  FightDurationCounter()->Add(duration_s,
+                              opentelemetry::common::KeyValueIterableView<Attributes>(fight));
+
+  for (const auto &[source, seconds] : active_seconds_by_source) {
+    if (seconds <= 0) continue;
+    Attributes attrs = {
+        {everquest_semconv::kEverquestCombatSource, source.c_str()},
+        {everquest_semconv::kEverquestCombatTarget, target.c_str()},
+        {everquest_semconv::kEverquestZoneName, zone.c_str()},
+    };
+    if (!character.empty()) attrs.push_back({everquest_semconv::kEverquestCharacterName, character.c_str()});
+    FightActiveCounter()->Add(seconds, opentelemetry::common::KeyValueIterableView<Attributes>(attrs));
+  }
+}
+
+void RecordCompleteHeal(const std::string &caster, const std::string &target, const std::string &zone,
+                        int chain_position, int caster_mana_percent) {
+  const auto now = std::chrono::steady_clock::now();
+
+  std::lock_guard<std::mutex> lock(g_mutex);
+  auto &chain = g_chains[target];
+  if (!chain.span) {
+    Attributes chain_attrs = {
+        {everquest_semconv::kEverquestCombatTarget, target.c_str()},
+        {everquest_semconv::kEverquestZoneName, zone.c_str()},
+    };
+    if (!g_character.empty())
+      chain_attrs.push_back({everquest_semconv::kEverquestCharacterName, g_character.c_str()});
+    chain.span = Tracer()->StartSpan("CH chain: " + target,
+                                     opentelemetry::common::KeyValueIterableView<Attributes>(chain_attrs));
+  }
+  chain.last = now;
+  chain.casts++;
+
+  Attributes attrs = {
+      {everquest_semconv::kEverquestCombatSource, caster.c_str()},
+      {everquest_semconv::kEverquestCombatTarget, target.c_str()},
+      {everquest_semconv::kEverquestZoneName, zone.c_str()},
+  };
+  if (!g_character.empty()) attrs.push_back({everquest_semconv::kEverquestCharacterName, g_character.c_str()});
+  // If this caster was cued, how long they took to answer it. Consumed either way, so a stale cue
+  // cannot attach itself to a later cast.
+  {
+    auto cue = g_handoff_cues.find(LowerName(caster));
+    if (cue != g_handoff_cues.end()) {
+      const auto waited = std::chrono::duration_cast<std::chrono::milliseconds>(now - cue->second).count();
+      if (waited >= 0 && waited <= kCompleteHealCastSeconds * 3 * 1000)
+        attrs.push_back({everquest_semconv::kEverquestHealChainHandoffMs, static_cast<long long>(waited)});
+      g_handoff_cues.erase(cue);
+    }
+  }
+
+  // The rotation slot the cleric was assigned. Absent rather than zero when the macro omits it.
+  if (chain_position > 0)
+    attrs.push_back({everquest_semconv::kEverquestHealChainPosition, chain_position});
+  // Out of range means the macro did not report it, or reported something that is not a percentage;
+  // an absent attribute beats a fabricated number that a chart would happily plot.
+  if (caster_mana_percent >= 0 && caster_mana_percent <= 100)
+    attrs.push_back({everquest_semconv::kEverquestHealCasterManaPercent, caster_mana_percent});
+
+  // Start now, end 10s from now. Complete Heal's cast time is fixed, so the span's extent is known
+  // at the announcement - which means it can be emitted immediately instead of held open for ten
+  // seconds waiting for something that is not reported anyway.
+  trace_api::StartSpanOptions options;
+  options.parent = chain.span->GetContext();
+  options.start_steady_time = opentelemetry::common::SteadyTimestamp(now);
+  options.start_system_time = opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now());
+  const std::string span_name =
+      chain_position > 0 ? ("CH" + std::to_string(chain_position) + ": " + caster) : ("CH: " + caster);
+  auto span = Tracer()->StartSpan(span_name,
+                                  opentelemetry::common::KeyValueIterableView<Attributes>(attrs), options);
+  trace_api::EndSpanOptions end;
+  end.end_steady_time = opentelemetry::common::SteadyTimestamp(now + std::chrono::seconds(kCompleteHealCastSeconds));
+  span->End(end);
+}
+
+void NoteChainHandoff(const std::string &next_caster) {
+  if (next_caster.empty()) return;
+  std::lock_guard<std::mutex> lock(g_mutex);
+  g_handoff_cues[LowerName(next_caster)] = std::chrono::steady_clock::now();
+}
+
+void SweepCompleteHealChains() {
+  const auto now = std::chrono::steady_clock::now();
+  std::lock_guard<std::mutex> lock(g_mutex);
+  for (auto it = g_handoff_cues.begin(); it != g_handoff_cues.end();) {
+    if (now - it->second > std::chrono::seconds(kCompleteHealCastSeconds * 3))
+      it = g_handoff_cues.erase(it);
+    else
+      ++it;
+  }
+  for (auto it = g_chains.begin(); it != g_chains.end();) {
+    if (now - it->second.last > std::chrono::seconds(kChainIdleSeconds)) {
+      if (it->second.span) it->second.span->End();
+      it = g_chains.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void RecordHeal(const std::string &source, const std::string &direction, const std::string &zone,
+                const std::string &group_leader, long long amount) {
+  Attributes attrs = {
+      {everquest_semconv::kEverquestCombatSource, source.c_str()},
+      {everquest_semconv::kEverquestCombatDirection, direction.c_str()},
+      {everquest_semconv::kEverquestZoneName, zone.c_str()},
+  };
+  if (!group_leader.empty()) attrs.push_back({everquest_semconv::kEverquestGroupLeader, group_leader.c_str()});
+  Add(HealCounter(), amount, attrs);
+}
+
+}  // namespace zeal::instrumentation

--- a/Zeal/instrumentation.h
+++ b/Zeal/instrumentation.h
@@ -1,0 +1,74 @@
+// Instrumentation for EverQuest gameplay, written against the OpenTelemetry **API** only.
+//
+// Nothing here includes an sdk/ or exporters/ header, and nothing here knows where telemetry goes.
+// If no SDK has been registered (see telemetry.h) every call is a no-op that costs a virtual call -
+// so call sites need no #ifdef and no "is telemetry on?" check.
+//
+// Instruments are created once, on first use, and cached. That is only sound because the providers
+// live for the process: the Resource is fixed at startup and everything that varies while the game
+// runs - the character above all - travels as a measurement attribute.
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace zeal::instrumentation {
+
+// The character the local player is currently on. Recorded as an attribute on every measurement
+// rather than as part of the Resource, because it changes when camping to character select and
+// identifying attributes of a Resource must not change during its lifetime.
+void SetCharacter(const std::string &name);
+
+// Slowly-changing character state, read by the observable gauges when the SDK collects. Called from
+// the game thread; the gauges' callbacks run on the SDK's collection thread and read the snapshot
+// this keeps, so neither touches game memory the other might be freeing.
+void SetCharacterState(const std::string &zone, long long attack, bool have_attack, long long haste,
+                       bool have_haste);
+
+// The seven base stats. Recorded only when one actually changes - swapping gear, a buff landing,
+// levelling - because a stat that has not moved is not news, and emitting it on a timer would make
+// "when did this change?" impossible to answer. Safe and cheap to call every tick.
+void SetCharacterStats(int strength, int stamina, int dexterity, int agility, int wisdom,
+                       int intelligence, int charisma);
+
+// Damage dealt or taken. `source_type` distinguishes player/pet/npc; `group_leader` is empty when
+// solo, and is then omitted entirely - an absent attribute is a missing label in Prometheus, which
+// keeps solo play out of group-scoped queries.
+// `source` is the owner even when a pet swung - that is how raiders count, and how the parser they
+// compare against reports it. `pet` names the pet underneath, empty when the owner swung themselves.
+void RecordDamage(const std::string &source, const std::string &source_type, const std::string &direction,
+                  const std::string &damage_type, const std::string &zone, const std::string &target,
+                  const std::string &group_leader, const std::string &pet, long long amount);
+
+// A Complete Heal announced by a cleric's macro ("<n> CH - <target> (<mana %>)").
+//
+// Each CH is a span of fixed 10s - the cast time - starting at the announcement, so the end is known
+// the moment it begins and no timer is needed. Casts on the same target become children of one chain
+// span, which is the whole point: on a timeline you can see immediately whether the chain overlaps
+// cleanly or leaves the tank uncovered between heals.
+void RecordCompleteHeal(const std::string &caster, const std::string &target, const std::string &zone,
+                        int chain_position, int caster_mana_percent);
+
+// The "GO - <name>" cue at the end of a cleric's macro, telling the next cleric to start. Recording
+// when it was said lets the next announcement be measured against it: how long someone took to
+// answer their cue is the earliest sign a chain is drifting.
+void NoteChainHandoff(const std::string &next_caster);
+
+// Closes chains that have gone quiet, so a chain span does not stay open all night. Called from the
+// game-thread tick.
+void SweepCompleteHealChains();
+
+// A finished encounter, recorded when the fight closes.
+//
+// `duration_s` is the whole fight; `active` is per attacker - the seconds each one was actually
+// dealing damage. Damage divided by one gives SDPS, by the other DPS, which are the two rates the
+// community's parser prints side by side and the two the guild argues about.
+void RecordFightTotals(const std::string &target, const std::string &zone, double duration_s,
+                       const std::vector<std::pair<std::string, double>> &active_seconds_by_source);
+
+// Healing delivered or received.
+void RecordHeal(const std::string &source, const std::string &direction, const std::string &zone,
+                const std::string &group_leader, long long amount);
+
+}  // namespace zeal::instrumentation

--- a/Zeal/io_ini.h
+++ b/Zeal/io_ini.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 // Declare a single function from game_functions.h to avoid pulling in too many headers.
 namespace Zeal::Game {
@@ -63,15 +64,27 @@ class IO_ini {
 
   template <typename T>
   T getValue(std::string section, std::string key) const {
-    char buffer[256];
-    DWORD bytesRead =
-        GetPrivateProfileStringA(section.c_str(), key.c_str(), "", buffer, sizeof(buffer), filename.c_str());
+    // Grows until the value fits. GetPrivateProfileStringA does not report that it truncated - it
+    // just returns nSize-1 and hands back a short string - so a fixed buffer silently corrupts any
+    // setting longer than it. The 256-byte one here turned a 300-character sealed OTLP token into
+    // 255 characters of unparseable base64, and the token read back as "not set" with nothing
+    // logged anywhere.
+    std::vector<char> buffer(256);
+    DWORD bytesRead = 0;
+    for (;;) {
+      bytesRead = GetPrivateProfileStringA(section.c_str(), key.c_str(), "", buffer.data(),
+                                           static_cast<DWORD>(buffer.size()), filename.c_str());
+      // Short of the cap means the whole value came back.
+      if (bytesRead < buffer.size() - 1) break;
+      if (buffer.size() >= (1u << 16)) break;  // 64 KB: no ini setting is this long, stop growing
+      buffer.resize(buffer.size() * 2);
+    }
 
     if (bytesRead == 0) {
       return T{};
     }
-    if constexpr (std::is_same_v<T, std::string>) return buffer;
-    return convertFromString<T>(std::string(buffer));
+    if constexpr (std::is_same_v<T, std::string>) return std::string(buffer.data(), bytesRead);
+    return convertFromString<T>(std::string(buffer.data(), bytesRead));
   }
 
   template <typename T>

--- a/Zeal/otlp_client.cpp
+++ b/Zeal/otlp_client.cpp
@@ -1,0 +1,134 @@
+#include "otlp_client.h"
+
+#include <winhttp.h>
+
+#include <chrono>
+
+#pragma comment(lib, "winhttp.lib")
+
+OtlpClient::OtlpClient(CollectFn collect_fn) : collect(std::move(collect_fn)) {
+  worker = std::thread([this]() { worker_loop(); });
+}
+
+OtlpClient::~OtlpClient() {
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    end_thread = true;
+  }
+  cv.notify_all();
+  if (worker.joinable()) worker.join();
+}
+
+void OtlpClient::set_endpoint(const std::string &value) {
+  std::lock_guard<std::mutex> lock(mutex);
+  endpoint = value;
+}
+
+void OtlpClient::set_flush_ms(int ms) { flush_ms.store(ms < kMinFlushMs ? kMinFlushMs : ms); }
+
+void OtlpClient::set_enabled(bool value) { enabled.store(value); }
+
+void OtlpClient::nudge() { cv.notify_all(); }
+
+std::string OtlpClient::last_error() const {
+  std::lock_guard<std::mutex> lock(error_mutex);
+  return last_error_text;
+}
+
+void OtlpClient::worker_loop() {
+  while (true) {
+    {
+      std::unique_lock<std::mutex> lock(mutex);
+      cv.wait_for(lock, std::chrono::milliseconds(flush_ms.load()), [this]() { return end_thread; });
+      if (end_thread) return;
+    }
+    if (!enabled.load()) continue;
+
+    try {
+      for (const Payload &payload : collect()) {
+        if (payload.second.empty()) continue;
+        if (post(payload.first, payload.second))
+          posted_count++;
+        else
+          failed_count++;
+      }
+    } catch (const std::exception &) {
+      // Never let telemetry take down the game: drop this cycle and try again on the next one.
+    }
+  }
+}
+
+void OtlpClient::set_auth_token(const std::string &token) {
+  std::lock_guard<std::mutex> lock(mutex);
+  auth_token = token;
+}
+
+bool OtlpClient::post(const std::string &path, const std::string &json_body) {
+  std::string url;
+  std::string token;
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    url = endpoint + path;
+    token = auth_token;
+  }
+  std::wstring wurl(url.begin(), url.end());
+
+  URL_COMPONENTS uc = {0};
+  uc.dwStructSize = sizeof(uc);
+  wchar_t host[256] = {0};
+  wchar_t url_path[1024] = {0};
+  uc.lpszHostName = host;
+  uc.dwHostNameLength = _countof(host);
+  uc.lpszUrlPath = url_path;
+  uc.dwUrlPathLength = _countof(url_path);
+  if (!WinHttpCrackUrl(wurl.c_str(), 0, 0, &uc)) return false;
+
+  bool ok = false;
+  HINTERNET session = WinHttpOpen(L"Zeal-OTLP/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME,
+                                  WINHTTP_NO_PROXY_BYPASS, 0);
+  if (session) {
+    // Bound every phase so a slow/unreachable endpoint can't hang the sender thread (and thus the
+    // join() on shutdown). Values in ms: resolve, connect, send, receive.
+    WinHttpSetTimeouts(session, 2000, 2000, 2000, 3000);
+    HINTERNET connect = WinHttpConnect(session, host, uc.nPort, 0);
+    if (connect) {
+      DWORD flags = (uc.nScheme == INTERNET_SCHEME_HTTPS) ? WINHTTP_FLAG_SECURE : 0;
+      HINTERNET request = WinHttpOpenRequest(connect, L"POST", url_path, nullptr, WINHTTP_NO_REFERER,
+                                             WINHTTP_DEFAULT_ACCEPT_TYPES, flags);
+      if (request) {
+        // The gateway authenticates per member, so an unauthenticated POST is
+        // a 401 rather than an anonymous accept. An empty token is still a
+        // valid state: a local collector wants no Authorization at all.
+        std::wstring headers = L"Content-Type: application/json";
+        if (!token.empty()) {
+          headers += L"\r\nAuthorization: Bearer ";
+          headers.append(token.begin(), token.end());  // tokens are hex, so no widening to do
+        }
+        if (WinHttpSendRequest(request, headers.c_str(), -1L, (LPVOID)json_body.data(),
+                               static_cast<DWORD>(json_body.size()), static_cast<DWORD>(json_body.size()), 0) &&
+            WinHttpReceiveResponse(request, nullptr)) {
+          DWORD status = 0, size = sizeof(status);
+          WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                              WINHTTP_HEADER_NAME_BY_INDEX, &status, &size, WINHTTP_NO_HEADER_INDEX);
+          last_http_status.store(static_cast<int>(status));
+          ok = (status >= 200 && status < 300);
+          if (!ok) {
+            // Keep the server's explanation - it names the exact problem (e.g. a malformed field),
+            // which is otherwise invisible from in-game.
+            std::string body;
+            char buf[512];
+            DWORD read = 0;
+            while (body.size() < 400 && WinHttpReadData(request, buf, sizeof(buf), &read) && read > 0)
+              body.append(buf, read);
+            std::lock_guard<std::mutex> lock(error_mutex);
+            last_error_text = path + " -> " + std::to_string(status) + " " + body.substr(0, 300);
+          }
+        }
+        WinHttpCloseHandle(request);
+      }
+      WinHttpCloseHandle(connect);
+    }
+    WinHttpCloseHandle(session);
+  }
+  return ok;
+}

--- a/Zeal/otlp_client.h
+++ b/Zeal/otlp_client.h
@@ -1,0 +1,77 @@
+#pragma once
+#include <Windows.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+// Transport half of the OTLP/HTTP JSON exporter: a worker thread, a flush timer, WinHTTP delivery,
+// and the send statistics. It knows nothing about EverQuest, or about what any payload contains -
+// callers hand it finished bodies and it delivers them.
+//
+// This is the split the OpenTelemetry client design principles ask for even when hand-rolling:
+// "The SDK must be clearly separated into wire protocol-independent parts that implement common
+// logic (e.g. batching, tag enrichment by process information, etc.) and protocol-dependent
+// telemetry exporters." The instrumentation side (which hooks the game and decides what a hit
+// means) has no business owning a socket.
+class OtlpClient {
+ public:
+  // One payload to deliver: the signal's path ("/v1/metrics") and its JSON body.
+  using Payload = std::pair<std::string, std::string>;
+  // Called on the worker thread once per flush interval; returns whatever is ready to send.
+  using CollectFn = std::function<std::vector<Payload>()>;
+
+  explicit OtlpClient(CollectFn collect);
+  ~OtlpClient();
+
+  OtlpClient(const OtlpClient &) = delete;
+  OtlpClient &operator=(const OtlpClient &) = delete;
+
+  // Configuration, all safe to call from the game thread while the worker runs.
+  void set_endpoint(const std::string &endpoint);
+  void set_flush_ms(int ms);
+  void set_enabled(bool enabled);
+  // Bearer token sent with every payload, or empty for an unauthenticated
+  // endpoint. The transport is handed the token already in the clear; how it
+  // is stored at rest is the exporter's problem, not the socket's.
+  void set_auth_token(const std::string &token);
+
+  // Wakes the worker early (e.g. a queue crossed its batch threshold, or /otlp flush was used).
+  void nudge();
+
+  // POSTs one payload synchronously. Public so a caller can deliver something off-cycle; the worker
+  // uses the same path.
+  bool post(const std::string &path, const std::string &json_body);
+
+  unsigned long long posted() const { return posted_count.load(); }
+  unsigned long long failed() const { return failed_count.load(); }
+  int last_status() const { return last_http_status.load(); }
+  std::string last_error() const;
+
+  static constexpr int kMinFlushMs = 100;  // Floor: metrics are periodic snapshots, 0 would spin.
+
+ private:
+  void worker_loop();
+
+  CollectFn collect;
+  std::thread worker;
+  mutable std::mutex mutex;
+  std::condition_variable cv;
+  bool end_thread = false;
+
+  std::string endpoint = "http://127.0.0.1:4318";
+  std::string auth_token;  // guarded by `mutex`, like `endpoint`
+  std::atomic<int> flush_ms{2000};
+  std::atomic<bool> enabled{false};
+
+  std::atomic<unsigned long long> posted_count{0};
+  std::atomic<unsigned long long> failed_count{0};
+  std::atomic<int> last_http_status{0};
+  mutable std::mutex error_mutex;
+  std::string last_error_text;  // response body of the most recent failure, for `/otlp status`
+};

--- a/Zeal/otlp_exporter.cpp
+++ b/Zeal/otlp_exporter.cpp
@@ -255,9 +255,18 @@ OtlpExporter::OtlpExporter(ZealService *zeal) {
     std::string pet_name;  // kept alongside the owner rather than replaced by it
     if (attacker->PetOwnerSpawnId != 0) {  // credit a pet's damage to its owner (charmed or summoned)
       auto *owner = ZealService::get_instance()->entity_manager->Get(attacker->PetOwnerSpawnId);
+      Zeal::GameStructures::Entity *self = Zeal::Game::get_self();
       if (owner) {
         pet_name = attacker->Name;
         attacker = owner;
+      } else if (self && attacker->PetOwnerSpawnId == self->SpawnId) {
+        // The entity list did not resolve the owner, but the id says it is us, and that is enough.
+        // Depending on the lookup lost charm damage in exactly the moments an enchanter cares
+        // about: a pet whose owner has left the list, or a hit arriving as the charm breaks. The
+        // damage then kept the mob as its attacker, became source_type=npc, and was dropped
+        // wholesale by scope=self - so it went missing rather than being misattributed.
+        pet_name = attacker->Name;
+        attacker = self;
       }
     }
     std::string src = attacker->Name;
@@ -860,7 +869,7 @@ void OtlpExporter::record_combat_damage(const std::string &source, const std::st
   zeal::instrumentation::RecordDamage(source, source_type, direction, type, zone, target, group, pet, amount);
 #else
   std::lock_guard<std::mutex> lock(metrics_mutex);
-  CombatTotal &entry = combat_damage[{source, source_type, direction, type, zone, target, group}];
+  CombatTotal &entry = combat_damage[{source, source_type, direction, type, zone, target, group, pet}];
   entry.total += amount;
   entry.last_ms = GetTickCount64();
 #endif
@@ -1108,6 +1117,10 @@ std::string OtlpExporter::build_metrics_payload() {
       // Prometheus, which keeps solo play out of every group-scoped query.
       if (!std::get<6>(key).empty())
         attrs.push_back(string_attr(everquest_semconv::kEverquestGroupLeader, std::get<6>(key)));
+      // Same rule for the pet: present only when the damage came through one, so a query can ask
+      // for a player's total and get pet damage included, or split it out by this label.
+      if (!std::get<7>(key).empty())
+        attrs.push_back(string_attr(everquest_semconv::kEverquestCombatPetName, std::get<7>(key)));
       data_points.push_back({{"attributes", attrs},
                              {"startTimeUnixNano", start},
                              {"timeUnixNano", now},

--- a/Zeal/otlp_exporter.cpp
+++ b/Zeal/otlp_exporter.cpp
@@ -2,17 +2,29 @@
 
 #include "everquest_semconv.h"  // generated from the semconv registry (see everquest-semconv/generate.sh)
 
+#ifdef ZEAL_OTEL_SDK
+#include "instrumentation.h"  // API-only gameplay instrumentation
+#include "telemetry.h"       // SDK setup, this file is the application owner
+#endif
+
 #include <winhttp.h>
+#include <wincrypt.h>  // DPAPI: the ingest token is sealed to this Windows account
+
+#pragma comment(lib, "crypt32.lib")
 
 #include <cctype>
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <random>
+#include <string>
+#include <vector>
 
 #include "callbacks.h"
 #include "chat.h"
 #include "commands.h"
 #include "entity_manager.h"
+#include "game_addresses.h"  // Zeal::Game::GroupInfo
 #include "game_functions.h"
 #include "game_structures.h"
 #include "json.hpp"
@@ -21,6 +33,14 @@
 #include "zeal.h"
 
 #pragma comment(lib, "winhttp.lib")
+
+#ifdef ZEAL_OTEL_SDK
+// Defined below, next to the chat handling it belongs with.
+static bool parse_ch_announce(const std::string &line, std::string &caster, std::string &target,
+                              int &position, int &mana_percent);
+// "GO - <name>": the cue the macro sends to whoever is next in the chain.
+static bool parse_ch_handoff(const std::string &line, std::string &next_caster);
+#endif
 
 namespace {
 // OTLP/HTTP JSON encodes 64-bit integer fields (timeUnixNano, AnyValue.intValue) as strings.
@@ -52,6 +72,20 @@ std::string hex_id(int bytes) {
   return out;
 }
 
+// "a_temple_guard00" -> "Transient Patroller" style: underscores to spaces, instance digits dropped,
+// case preserved. The instance suffix is a spawn ID, and OpenTelemetry is explicit that IDs do not
+// belong in metric attributes - each one mints a new timeseries, so a camp of respawning mobs walks
+// the metric toward the cardinality limit for no analytical gain. It also makes the same mob look
+// like strangers across pulls, when "damage onto that mob" is the actual question. Chat-parsed names
+// (DoT ticks) already arrive in this form, so this makes both sources agree.
+std::string target_display(const std::string &raw) {
+  std::string d = raw;
+  while (!d.empty() && isdigit(static_cast<unsigned char>(d.back()))) d.pop_back();
+  for (auto &c : d)
+    if (c == '_') c = ' ';
+  return d;
+}
+
 // "a_temple_guard00" -> "a temple guard" (lowercase, underscores to spaces, trailing digits dropped)
 std::string display_of(const std::string &raw) {
   std::string d = raw;
@@ -65,6 +99,39 @@ std::string current_zone_name() {
   Zeal::GameStructures::Entity *self = Zeal::Game::get_self();
   if (!Zeal::Game::is_in_game() || !self) return "";
   return Zeal::Game::get_full_zone_name(self->ZoneId);
+}
+
+// The group's leader names the group ("" when ungrouped). Game thread only.
+//
+// Leader rather than a roster hash: a roster identifier changes the moment anyone joins or leaves,
+// which splits a timeseries mid-fight, whereas leadership rarely changes hands.
+std::string current_group_leader() {
+  const Zeal::GameStructures::GroupInfo *gi = Zeal::Game::GroupInfo;
+  if (!Zeal::Game::is_in_game() || !gi || !gi->is_in_group()) return "";
+  return gi->LeaderName;
+}
+
+// True if `name` is the local character or one of their group-mates. Game thread only.
+bool in_my_group(const std::string &name) {
+  const Zeal::GameStructures::GroupInfo *gi = Zeal::Game::GroupInfo;
+  if (!Zeal::Game::is_in_game() || !gi || !gi->is_in_group()) return false;
+  Zeal::GameStructures::GAMECHARINFO *ci = Zeal::Game::get_char_info();
+  if (ci && name == ci->Name) return true;
+  for (int i = 0; i < GAME_NUM_GROUP_MEMBERS; ++i)
+    if (gi->IsValidList[i] && name == gi->Names[i]) return true;
+  return false;
+}
+
+// The group a damage/heal record belongs to, or "" for none.
+//
+// Under `/otlp scope all` we record every attacker we can see, including players who are not grouped
+// with us - and stamping our own leader on their damage would fold strangers into our group's total.
+// So the label is only attached when the damage is genuinely the group's: dealt by a group member
+// (pets already resolve to their owner before this point), or taken by us, which is by definition a
+// group member taking damage.
+std::string group_for(const std::string &source, const std::string &direction) {
+  const bool ours = (direction == "incoming") || in_my_group(source);
+  return ours ? current_group_leader() : "";
 }
 
 const char *class_name(int class_id) {
@@ -88,47 +155,62 @@ const char *class_name(int class_id) {
   }
 }
 
-// Parses an EverQuest combat log line for damage the player is directly involved in and, if found,
-// fills direction ("outgoing"/"incoming"), type (the melee verb or "spell"), and amount. Returns
-// false for lines that aren't self-involved damage (e.g. a group member's hits) so they aren't
-// double counted. EQ renders the local player as "You"/"YOU".
-// Maps an EQ melee SkillType (Damage_Struct.type) to a canonical damage-type label.
-const char *melee_type_name(unsigned short skill) {
-  using S = Zeal::GameEnums::SkillType;
-  switch (skill) {
-    case S::Skill1HSlashing:
-    case S::Skill2HSlashing:
-      return "slash";
-    case S::Skill1HBlunt:
-    case S::Skill2HBlunt:
-      return "crush";
-    case S::Skill1HPiercing:
-      return "pierce";
-    case S::SkillBash:
-      return "bash";
-    case S::SkillKick:
-    case S::SkillFlyingKick:
-    case S::SkillRoundKick:
-      return "kick";
-    case S::SkillHandtoHand:
-      return "hth";
-    case S::SkillBackstab:
-      return "backstab";
-    case S::SkillArchery:
-      return "archery";
-    case S::SkillDragonPunch:
-    case S::SkillEagleStrike:
-      return "special";
-    default:
-      return "melee";
+// Maps the damage packet's `type` field to a canonical label.
+//
+// This field is NOT a SkillType, despite looking like one. The server sends
+// SkillDamageTypes[skill] (EQMacEmu common/eq_constants.h), a lookup that collapses several skills
+// onto one value:
+//
+//   1HBlunt, 2HBlunt      -> 0        HandtoHand              -> 4
+//   1HSlashing, 2HSlashing-> 1        Kick, RoundKick, Intimidation -> 30
+//   Archery               -> 7        1HPiercing              -> 36
+//   Backstab              -> 8        Throwing                -> 51
+//   Bash                  -> 10       DragonPunch             -> 21
+//   EagleStrike, TigerClaw-> 23       spell skills            -> 0xE7
+//                                     no damage type          -> 0xFF
+//
+// Reading it as a SkillType happened to work for slash (1) and bash (10), because those values
+// coincide, and quietly mislabelled everything else - hand-to-hand (4) landed in the "melee"
+// catch-all, which is how a bite showed up as generic melee.
+const char *damage_type_name(unsigned short damage_type) {
+  switch (damage_type) {
+    case 0: return "crush";
+    case 1: return "slash";
+    case 4: return "hth";
+    case 7: return "archery";
+    case 8: return "backstab";
+    case 10: return "bash";
+    case 21: return "special";  // dragon punch
+    case 23: return "special";  // eagle strike / tiger claw
+    case 30: return "kick";     // kick, round kick, intimidation
+    case 36: return "pierce";
+    case 51: return "throwing";
+    case 0xE7: return "spell";  // DamageTypeSpell
+    default: return "melee";    // includes DamageTypeUnknown (0xFF)
   }
+}
+
+// Damage shield hits arrive as ordinary damage packets, but the server puts a DmgShieldType into the
+// field where a SkillType would normally go, so they cannot be classified with damage_type_name:
+//
+//   Mob::DamageShield()                    (EQMacEmu zone/attack.cpp, which Quarm derives from)
+//     cds->type    = spellbonuses.DamageShieldType;   // DS_DECAY(244) .. DS_THORNS(249)
+//     cds->spellid = spellid;                         // the DS spell, or SPELL_UNKNOWN
+//
+// NOTE: on Project Quarm this never fires - verified in game with `/otlp debug`, where shield hits
+// produced chat messages but no hit event at all (see parse_dot_or_heal, which handles them from
+// text). It is kept because it costs nothing and is correct for servers that do deliver a shield as
+// a damage packet, where the alternative is silently filing it under "spell" or "melee".
+bool is_damage_shield_type(unsigned short type) {
+  constexpr unsigned short kDsDecay = 244;
+  constexpr unsigned short kDsThorns = 249;
+  return type >= kDsDecay && type <= kDsThorns;
 }
 
 }  // namespace
 
 OtlpExporter::OtlpExporter(ZealService *zeal) {
   start_time_unix_nano = now_unix_nano();
-  worker = std::thread([this]() { worker_loop(); });
 
   // Emit every print-to-chat line as a log record and mine it for combat damage. This is the live
   // source (the pipe uses the same callback); registering our own keeps OTLP independent of whether
@@ -136,9 +218,29 @@ OtlpExporter::OtlpExporter(ZealService *zeal) {
   zeal->chat_hook->add_print_chat_callback([this](const char *data, int color_index) {
     if (!is_enabled() || !data) return;
     log(data, color_index);
+#ifdef ZEAL_OTEL_SDK
+    {
+      // Complete Heal chains. The announcement is a cleric's macro line, not a combat message, so it
+      // is read here rather than from the damage packets.
+      std::string ch_caster, ch_target;
+      std::string ch_next;
+      if (parse_ch_handoff(data, ch_next)) {
+        zeal::instrumentation::NoteChainHandoff(ch_next);
+        if (debug_hits.load()) Zeal::Game::print_chat("OTLP CH handoff -> %s", ch_next.c_str());
+      }
+      int ch_mana = -1, ch_pos = -1;
+      if (parse_ch_announce(data, ch_caster, ch_target, ch_pos, ch_mana)) {
+        zeal::instrumentation::RecordCompleteHeal(ch_caster, ch_target, current_zone_name(), ch_pos, ch_mana);
+        if (debug_hits.load())
+          Zeal::Game::print_chat("OTLP CH%i: caster=%s target=%s mana=%i%%", ch_pos, ch_caster.c_str(),
+                                 ch_target.c_str(), ch_mana);
+      }
+    }
+#endif
     // DoT ticks and heal amounts never fire the hit event and are only messaged to the involved
     // client, so text is the correct (and self-reporting, non-duplicating) channel for them.
     parse_dot_or_heal(data);
+    parse_lockout(data);
     handle_slain_line(data);
   });
 
@@ -150,21 +252,48 @@ OtlpExporter::OtlpExporter(ZealService *zeal) {
                                                  short damage, char) {
     if (!is_enabled() || !source || damage <= 0) return;
     Zeal::GameStructures::Entity *attacker = source;
+    std::string pet_name;  // kept alongside the owner rather than replaced by it
     if (attacker->PetOwnerSpawnId != 0) {  // credit a pet's damage to its owner (charmed or summoned)
       auto *owner = ZealService::get_instance()->entity_manager->Get(attacker->PetOwnerSpawnId);
-      if (owner) attacker = owner;
+      if (owner) {
+        pet_name = attacker->Name;
+        attacker = owner;
+      }
     }
     std::string src = attacker->Name;
     const char *src_type = (attacker->Type == Zeal::GameEnums::EntityTypes::Player) ? "player" : "npc";
     const char *direction = (target && target == Zeal::Game::get_self()) ? "incoming" : "outgoing";
-    const char *dtype = (spell_id > 0) ? "spell" : melee_type_name(type);
-    const std::string tgt = target ? target->Name : "";  // raw spawn name, e.g. "a_temple_guard00"
-    if (in_combat_scope(src)) record_combat_damage(src, src_type, direction, dtype, tgt, damage);
+    // Tested before spell_id: a buff-granted damage shield carries one, and would otherwise be
+    // indistinguishable from a nuke.
+    const char *dtype = is_damage_shield_type(type) ? "damage_shield"
+                        : (spell_id > 0)            ? "spell"
+                                                    : damage_type_name(type);
+    // Two forms deliberately: the metric attribute is normalised (see target_display), while fight
+    // spans keep the raw spawn name so two mobs of the same name pulled at once stay separate
+    // encounters - a trace is about one fight, a metric is about damage onto that kind of target.
+    const std::string raw_tgt = target ? target->Name : "";
+    const std::string tgt = target_display(raw_tgt);
+    if (debug_hits.load()) {
+      // The raw packet fields, before interpretation: `type` is a SkillType for melee but a
+      // DmgShieldType (244..249) for a damage shield, and spell_id is -1 (SPELL_UNKNOWN) when the
+      // server sends no spell. Printing both is what makes a misclassification visible.
+      Zeal::Game::print_chat("[otlp] %s -> %s  type=%u spell=%d dmg=%d  => %s (%s)", src.c_str(), tgt.c_str(),
+                             static_cast<unsigned int>(type), static_cast<int>(spell_id), static_cast<int>(damage),
+                             dtype, direction);
+    }
+    // Damage *taken* is always recorded, whatever the scope. The scope filter exists to stop several
+    // clients reporting the same attacker, but only the victim is told about damage landing on it, so
+    // there is nobody to duplicate - and filtering on the attacker meant a tank running the default
+    // scope=self dropped its own damage taken, which is precisely the number a raid wants next to
+    // healing received.
+    const bool incoming = (direction[0] == 'i');
+    if (incoming || in_combat_scope(src))
+      record_combat_damage(src, src_type, direction, dtype, tgt, pet_name, damage);
     // Fight spans: track encounters with NPCs (the mob is the target when we hit it, the source
     // when it hits us).
     const bool outgoing = (direction[0] == 'o');
-    const std::string mob = outgoing ? tgt : std::string(source->Name);
-    if (!mob.empty()) note_fight_damage(mob, outgoing, damage);
+    const std::string mob = outgoing ? raw_tgt : std::string(source->Name);
+    if (!mob.empty()) note_fight_damage(mob, src, outgoing, damage);
   });
 
   // Sample live game state on the game thread (MainLoop); the sender thread only ever serializes the
@@ -172,24 +301,92 @@ OtlpExporter::OtlpExporter(ZealService *zeal) {
   zeal->callbacks->AddGeneric([this]() {
     sample_game_state();
     if (is_enabled()) fight_tick();
+#ifdef ZEAL_OTEL_SDK
+    zeal::instrumentation::SweepCompleteHealChains();
+#endif
+#ifdef ZEAL_OTEL_SDK
+    // The providers are built once and live for the process; only the character changes, and it is
+    // a measurement attribute now, so keeping it current is a string assignment rather than a
+    // teardown and rebuild of the whole pipeline.
+    if (is_enabled()) {
+      if (!zeal::telemetry::Running()) {
+        std::string err;
+        if (!zeal::telemetry::Start(setting_endpoint.get(), auth_token(), setting_flush_ms.get(),
+                                    ZEAL_VERSION "+" ZEAL_BUILD_VERSION, err))
+          Zeal::Game::print_chat(USERCOLOR_SPELL_FAILURE, "OpenTelemetry failed to start: %s", err.c_str());
+      }
+      std::lock_guard<std::mutex> lock(snapshot_mutex);
+      zeal::instrumentation::SetCharacter(snapshot.in_game ? snapshot.name : std::string());
+      if (snapshot.in_game) {
+        zeal::instrumentation::SetCharacterState(snapshot.zone, snapshot.attack, snapshot.have_attack,
+                                                 snapshot.haste, snapshot.have_haste);
+        zeal::instrumentation::SetCharacterStats(snapshot.str, snapshot.sta, snapshot.dex, snapshot.agi,
+                                                 snapshot.wis, snapshot.intel, snapshot.cha);
+      }
+    }
+#endif
   });
 
-  zeal->commands_hook->Add("/otlp", {}, "OTLP/HTTP telemetry export. Usage: /otlp on|off|status|endpoint <url>",
+  zeal->commands_hook->Add("/otlp", {},
+                           "OTLP/HTTP telemetry export. Usage: /otlp on|off|status|endpoint <url>|flush <ms>|"
+                           "scope self|all|debug",
                            [this](std::vector<std::string> &args) {
                              if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "on")) {
                                setting_enabled.set(true);
-                               Zeal::Game::print_chat("OTLP export enabled -> %s/v1/logs",
+                               client->set_enabled(true);
+                               // Names the paths actually used. Logs are deliberately not
+                               // exported - chat carries private conversation - and this line used
+                               // to advertise the one path nothing posts to.
+                               Zeal::Game::print_chat("OTLP export enabled -> %s/v1/{metrics,traces}",
                                                       setting_endpoint.get().c_str());
                                return true;
                              }
                              if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "off")) {
                                setting_enabled.set(false);
+                               client->set_enabled(false);
                                Zeal::Game::print_chat("OTLP export disabled.");
                                return true;
                              }
                              if (args.size() == 3 && Zeal::String::compare_insensitive(args[1], "endpoint")) {
                                setting_endpoint.set(args[2]);
+                               client->set_endpoint(args[2]);
+                               restart_pipeline();
                                Zeal::Game::print_chat("OTLP endpoint set to %s", args[2].c_str());
+                               return true;
+                             }
+                             // Deliberately never echoes the value, and does not
+                             // fall through to the generic usage line on a bad
+                             // argument. print_chat output is written to
+                             // eqlog_*.txt whenever logging is on - the same file
+                             // people hand over when asking for help with their UI,
+                             // and the one pq companion reads. A token that reaches
+                             // a log is a token to reissue.
+                             if (args.size() >= 2 && Zeal::String::compare_insensitive(args[1], "token")) {
+                               if (args.size() == 3 &&
+                                   Zeal::String::compare_insensitive(args[2], "clear")) {
+                                 setting_token_sealed.set("");
+                                 token_plain.clear();
+                                 token_loaded = true;
+                                 client->set_auth_token("");
+                                 restart_pipeline();
+                                 Zeal::Game::print_chat("OTLP token cleared.");
+                                 return true;
+                               }
+                               if (args.size() != 3) {
+                                 Zeal::Game::print_chat("Usage: /otlp token <token> | /otlp token clear");
+                                 return true;
+                               }
+                               const std::string sealed = seal_token(args[2]);
+                               if (sealed.empty()) {
+                                 Zeal::Game::print_chat("OTLP token could not be stored (DPAPI failed).");
+                                 return true;
+                               }
+                               setting_token_sealed.set(sealed);
+                               token_plain = args[2];
+                               token_loaded = true;
+                               client->set_auth_token(token_plain);
+                               restart_pipeline();
+                               Zeal::Game::print_chat("OTLP token stored (sealed to this Windows account).");
                                return true;
                              }
                              if (args.size() == 3 && Zeal::String::compare_insensitive(args[1], "flush")) {
@@ -198,11 +395,58 @@ OtlpExporter::OtlpExporter(ZealService *zeal) {
                                  Zeal::Game::print_chat("Usage: /otlp flush <milliseconds>");
                                  return true;
                                }
-                               if (ms < kMinFlushMs) ms = kMinFlushMs;  // Clamp: metrics are periodic; 0 would just hammer.
+                               if (ms < OtlpClient::kMinFlushMs)
+                                 ms = OtlpClient::kMinFlushMs;  // Clamp: metrics are periodic; 0 would just hammer.
                                setting_flush_ms.set(ms);
+                               client->set_flush_ms(ms);
+#ifdef ZEAL_OTEL_SDK
+                               // The SDK reads this when its providers are built, so the setting
+                               // only becomes real on a rebuild. Without this the command changed
+                               // a number in the ini and nothing else - the export interval stayed
+                               // wherever it started.
+                               restart_pipeline();
+                               // Clamped with comparisons rather than std::min/max: windows.h is
+                               // in scope here and defines min/max as macros, and NOMINMAX cannot
+                               // be set for this file (see telemetry.cpp - 164 call sites rely on
+                               // the macros).
+                               int effective = ms;
+                               if (effective < zeal::telemetry::kMinExportIntervalMs)
+                                 effective = zeal::telemetry::kMinExportIntervalMs;
+                               if (effective > zeal::telemetry::kMaxExportIntervalMs)
+                                 effective = zeal::telemetry::kMaxExportIntervalMs;
+                               if (effective != ms)
+                                 Zeal::Game::print_chat(
+                                     "OTLP flush interval set to %ims (clamped from %ims: every export "
+                                     "re-sends every series)",
+                                     effective, ms);
+                               else
+                                 Zeal::Game::print_chat("OTLP flush interval set to %ims", effective);
+#else
                                Zeal::Game::print_chat("OTLP flush interval set to %ims", ms);
+#endif
                                return true;
                              }
+                             if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "debug")) {
+                               const bool on = !debug_hits.load();
+                               debug_hits.store(on);
+                               Zeal::Game::print_chat(
+                                   on ? "OTLP hit debug ON - every recorded hit prints its raw packet fields. "
+                                        "Spammy; /otlp debug again to stop."
+                                      : "OTLP hit debug off.");
+                               return true;
+                             }
+#ifdef ZEAL_OTEL_SDK
+                             // Reports what the SDK pipeline is doing. The probe command this
+                             // replaces existed to start the SDK by hand; the providers now come up
+                             // with the exporter, so there is nothing left to trigger.
+                             if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "sdk")) {
+                               Zeal::Game::print_chat("OpenTelemetry SDK: %s",
+                                                      zeal::telemetry::Running() ? "running" : "not started");
+                               Zeal::Game::print_chat("  metrics, logs and traces over WinHTTP -> %s",
+                                                      setting_endpoint.get().c_str());
+                               return true;
+                             }
+#endif
                              if (args.size() == 3 && Zeal::String::compare_insensitive(args[1], "scope")) {
                                if (Zeal::String::compare_insensitive(args[2], "self") ||
                                    Zeal::String::compare_insensitive(args[2], "all")) {
@@ -214,91 +458,256 @@ OtlpExporter::OtlpExporter(ZealService *zeal) {
                                }
                                return true;
                              }
+                             // Reports the interval actually in force, not the number in the ini:
+                             // the two differ whenever the setting is below the floor.
                              Zeal::Game::print_chat("OTLP: %s, endpoint %s, flush %ims, scope %s",
                                                     setting_enabled.get() ? "enabled" : "disabled",
                                                     setting_endpoint.get().c_str(), setting_flush_ms.get(),
                                                     setting_combat_scope.get().c_str());
-                             Zeal::Game::print_chat("  sent: %llu log batches-worth, %llu metric posts, %llu failed",
-                                                    logs_posted.load(), metrics_posted.load(), failed_posts.load());
-                             Zeal::Game::print_chat("  last HTTP status: %i", last_http_status.load());
+#ifdef ZEAL_OTEL_SDK
+                             // The SDK owns delivery here, so report *its* transport. The
+                             // hand-rolled client's counters sit at zero in this build and reading
+                             // them as health is how an exporter that sent nothing looked fine.
                              {
-                               std::lock_guard<std::mutex> lock(last_error_mutex);
-                               if (!last_error.empty())
+                               const auto st = zeal::telemetry::Stats();
+                               Zeal::Game::print_chat("  sent: %llu payloads, %llu failed", st.posted,
+                                                      st.failed);
+                               Zeal::Game::print_chat("  last HTTP status: %i", st.last_status);
+                               if (!st.last_error.empty())
                                  Zeal::Game::print_chat(USERCOLOR_SPELL_FAILURE, "  last error: %s",
-                                                        last_error.c_str());
+                                                        st.last_error.c_str());
                              }
-                             Zeal::Game::print_chat("Usage: /otlp on|off|status|endpoint <url>|flush <ms>|scope self|all");
+#else
+                             Zeal::Game::print_chat("  sent: %llu log lines, %llu payloads, %llu failed",
+                                                    logs_posted.load(), client->posted(), client->failed());
+                             Zeal::Game::print_chat("  last HTTP status: %i", client->last_status());
+#endif
+                             // Presence and the last four characters: enough to
+                             // tell two tokens apart without putting a working
+                             // one in the chat log.
+                             {
+                               // "Stored but unreadable" is a different problem from "never set",
+                               // and reporting both as "not set" is what hid a truncating ini read:
+                               // the token was there, the client could not use it, and nothing said
+                               // so while uploads went out unauthenticated.
+                               const std::string &tok = auth_token();
+                               if (!tok.empty())
+                                 Zeal::Game::print_chat("  token: set (ends %s)",
+                                                        tok.substr(tok.size() - 4).c_str());
+                               else if (setting_token_sealed.get().empty())
+                                 Zeal::Game::print_chat("  token: not set");
+                               else
+                                 Zeal::Game::print_chat(
+                                     USERCOLOR_SPELL_FAILURE,
+                                     "  token: stored but could not be read - set it again with "
+                                     "/otlp token <token>");
+                             }
+#ifndef ZEAL_OTEL_SDK
+                             {
+                               const std::string err = client->last_error();
+                               if (!err.empty())
+                                 Zeal::Game::print_chat(USERCOLOR_SPELL_FAILURE, "  last error: %s", err.c_str());
+                             }
+#endif
+                             Zeal::Game::print_chat("Usage: /otlp on|off|status|endpoint <url>|token <token>|flush <ms>|scope self|all");
                              return true;
                            });
+
+
+  // Constructed last: the worker calls collect() as soon as it starts, so every piece of state it
+  // reads must already exist.
+  client = std::make_unique<OtlpClient>([this]() { return collect(); });
+  client->set_endpoint(setting_endpoint.get());
+  client->set_flush_ms(setting_flush_ms.get());
+  client->set_enabled(setting_enabled.get());
+  client->set_auth_token(auth_token());
 }
 
 OtlpExporter::~OtlpExporter() {
+#ifdef ZEAL_OTEL_SDK
+  // Shut the SDK down first: the metric reader and batch processors own threads that would
+  // otherwise still be running when this DLL unloads, exporting from memory that no longer exists.
+  zeal::telemetry::Stop();
+#endif
+  client.reset();  // stops and joins the worker before any state it collects from goes away
+}
+
+// Pulls the caster, target and reported mana out of a Complete Heal announcement.
+//
+// The macro is "/4 <n> - CH - %t (%n)", where the parenthesised value is the caster's *mana*, not
+// their name - so the caster has to come from the channel line's speaker prefix. Matching on the
+// " CH - " marker rather than the whole line keeps this working across channel formats and whatever
+// numbering convention a guild puts in front.
+static bool parse_ch_announce(const std::string &line, std::string &caster, std::string &target,
+                              int &position, int &mana_percent) {
+  const size_t marker = line.find(" CH - ");
+  if (marker == std::string::npos) return false;
+  const size_t pos = marker + 6;
+
+  // Target runs to the mana parenthesis, the closing quote, or end of line.
+  size_t stop = line.find(" (", pos);
+  const size_t quote = line.find('\'', pos);
+  if (quote != std::string::npos && (stop == std::string::npos || quote < stop)) stop = quote;
+  if (stop == std::string::npos) stop = line.size();
+  target = Zeal::String::trim_and_reduce_spaces(line.substr(pos, stop - pos));
+  if (target.empty()) return false;
+
+  // The rotation slot is whatever number sits immediately before the marker: "1 - CH - ...".
+  // Scanning back from the marker rather than anchoring to the line start keeps it independent of
+  // the channel prefix the client puts in front.
+  position = -1;
   {
-    std::lock_guard<std::mutex> lock(queue_mutex);
-    end_thread = true;
+    size_t scan = marker;
+    while (scan > 0 && !isdigit(static_cast<unsigned char>(line[scan - 1]))) {
+      const char c = line[scan - 1];
+      if (c != ' ' && c != '-') break;  // only whitespace and the dash may sit between
+      scan--;
+    }
+    size_t digits_end = scan;
+    while (scan > 0 && isdigit(static_cast<unsigned char>(line[scan - 1]))) scan--;
+    if (digits_end > scan) {
+      int parsed = 0;
+      if (Zeal::String::tryParse(line.substr(scan, digits_end - scan), &parsed, true)) position = parsed;
+    }
   }
-  queue_cv.notify_all();
-  if (worker.joinable()) worker.join();
+
+  mana_percent = -1;
+  const size_t open = line.find(" (", pos);
+  if (open != std::string::npos) {
+    const size_t close = line.find(')', open);
+    if (close != std::string::npos) {
+      int parsed = 0;
+      if (Zeal::String::tryParse(Zeal::String::trim_and_reduce_spaces(line.substr(open + 2, close - open - 2)),
+                                 &parsed, true))
+        mana_percent = parsed;  // 0-100; validated where it is recorded
+    }
+  }
+
+  // The speaker prefix the client adds to channel lines: "<name> tells ...".
+  const size_t tells = line.find(" tells ");
+  if (tells != std::string::npos && tells < marker)
+    caster = Zeal::String::trim_and_reduce_spaces(line.substr(0, tells));
+  return !caster.empty();
+}
+
+// "/4 GO - Abuelo" - the last line of the macro, telling the next cleric to start. Anchored on
+// " GO - " for the same reason as the CH marker: the channel prefix varies and the guild's own
+// numbering sits in front of it.
+static bool parse_ch_handoff(const std::string &line, std::string &next_caster) {
+  const size_t marker = line.find(" GO - ");
+  if (marker == std::string::npos) return false;
+  size_t stop = line.find('\'', marker + 6);
+  if (stop == std::string::npos) stop = line.size();
+  next_caster = Zeal::String::trim_and_reduce_spaces(line.substr(marker + 6, stop - marker - 6));
+  // A name, not a sentence: anything with spaces is someone talking about the chain, not a cue.
+  return !next_caster.empty() && next_caster.find(' ') == std::string::npos;
+}
+
+// ---------------------------------------------------------------------------
+// Token storage
+//
+// The value is a bearer credential for the guild's ingest gateway. It is
+// sealed with CryptProtectData, which ties it to this Windows account, and
+// base64'd so it survives an ini round-trip. A blob lifted out of someone
+// else's zeal.ini decrypts to nothing on this machine.
+// ---------------------------------------------------------------------------
+
+std::string OtlpExporter::seal_token(const std::string &plain) {
+  if (plain.empty()) return "";
+  DATA_BLOB in = {static_cast<DWORD>(plain.size()), (BYTE *)plain.data()};
+  DATA_BLOB out = {0, nullptr};
+  if (!CryptProtectData(&in, L"Zeal OTLP token", nullptr, nullptr, nullptr, CRYPTPROTECT_UI_FORBIDDEN,
+                        &out))
+    return "";
+  DWORD chars = 0;
+  std::string encoded;
+  if (CryptBinaryToStringA(out.pbData, out.cbData, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, nullptr,
+                           &chars) &&
+      chars > 0) {
+    encoded.resize(chars);
+    if (!CryptBinaryToStringA(out.pbData, out.cbData, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF,
+                              &encoded[0], &chars))
+      encoded.clear();
+    else
+      encoded.resize(strlen(encoded.c_str()));
+  }
+  LocalFree(out.pbData);
+  return encoded;
+}
+
+std::string OtlpExporter::unseal_token(const std::string &sealed) {
+  if (sealed.empty()) return "";
+  DWORD bytes = 0;
+  if (!CryptStringToBinaryA(sealed.c_str(), 0, CRYPT_STRING_BASE64, nullptr, &bytes, nullptr, nullptr) ||
+      bytes == 0)
+    return "";
+  std::vector<BYTE> raw(bytes);
+  if (!CryptStringToBinaryA(sealed.c_str(), 0, CRYPT_STRING_BASE64, raw.data(), &bytes, nullptr, nullptr))
+    return "";
+  DATA_BLOB in = {bytes, raw.data()};
+  DATA_BLOB out = {0, nullptr};
+  if (!CryptUnprotectData(&in, nullptr, nullptr, nullptr, nullptr, CRYPTPROTECT_UI_FORBIDDEN, &out))
+    return "";  // another account's blob, or a corrupted ini: upload unauthenticated
+  std::string plain(reinterpret_cast<char *>(out.pbData), out.cbData);
+  LocalFree(out.pbData);
+  return plain;
+}
+
+// Rebuild the SDK pipeline so an endpoint or token change actually takes effect.
+//
+// The providers capture both when they are constructed - the exporters hold their own copies of the
+// URL and the headers - and telemetry.h says so plainly: Start() is a no-op while running. Without
+// this, /otlp endpoint and /otlp token updated a transport that, in an SDK build, sends nothing,
+// and the real exporter carried on posting to wherever it was first pointed. Stop() here and the
+// periodic sampler starts it again with the new values on its next tick.
+void OtlpExporter::restart_pipeline() {
+#ifdef ZEAL_OTEL_SDK
+  if (zeal::telemetry::Running()) zeal::telemetry::Stop();
+#endif
+}
+
+const std::string &OtlpExporter::auth_token() const {
+  if (!token_loaded) {
+    token_plain = unseal_token(setting_token_sealed.get());
+    token_loaded = true;
+  }
+  return token_plain;
 }
 
 void OtlpExporter::log(const std::string &body, int color_index) {
-  if (!setting_enabled.get() || body.empty()) return;
-
-  LogRecord record;
-  record.time_unix_nano = now_unix_nano();
-  record.body = body;
-  record.color_index = color_index;
-  if (Zeal::Game::is_in_game() && Zeal::Game::get_self()) record.zone_id = Zeal::Game::get_self()->ZoneId;
-
-  {
-    std::lock_guard<std::mutex> lock(queue_mutex);
-    queue.push_back(std::move(record));
-  }
-  queue_cv.notify_one();
+  // Chat is no longer collected at all.
+  //
+  // It only ever reached the player's own collector, whose logs pipeline dropped it - so it produced
+  // no observability while carrying the most sensitive content in the game, private tells among it.
+  // Not collecting it is a stronger guarantee than a pipeline that promises to discard it, and one
+  // fewer thing anyone has to take on trust when they install this.
+  //
+  // The chat hook itself stays: it is what combat damage is parsed from.
+  (void)body;
+  (void)color_index;
 }
 
-void OtlpExporter::worker_loop() {
-  while (true) {
-    std::vector<LogRecord> batch;
-    {
-      std::unique_lock<std::mutex> lock(queue_mutex);
-      const int configured = setting_flush_ms.get();
-      const int interval = configured > 0 ? (configured < kMinFlushMs ? kMinFlushMs : configured) : 2000;
-      queue_cv.wait_for(lock, std::chrono::milliseconds(interval),
-                        [this]() { return end_thread || !queue.empty(); });
-      if (end_thread && queue.empty()) return;
+std::vector<OtlpClient::Payload> OtlpExporter::collect() {
+  std::vector<OtlpClient::Payload> payloads;
 
-      const int max_batch = setting_max_batch.get() > 0 ? setting_max_batch.get() : 512;
-      while (!queue.empty() && static_cast<int>(batch.size()) < max_batch) {
-        batch.push_back(std::move(queue.front()));
-        queue.pop_front();
-      }
-    }
-
-    if (!setting_enabled.get()) continue;
-
-    try {
-      if (!batch.empty()) {
-        if (post_json("/v1/logs", build_logs_payload(batch)))
-          logs_posted += batch.size();
-        else
-          failed_posts++;
-      }
-      // Metrics use cumulative temporality, so emit the current snapshot every flush even when no
-      // new log lines arrived this cycle.
-      std::string metrics = build_metrics_payload();
-      if (!metrics.empty()) {
-        if (post_json("/v1/metrics", metrics))
-          metrics_posted++;
-        else
-          failed_posts++;
-      }
-      std::string traces = build_traces_payload();
-      if (!traces.empty() && !post_json("/v1/traces", traces)) failed_posts++;
-    } catch (const std::exception &) {
-      // Never let telemetry take down the game; drop this cycle on failure.
+  std::vector<LogRecord> batch;
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex);
+    const int max_batch = setting_max_batch.get() > 0 ? setting_max_batch.get() : 512;
+    while (!queue.empty() && static_cast<int>(batch.size()) < max_batch) {
+      batch.push_back(std::move(queue.front()));
+      queue.pop_front();
     }
   }
+  if (!batch.empty()) {
+    // Chat is not collected and spans are the SDK's now; nothing produces these any more.
+    logs_posted += batch.size();
+  }
+  // Metrics use cumulative temporality, so emit the current snapshot every flush even when no new
+  // log lines arrived this cycle.
+  payloads.emplace_back("/v1/metrics", build_metrics_payload());
+  payloads.emplace_back("/v1/traces", build_traces_payload());
+  return payloads;
 }
 
 void OtlpExporter::sample_game_state() {
@@ -328,6 +737,20 @@ void OtlpExporter::sample_game_state() {
       s.have_attack = true;
       s.attack = atoll(offense.c_str());
     }
+    // Group roster. GroupInfo.Names is a fixed array gated by IsValidList, and does not include the
+    // local character, so add it explicitly - otherwise the reporting player is missing from their
+    // own group.
+    const Zeal::GameStructures::GroupInfo *gi = Zeal::Game::GroupInfo;
+    if (gi && gi->is_in_group()) {
+      s.group_leader = gi->LeaderName;
+      s.group_members.push_back(s.name);
+      for (int i = 0; i < GAME_NUM_GROUP_MEMBERS; ++i) {  // 5 slots: the group minus yourself
+        if (!gi->IsValidList[i] || gi->Names[i][0] == 0) continue;
+        if (s.name == gi->Names[i]) continue;  // belt and braces against a duplicate self entry
+        s.group_members.push_back(gi->Names[i]);
+      }
+    }
+
     Zeal::GameStructures::Entity *self = Zeal::Game::get_self();
     if (self) {
       // ModifyAttackSpeed applies total effective haste (worn + spell + overhaste) to a reference
@@ -350,7 +773,12 @@ void OtlpExporter::sample_game_state() {
 nlohmann::json OtlpExporter::build_resource_attributes() const {
   nlohmann::json attrs = nlohmann::json::array();
   attrs.push_back(string_attr("service.name", "everquest"));
-  attrs.push_back(string_attr("service.version", ZEAL_VERSION));
+  // ZEAL_VERSION alone cannot distinguish two builds of the same release, and every build of this
+  // branch reports 1.4.5 - so "which build is that member running?" was unanswerable, which is
+  // exactly the question that comes up when a feature appears to be missing for one person. The
+  // short git hash the build workflow compiles in (or "UNOFFICIAL" for a local build) is appended as
+  // semver build metadata, which is what that field is for.
+  attrs.push_back(string_attr("service.version", ZEAL_VERSION "+" ZEAL_BUILD_VERSION));
   attrs.push_back(string_attr("telemetry.sdk.name", "zeal"));
 
   Snapshot s;
@@ -366,6 +794,10 @@ nlohmann::json OtlpExporter::build_resource_attributes() const {
     attrs.push_back(int_attr(everquest_semconv::kEverquestCharacterLevel, s.level));
     attrs.push_back(int_attr(everquest_semconv::kEverquestCharacterDeity, s.deity));
     attrs.push_back(int_attr(everquest_semconv::kEverquestCharacterAaUnspent, s.aa_unspent));
+#ifndef ZEAL_OTEL_SDK
+    // Migrated to a change-driven gauge (see instrumentation.cpp). These cannot live on the Resource
+    // any more: it is fixed for the process, and a stat that changes when you swap gear would either
+    // go stale or force the whole pipeline to be rebuilt.
     attrs.push_back(int_attr("everquest.character.stat.strength", s.str));
     attrs.push_back(int_attr("everquest.character.stat.stamina", s.sta));
     attrs.push_back(int_attr("everquest.character.stat.dexterity", s.dex));
@@ -373,6 +805,7 @@ nlohmann::json OtlpExporter::build_resource_attributes() const {
     attrs.push_back(int_attr("everquest.character.stat.wisdom", s.wis));
     attrs.push_back(int_attr("everquest.character.stat.intelligence", s.intel));
     attrs.push_back(int_attr("everquest.character.stat.charisma", s.cha));
+#endif
   }
   return attrs;
 }
@@ -416,18 +849,32 @@ bool OtlpExporter::in_combat_scope(const std::string &source) const {
 
 void OtlpExporter::record_combat_damage(const std::string &source, const std::string &source_type,
                                         const std::string &direction, const std::string &type,
-                                        const std::string &target, long long amount) {
-  const std::string zone = current_zone_name();  // where the hit happened (game thread)
+                                        const std::string &target, const std::string &pet,
+                                        long long amount) {
+  const std::string zone = current_zone_name();     // where the hit happened (game thread)
+  const std::string group = group_for(source, direction);  // "" unless it is genuinely our group's
+#ifdef ZEAL_OTEL_SDK
+  // Migrated: the SDK owns this metric now, so the hand-rolled aggregation below is skipped rather
+  // than run alongside - both emit everquest.combat.damage and would otherwise collide. Parity was
+  // verified against live combat first (12 series, 12 labels, identical values).
+  zeal::instrumentation::RecordDamage(source, source_type, direction, type, zone, target, group, pet, amount);
+#else
   std::lock_guard<std::mutex> lock(metrics_mutex);
-  CombatTotal &entry = combat_damage[{source, source_type, direction, type, zone, target}];
+  CombatTotal &entry = combat_damage[{source, source_type, direction, type, zone, target, group}];
   entry.total += amount;
   entry.last_ms = GetTickCount64();
+#endif
 }
 
 void OtlpExporter::record_heal(const std::string &source, const std::string &direction, long long amount) {
   const std::string zone = current_zone_name();
+  const std::string group = group_for(source, direction);  // "" unless it is genuinely our group's
+#ifdef ZEAL_OTEL_SDK
+  zeal::instrumentation::RecordHeal(source, direction, zone, group, amount);
+#else
   std::lock_guard<std::mutex> lock(metrics_mutex);
-  combat_heal[{source, direction, zone}] += amount;
+  combat_heal[{source, direction, zone, group}] += amount;
+#endif
 }
 
 // Extracts the positive integer that starts at line[pos] (returns 0 if none).
@@ -437,9 +884,73 @@ static long long read_number(const std::string &line, size_t pos) {
   return (end > pos) ? atoll(line.substr(pos, end - pos).c_str()) : 0;
 }
 
+// Damage shield damage never reaches the ReportSuccessfulHit hook on this server - verified in game
+// with `/otlp debug`, where every melee swing printed a hit line but the shield produced only chat:
+//
+//   A vampyre bat was hit by non-melee for 30 points of damage.   <- message 434, the amount
+//   A vampyre bat was chilled to the bone.                        <- message 12140, the cause
+//
+// Neither line is sufficient alone: 434 is also emitted for ordinary spell damage and names no
+// attacker, and the flavour line carries no number. They are paired by arriving back to back for the
+// same target, which is what this parser keys on. The six flavour messages (12132..12142) correspond
+// one-to-one with the six DmgShieldType values the server tracks internally.
+namespace {
+const char *const kDamageShieldSuffixes[] = {
+    " was pierced by thorns.", " was burned.", " was tormented.",
+    " was chilled to the bone.", " is burning.", " is freezing!",
+};
+
+// "<target> was chilled to the bone." -> "<target>", or "" if the line is not a shield message.
+std::string damage_shield_target(const std::string &line) {
+  for (const char *suffix : kDamageShieldSuffixes) {
+    const size_t len = strlen(suffix);
+    if (line.size() > len && line.compare(line.size() - len, len, suffix) == 0)
+      return line.substr(0, line.size() - len);
+  }
+  return "";
+}
+}  // namespace
+
 void OtlpExporter::parse_dot_or_heal(const std::string &line) {
   const char *self = Zeal::Game::get_self() ? Zeal::Game::get_self()->Name : nullptr;
   if (!self) return;
+
+  // Damage shield, part 2: a flavour line claims the amount buffered from the line before it. The
+  // pending slot holds only the most recent 434 message, so an unrelated nuke on the same target
+  // cannot be claimed unless it landed immediately before the shield fired.
+  const std::string ds_target = damage_shield_target(line);
+  if (!ds_target.empty()) {
+    const bool claimed = !ds_pending_target.empty() && ds_pending_target == ds_target &&
+                         GetTickCount64() - ds_pending_ms < 1000;
+    if (claimed) {
+      record_combat_damage(self, "player", "outgoing", "damage_shield", ds_pending_target, "", ds_pending_amount);
+    }
+    if (debug_hits.load()) {
+      // Shields take the text path, so without this `/otlp debug` would stay silent for them and a
+      // pairing that never fires would look identical to one that does.
+      if (claimed)
+        Zeal::Game::print_chat("[otlp] damage_shield %s dmg=%lld (paired with the preceding non-melee line)",
+                               ds_target.c_str(), ds_pending_amount);
+      else
+        Zeal::Game::print_chat("[otlp] damage_shield %s UNPAIRED - no non-melee amount to claim", ds_target.c_str());
+    }
+    ds_pending_target.clear();
+    return;
+  }
+
+  // Damage shield, part 1: buffer "<target> was hit by non-melee for <N> points of damage." Kept
+  // rather than recorded, because this message is also how ordinary spell damage is announced.
+  static const char kNonMelee[] = " was hit by non-melee for ";
+  const size_t nm = line.find(kNonMelee);
+  if (nm != std::string::npos) {
+    const long long amount = read_number(line, nm + sizeof(kNonMelee) - 1);
+    if (amount > 0) {
+      ds_pending_target = line.substr(0, nm);
+      ds_pending_amount = amount;
+      ds_pending_ms = GetTickCount64();
+    }
+    return;
+  }
 
   // DoT tick (caster-side): "<target> has taken <N> damage from your <spell>."
   // Observer form:          "<target> has taken <N> damage from <caster>'s <spell>."
@@ -451,14 +962,16 @@ void OtlpExporter::parse_dot_or_heal(const std::string &line) {
       const std::string dot_target = line.substr(0, p);  // display name; chat has no instance digits
       std::string rest = line.substr(from + 13);
       if (rest.rfind("your ", 0) == 0) {
-        record_combat_damage(self, "player", "outgoing", "dot", dot_target, amount);
+        if (debug_hits.load())
+          Zeal::Game::print_chat("[otlp] dot %s -> %s dmg=%lld", self, dot_target.c_str(), amount);
+        record_combat_damage(self, "player", "outgoing", "dot", dot_target, "", amount);
       } else {
         size_t apos = rest.find("'s ");  // "<caster>'s <spell>"
         if (apos != std::string::npos && setting_combat_scope.get() != "self") {
           std::string caster = rest.substr(0, apos);
           auto *e = ZealService::get_instance()->entity_manager->Get(caster);
           const char *ct = (e && e->Type == Zeal::GameEnums::EntityTypes::Player) ? "player" : "npc";
-          record_combat_damage(caster, ct, "outgoing", "dot", dot_target, amount);
+          record_combat_damage(caster, ct, "outgoing", "dot", dot_target, "", amount);
         }
       }
     }
@@ -471,7 +984,10 @@ void OtlpExporter::parse_dot_or_heal(const std::string &line) {
     size_t f = line.find(" for ", 16);
     if (f != std::string::npos) {
       long long amount = read_number(line, f + 5);
-      if (amount > 0) record_heal(self, "outgoing", amount);
+      if (amount > 0) {
+        if (debug_hits.load()) Zeal::Game::print_chat("[otlp] heal outgoing %lld", amount);
+        record_heal(self, "outgoing", amount);
+      }
     }
     return;
   }
@@ -480,7 +996,12 @@ void OtlpExporter::parse_dot_or_heal(const std::string &line) {
   p = line.find("You have been healed for ");
   if (p == 0) {
     long long amount = read_number(line, 25);
-    if (amount > 0) record_heal(self, "incoming", amount);
+    if (amount > 0) {
+      // Healing is only ever messaged to the target, so this is the line that carries every heal
+      // landing on you - including your own self-heals.
+      if (debug_hits.load()) Zeal::Game::print_chat("[otlp] heal received %lld", amount);
+      record_heal(self, "incoming", amount);
+    }
   }
 }
 
@@ -496,6 +1017,66 @@ static nlohmann::json gauge_metric(const char *name, const char *unit, const std
   metric["unit"] = unit;
   metric["gauge"] = {{"dataPoints", nlohmann::json::array({point})}};
   return metric;
+}
+
+// Raid lockouts. The server builds this message in zone/corpse.cpp:
+//
+//   "You have incurred a lockout for " + npc->GetCleanName()
+//     + " that expires in " + Strings::SecondsToTime(loot_lockout_timer) + "."
+//
+// SecondsToTime emits a *compound* duration - "18 Hours", but equally "1 Day, 2 Hours, 3 Minutes,
+// and 4 Seconds", singular or plural per unit - so every number/unit pair has to be summed. Reading
+// only the first pair (as this did at first) silently truncates: "17 Hours, 45 Minutes" would
+// become 17 hours and the countdown would finish 45 minutes early.
+//
+// The expiry is recorded as an absolute instant, not a remaining duration: a countdown computed
+// once would be wrong the moment it was exported, whereas a deadline stays correct for as long as
+// the value survives, including after the player logs off.
+void OtlpExporter::parse_lockout(const std::string &line) {
+  static const char kFor[] = " lockout for ";
+  static const char kExpires[] = " that expires in ";
+  const size_t f = line.find(kFor);
+  if (f == std::string::npos) return;
+  const size_t e = line.find(kExpires, f);
+  if (e == std::string::npos) return;
+
+  const std::string target = line.substr(f + sizeof(kFor) - 1, e - (f + sizeof(kFor) - 1));
+  if (target.empty()) return;
+
+  // Sum every "<n> <unit>" pair in the tail. SecondsToTime returns "Unknown" for a non-positive
+  // duration, which yields no pairs and is skipped.
+  long long seconds = 0;
+  for (size_t i = e + sizeof(kExpires) - 1; i < line.size();) {
+    if (!isdigit(static_cast<unsigned char>(line[i]))) {
+      ++i;
+      continue;
+    }
+    const long long amount = read_number(line, i);
+    while (i < line.size() && isdigit(static_cast<unsigned char>(line[i]))) ++i;
+    while (i < line.size() && line[i] == ' ') ++i;
+    std::string unit;
+    while (i < line.size() && isalpha(static_cast<unsigned char>(line[i])))
+      unit.push_back(static_cast<char>(tolower(static_cast<unsigned char>(line[i++]))));
+    // "Milli..." before "Min...": both start with 'm'.
+    if (unit.rfind("mil", 0) == 0) continue;  // sub-second precision is noise for an 18h lockout
+    else if (unit.rfind("d", 0) == 0) seconds += amount * 86400;
+    else if (unit.rfind("h", 0) == 0) seconds += amount * 3600;
+    else if (unit.rfind("m", 0) == 0) seconds += amount * 60;
+    else if (unit.rfind("s", 0) == 0) seconds += amount;
+  }
+  if (seconds <= 0) return;
+
+  const long long now_s = static_cast<long long>(now_unix_nano() / 1000000000ULL);
+  const long long expiry = now_s + seconds;
+  {
+    std::lock_guard<std::mutex> lock(metrics_mutex);
+    lockouts[target] = expiry;
+    // The server emits this notice from NPC::CreateCorpse, i.e. at the kill, so this is the time of
+    // death rather than the time of looting.
+    raid_kills[target] = now_s;
+  }
+  if (debug_hits.load())
+    Zeal::Game::print_chat("[otlp] lockout %s in %lld s (expires at unix %lld)", target.c_str(), seconds, expiry);
 }
 
 std::string OtlpExporter::build_metrics_payload() {
@@ -516,13 +1097,18 @@ std::string OtlpExporter::build_metrics_payload() {
         continue;
       }
       const auto &key = it->first;
-      data_points.push_back({{"attributes",
-                              {string_attr(everquest_semconv::kEverquestCombatSource, std::get<0>(key)),
-                               string_attr(everquest_semconv::kEverquestCombatSourceType, std::get<1>(key)),
-                               string_attr(everquest_semconv::kEverquestCombatDirection, std::get<2>(key)),
-                               string_attr(everquest_semconv::kEverquestCombatDamageType, std::get<3>(key)),
-                               string_attr(everquest_semconv::kEverquestZoneName, std::get<4>(key)),
-                               string_attr(everquest_semconv::kEverquestCombatTarget, std::get<5>(key))}},
+      nlohmann::json attrs = nlohmann::json::array(
+          {string_attr(everquest_semconv::kEverquestCombatSource, std::get<0>(key)),
+           string_attr(everquest_semconv::kEverquestCombatSourceType, std::get<1>(key)),
+           string_attr(everquest_semconv::kEverquestCombatDirection, std::get<2>(key)),
+           string_attr(everquest_semconv::kEverquestCombatDamageType, std::get<3>(key)),
+           string_attr(everquest_semconv::kEverquestZoneName, std::get<4>(key)),
+           string_attr(everquest_semconv::kEverquestCombatTarget, std::get<5>(key))});
+      // Omitted rather than sent empty when ungrouped: an absent attribute is a missing label in
+      // Prometheus, which keeps solo play out of every group-scoped query.
+      if (!std::get<6>(key).empty())
+        attrs.push_back(string_attr(everquest_semconv::kEverquestGroupLeader, std::get<6>(key)));
+      data_points.push_back({{"attributes", attrs},
                              {"startTimeUnixNano", start},
                              {"timeUnixNano", now},
                              {"asInt", std::to_string(it->second.total)}});
@@ -542,10 +1128,13 @@ std::string OtlpExporter::build_metrics_payload() {
   {
     std::lock_guard<std::mutex> lock(metrics_mutex);
     for (const auto &[key, total] : combat_heal) {
-      heal_points.push_back({{"attributes",
-                              {string_attr(everquest_semconv::kEverquestCombatSource, std::get<0>(key)),
-                               string_attr(everquest_semconv::kEverquestCombatDirection, std::get<1>(key)),
-                               string_attr(everquest_semconv::kEverquestZoneName, std::get<2>(key))}},
+      nlohmann::json attrs =
+          nlohmann::json::array({string_attr(everquest_semconv::kEverquestCombatSource, std::get<0>(key)),
+                                 string_attr(everquest_semconv::kEverquestCombatDirection, std::get<1>(key)),
+                                 string_attr(everquest_semconv::kEverquestZoneName, std::get<2>(key))});
+      if (!std::get<3>(key).empty())
+        attrs.push_back(string_attr(everquest_semconv::kEverquestGroupLeader, std::get<3>(key)));
+      heal_points.push_back({{"attributes", attrs},
                              {"startTimeUnixNano", start},
                              {"timeUnixNano", now},
                              {"asInt", std::to_string(total)}});
@@ -559,16 +1148,6 @@ std::string OtlpExporter::build_metrics_payload() {
     metrics.push_back(metric);
   }
 
-  // Attack (offense) and haste gauges for DPS correlation, read from the game-thread snapshot.
-  {
-    Snapshot s;
-    {
-      std::lock_guard<std::mutex> lock(snapshot_mutex);
-      s = snapshot;
-    }
-    if (s.have_attack) metrics.push_back(gauge_metric(everquest_semconv::kEverquestCharacterAttackMetric, "1", now, s.attack, s.zone));
-    if (s.have_haste) metrics.push_back(gauge_metric(everquest_semconv::kEverquestCharacterHasteMetric, "%", now, s.haste, s.zone));
-  }
 
   if (metrics.empty()) return "";
 
@@ -586,7 +1165,8 @@ std::string OtlpExporter::build_metrics_payload() {
 }
 
 
-void OtlpExporter::note_fight_damage(const std::string &raw_target, bool outgoing, long long dmg) {
+void OtlpExporter::note_fight_damage(const std::string &raw_target, const std::string &attacker,
+                                     bool outgoing, long long dmg) {
   const unsigned long long now = now_unix_nano();
   ActiveFight &f = active_fights[raw_target];
   if (f.start_ns == 0) {
@@ -596,6 +1176,18 @@ void OtlpExporter::note_fight_damage(const std::string &raw_target, bool outgoin
   }
   f.last_ns = now;
   (outgoing ? f.dmg_out : f.dmg_in) += dmg;
+
+  if (!attacker.empty()) {
+    // Engaged time, accumulated between consecutive hits. A gap longer than kAttackerIdleNs is
+    // downtime rather than slow swings - counting it would flatter a caster who nuked once at the
+    // start and once at the end into looking continuously engaged.
+    auto &entry = f.attacker_activity[attacker];
+    if (entry.first != 0 && now > entry.first) {
+      const unsigned long long gap = now - entry.first;
+      if (gap <= kAttackerIdleNs) entry.second += gap / 1e9;
+    }
+    entry.first = now;
+  }
 }
 
 void OtlpExporter::end_fight(const std::string &key, const char *outcome, unsigned long long end_ns) {
@@ -609,12 +1201,32 @@ void OtlpExporter::end_fight(const std::string &key, const char *outcome, unsign
   sp.name = "fight " + f.display;
   sp.start_ns = f.start_ns;
   sp.end_ns = end_ns ? end_ns : f.last_ns;
+#ifdef ZEAL_OTEL_SDK
+  {
+    // Fight-scoped totals, so damage can be divided by a time that means something: the fight's
+    // duration gives SDPS, each attacker's engaged seconds gives DPS. Both are what the community
+    // parser prints, and matching its arithmetic is the difference between a number people use and
+    // a number people argue with.
+    const unsigned long long finished_ns = end_ns ? end_ns : f.last_ns;
+    const double duration_s = (finished_ns > f.start_ns) ? (finished_ns - f.start_ns) / 1e9 : 0.0;
+    std::vector<std::pair<std::string, double>> active;
+    active.reserve(f.attacker_activity.size());
+    for (const auto &[who, act] : f.attacker_activity) {
+      // A single hit has no measurable span; credit it with one swing so a one-shot kill does not
+      // divide by zero and report an infinite rate.
+      active.emplace_back(who, act.second > 0.0 ? act.second : 1.0);
+    }
+    zeal::instrumentation::RecordFightTotals(key, zone_active, duration_s, active);
+  }
+  (void)sp;
+#else
   sp.str_attrs = {{everquest_semconv::kEverquestCombatTarget, key}, {everquest_semconv::kEverquestZoneName, zone_active}, {"everquest.fight.outcome", outcome}};
   sp.int_attrs = {{"everquest.fight.damage.dealt", f.dmg_out}, {"everquest.fight.damage.taken", f.dmg_in}};
   {
     std::lock_guard<std::mutex> lock(spans_mutex);
     completed_spans.push_back(std::move(sp));
   }
+#endif
   active_fights.erase(it);
 }
 
@@ -628,6 +1240,7 @@ void OtlpExporter::fight_tick() {
       ++it;
       end_fight(key, "zoned", 0);
     }
+#ifndef ZEAL_OTEL_SDK
     if (!zone_active.empty() && zone_start_ns) {  // close the previous zone-session span
       FightSpan sp;
       sp.trace_id = zone_trace_id;
@@ -639,6 +1252,7 @@ void OtlpExporter::fight_tick() {
       std::lock_guard<std::mutex> lock(spans_mutex);
       completed_spans.push_back(std::move(sp));
     }
+#endif
     zone_active = zone;
     if (!zone.empty()) {
       zone_trace_id = hex_id(16);
@@ -717,59 +1331,3 @@ std::string OtlpExporter::build_traces_payload() {
   return payload.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
 }
 
-bool OtlpExporter::post_json(const std::string &path, const std::string &json_body) {
-  std::string url = setting_endpoint.get() + path;
-  std::wstring wurl(url.begin(), url.end());
-
-  URL_COMPONENTS uc = {0};
-  uc.dwStructSize = sizeof(uc);
-  wchar_t host[256] = {0};
-  wchar_t url_path[1024] = {0};
-  uc.lpszHostName = host;
-  uc.dwHostNameLength = _countof(host);
-  uc.lpszUrlPath = url_path;
-  uc.dwUrlPathLength = _countof(url_path);
-  if (!WinHttpCrackUrl(wurl.c_str(), 0, 0, &uc)) return false;
-
-  bool ok = false;
-  HINTERNET session = WinHttpOpen(L"Zeal-OTLP/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME,
-                                  WINHTTP_NO_PROXY_BYPASS, 0);
-  if (session) {
-    // Bound every phase so a slow/unreachable endpoint can't hang the sender thread (and thus the
-    // join() on shutdown). Values in ms: resolve, connect, send, receive.
-    WinHttpSetTimeouts(session, 2000, 2000, 2000, 3000);
-    HINTERNET connect = WinHttpConnect(session, host, uc.nPort, 0);
-    if (connect) {
-      DWORD flags = (uc.nScheme == INTERNET_SCHEME_HTTPS) ? WINHTTP_FLAG_SECURE : 0;
-      HINTERNET request = WinHttpOpenRequest(connect, L"POST", url_path, nullptr, WINHTTP_NO_REFERER,
-                                             WINHTTP_DEFAULT_ACCEPT_TYPES, flags);
-      if (request) {
-        const wchar_t *headers = L"Content-Type: application/json";
-        if (WinHttpSendRequest(request, headers, -1L, (LPVOID)json_body.data(),
-                               static_cast<DWORD>(json_body.size()), static_cast<DWORD>(json_body.size()), 0) &&
-            WinHttpReceiveResponse(request, nullptr)) {
-          DWORD status = 0, size = sizeof(status);
-          WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX,
-                              &status, &size, WINHTTP_NO_HEADER_INDEX);
-          last_http_status.store(static_cast<int>(status));
-          ok = (status >= 200 && status < 300);
-          if (!ok) {
-            // Keep the server's explanation — it names the exact problem (e.g. a malformed field),
-            // which is otherwise invisible from in-game.
-            std::string body;
-            char buf[512];
-            DWORD read = 0;
-            while (body.size() < 400 && WinHttpReadData(request, buf, sizeof(buf), &read) && read > 0)
-              body.append(buf, read);
-            std::lock_guard<std::mutex> lock(last_error_mutex);
-            last_error = path + " -> " + std::to_string(status) + " " + body.substr(0, 300);
-          }
-        }
-        WinHttpCloseHandle(request);
-      }
-      WinHttpCloseHandle(connect);
-    }
-    WinHttpCloseHandle(session);
-  }
-  return ok;
-}

--- a/Zeal/otlp_exporter.cpp
+++ b/Zeal/otlp_exporter.cpp
@@ -1,0 +1,775 @@
+#include "otlp_exporter.h"
+
+#include "everquest_semconv.h"  // generated from the semconv registry (see everquest-semconv/generate.sh)
+
+#include <winhttp.h>
+
+#include <cctype>
+#include <chrono>
+#include <cstdlib>
+#include <random>
+
+#include "callbacks.h"
+#include "chat.h"
+#include "commands.h"
+#include "entity_manager.h"
+#include "game_functions.h"
+#include "game_structures.h"
+#include "json.hpp"
+#include "labels.h"
+#include "string_util.h"
+#include "zeal.h"
+
+#pragma comment(lib, "winhttp.lib")
+
+namespace {
+// OTLP/HTTP JSON encodes 64-bit integer fields (timeUnixNano, AnyValue.intValue) as strings.
+nlohmann::json string_attr(const char *key, const std::string &value) {
+  return {{"key", key}, {"value", {{"stringValue", value}}}};
+}
+nlohmann::json int_attr(const char *key, long long value) {
+  return {{"key", key}, {"value", {{"intValue", std::to_string(value)}}}};
+}
+
+unsigned long long now_unix_nano() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+// Random hex id for traces/spans (game thread only; single static generator).
+std::string hex_id(int bytes) {
+  static std::mt19937_64 rng(std::random_device{}() ^ GetTickCount64());
+  static const char *digits = "0123456789abcdef";
+  std::string out;
+  out.reserve(bytes * 2);
+  for (int i = 0; i < bytes; i += 8) {
+    unsigned long long v = rng();
+    for (int b = 0; b < 8 && (i + b) < bytes; b++) {
+      out.push_back(digits[(v >> (b * 8 + 4)) & 0xF]);
+      out.push_back(digits[(v >> (b * 8)) & 0xF]);
+    }
+  }
+  return out;
+}
+
+// "a_temple_guard00" -> "a temple guard" (lowercase, underscores to spaces, trailing digits dropped)
+std::string display_of(const std::string &raw) {
+  std::string d = raw;
+  while (!d.empty() && isdigit(static_cast<unsigned char>(d.back()))) d.pop_back();
+  for (auto &c : d) c = (c == '_') ? ' ' : static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  return d;
+}
+
+// Full zone name of the local player ("" when not resolvable). Game thread only.
+std::string current_zone_name() {
+  Zeal::GameStructures::Entity *self = Zeal::Game::get_self();
+  if (!Zeal::Game::is_in_game() || !self) return "";
+  return Zeal::Game::get_full_zone_name(self->ZoneId);
+}
+
+const char *class_name(int class_id) {
+  switch (class_id) {
+    case 1: return "Warrior";
+    case 2: return "Cleric";
+    case 3: return "Paladin";
+    case 4: return "Ranger";
+    case 5: return "Shadowknight";
+    case 6: return "Druid";
+    case 7: return "Monk";
+    case 8: return "Bard";
+    case 9: return "Rogue";
+    case 10: return "Shaman";
+    case 11: return "Necromancer";
+    case 12: return "Wizard";
+    case 13: return "Magician";
+    case 14: return "Enchanter";
+    case 15: return "Beastlord";
+    default: return "Unknown";
+  }
+}
+
+// Parses an EverQuest combat log line for damage the player is directly involved in and, if found,
+// fills direction ("outgoing"/"incoming"), type (the melee verb or "spell"), and amount. Returns
+// false for lines that aren't self-involved damage (e.g. a group member's hits) so they aren't
+// double counted. EQ renders the local player as "You"/"YOU".
+// Maps an EQ melee SkillType (Damage_Struct.type) to a canonical damage-type label.
+const char *melee_type_name(unsigned short skill) {
+  using S = Zeal::GameEnums::SkillType;
+  switch (skill) {
+    case S::Skill1HSlashing:
+    case S::Skill2HSlashing:
+      return "slash";
+    case S::Skill1HBlunt:
+    case S::Skill2HBlunt:
+      return "crush";
+    case S::Skill1HPiercing:
+      return "pierce";
+    case S::SkillBash:
+      return "bash";
+    case S::SkillKick:
+    case S::SkillFlyingKick:
+    case S::SkillRoundKick:
+      return "kick";
+    case S::SkillHandtoHand:
+      return "hth";
+    case S::SkillBackstab:
+      return "backstab";
+    case S::SkillArchery:
+      return "archery";
+    case S::SkillDragonPunch:
+    case S::SkillEagleStrike:
+      return "special";
+    default:
+      return "melee";
+  }
+}
+
+}  // namespace
+
+OtlpExporter::OtlpExporter(ZealService *zeal) {
+  start_time_unix_nano = now_unix_nano();
+  worker = std::thread([this]() { worker_loop(); });
+
+  // Emit every print-to-chat line as a log record and mine it for combat damage. This is the live
+  // source (the pipe uses the same callback); registering our own keeps OTLP independent of whether
+  // the pipe has a reader connected.
+  zeal->chat_hook->add_print_chat_callback([this](const char *data, int color_index) {
+    if (!is_enabled() || !data) return;
+    log(data, color_index);
+    // DoT ticks and heal amounts never fire the hit event and are only messaged to the involved
+    // client, so text is the correct (and self-reporting, non-duplicating) channel for them.
+    parse_dot_or_heal(data);
+    handle_slain_line(data);
+  });
+
+  // (see parse_dot_or_heal below for DoT/heal text handling)
+  // Combat damage from the actual hit event (spawn IDs resolved to entities) — far more reliable than
+  // parsing chat text: exact attacker/target, damage, and skill/spell, incl. charmed pets.
+  zeal->callbacks->AddReportSuccessfulHit([this](Zeal::GameStructures::Entity *source,
+                                                 Zeal::GameStructures::Entity *target, WORD type, short spell_id,
+                                                 short damage, char) {
+    if (!is_enabled() || !source || damage <= 0) return;
+    Zeal::GameStructures::Entity *attacker = source;
+    if (attacker->PetOwnerSpawnId != 0) {  // credit a pet's damage to its owner (charmed or summoned)
+      auto *owner = ZealService::get_instance()->entity_manager->Get(attacker->PetOwnerSpawnId);
+      if (owner) attacker = owner;
+    }
+    std::string src = attacker->Name;
+    const char *src_type = (attacker->Type == Zeal::GameEnums::EntityTypes::Player) ? "player" : "npc";
+    const char *direction = (target && target == Zeal::Game::get_self()) ? "incoming" : "outgoing";
+    const char *dtype = (spell_id > 0) ? "spell" : melee_type_name(type);
+    const std::string tgt = target ? target->Name : "";  // raw spawn name, e.g. "a_temple_guard00"
+    if (in_combat_scope(src)) record_combat_damage(src, src_type, direction, dtype, tgt, damage);
+    // Fight spans: track encounters with NPCs (the mob is the target when we hit it, the source
+    // when it hits us).
+    const bool outgoing = (direction[0] == 'o');
+    const std::string mob = outgoing ? tgt : std::string(source->Name);
+    if (!mob.empty()) note_fight_damage(mob, outgoing, damage);
+  });
+
+  // Sample live game state on the game thread (MainLoop); the sender thread only ever serializes the
+  // cached snapshot, so it never races the game thread reading/freeing character structures.
+  zeal->callbacks->AddGeneric([this]() {
+    sample_game_state();
+    if (is_enabled()) fight_tick();
+  });
+
+  zeal->commands_hook->Add("/otlp", {}, "OTLP/HTTP telemetry export. Usage: /otlp on|off|status|endpoint <url>",
+                           [this](std::vector<std::string> &args) {
+                             if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "on")) {
+                               setting_enabled.set(true);
+                               Zeal::Game::print_chat("OTLP export enabled -> %s/v1/logs",
+                                                      setting_endpoint.get().c_str());
+                               return true;
+                             }
+                             if (args.size() == 2 && Zeal::String::compare_insensitive(args[1], "off")) {
+                               setting_enabled.set(false);
+                               Zeal::Game::print_chat("OTLP export disabled.");
+                               return true;
+                             }
+                             if (args.size() == 3 && Zeal::String::compare_insensitive(args[1], "endpoint")) {
+                               setting_endpoint.set(args[2]);
+                               Zeal::Game::print_chat("OTLP endpoint set to %s", args[2].c_str());
+                               return true;
+                             }
+                             if (args.size() == 3 && Zeal::String::compare_insensitive(args[1], "flush")) {
+                               int ms = 0;
+                               if (!Zeal::String::tryParse(args[2], &ms)) {
+                                 Zeal::Game::print_chat("Usage: /otlp flush <milliseconds>");
+                                 return true;
+                               }
+                               if (ms < kMinFlushMs) ms = kMinFlushMs;  // Clamp: metrics are periodic; 0 would just hammer.
+                               setting_flush_ms.set(ms);
+                               Zeal::Game::print_chat("OTLP flush interval set to %ims", ms);
+                               return true;
+                             }
+                             if (args.size() == 3 && Zeal::String::compare_insensitive(args[1], "scope")) {
+                               if (Zeal::String::compare_insensitive(args[2], "self") ||
+                                   Zeal::String::compare_insensitive(args[2], "all")) {
+                                 setting_combat_scope.set(Zeal::String::compare_insensitive(args[2], "all") ? "all"
+                                                                                                           : "self");
+                                 Zeal::Game::print_chat("OTLP combat scope: %s", setting_combat_scope.get().c_str());
+                               } else {
+                                 Zeal::Game::print_chat("Usage: /otlp scope self|all  (self=you+pet, all=everyone)");
+                               }
+                               return true;
+                             }
+                             Zeal::Game::print_chat("OTLP: %s, endpoint %s, flush %ims, scope %s",
+                                                    setting_enabled.get() ? "enabled" : "disabled",
+                                                    setting_endpoint.get().c_str(), setting_flush_ms.get(),
+                                                    setting_combat_scope.get().c_str());
+                             Zeal::Game::print_chat("  sent: %llu log batches-worth, %llu metric posts, %llu failed",
+                                                    logs_posted.load(), metrics_posted.load(), failed_posts.load());
+                             Zeal::Game::print_chat("  last HTTP status: %i", last_http_status.load());
+                             {
+                               std::lock_guard<std::mutex> lock(last_error_mutex);
+                               if (!last_error.empty())
+                                 Zeal::Game::print_chat(USERCOLOR_SPELL_FAILURE, "  last error: %s",
+                                                        last_error.c_str());
+                             }
+                             Zeal::Game::print_chat("Usage: /otlp on|off|status|endpoint <url>|flush <ms>|scope self|all");
+                             return true;
+                           });
+}
+
+OtlpExporter::~OtlpExporter() {
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex);
+    end_thread = true;
+  }
+  queue_cv.notify_all();
+  if (worker.joinable()) worker.join();
+}
+
+void OtlpExporter::log(const std::string &body, int color_index) {
+  if (!setting_enabled.get() || body.empty()) return;
+
+  LogRecord record;
+  record.time_unix_nano = now_unix_nano();
+  record.body = body;
+  record.color_index = color_index;
+  if (Zeal::Game::is_in_game() && Zeal::Game::get_self()) record.zone_id = Zeal::Game::get_self()->ZoneId;
+
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex);
+    queue.push_back(std::move(record));
+  }
+  queue_cv.notify_one();
+}
+
+void OtlpExporter::worker_loop() {
+  while (true) {
+    std::vector<LogRecord> batch;
+    {
+      std::unique_lock<std::mutex> lock(queue_mutex);
+      const int configured = setting_flush_ms.get();
+      const int interval = configured > 0 ? (configured < kMinFlushMs ? kMinFlushMs : configured) : 2000;
+      queue_cv.wait_for(lock, std::chrono::milliseconds(interval),
+                        [this]() { return end_thread || !queue.empty(); });
+      if (end_thread && queue.empty()) return;
+
+      const int max_batch = setting_max_batch.get() > 0 ? setting_max_batch.get() : 512;
+      while (!queue.empty() && static_cast<int>(batch.size()) < max_batch) {
+        batch.push_back(std::move(queue.front()));
+        queue.pop_front();
+      }
+    }
+
+    if (!setting_enabled.get()) continue;
+
+    try {
+      if (!batch.empty()) {
+        if (post_json("/v1/logs", build_logs_payload(batch)))
+          logs_posted += batch.size();
+        else
+          failed_posts++;
+      }
+      // Metrics use cumulative temporality, so emit the current snapshot every flush even when no
+      // new log lines arrived this cycle.
+      std::string metrics = build_metrics_payload();
+      if (!metrics.empty()) {
+        if (post_json("/v1/metrics", metrics))
+          metrics_posted++;
+        else
+          failed_posts++;
+      }
+      std::string traces = build_traces_payload();
+      if (!traces.empty() && !post_json("/v1/traces", traces)) failed_posts++;
+    } catch (const std::exception &) {
+      // Never let telemetry take down the game; drop this cycle on failure.
+    }
+  }
+}
+
+void OtlpExporter::sample_game_state() {
+  if (!setting_enabled.get()) return;  // No need to read game memory while export is off.
+
+  Snapshot s;
+  Zeal::GameStructures::GAMECHARINFO *ci = Zeal::Game::get_char_info();
+  if (Zeal::Game::is_in_game() && ci) {
+    s.in_game = true;
+    s.name = ci->Name;
+    s.zone = current_zone_name();
+    s.class_name = class_name(ci->Class);
+    s.level = ci->Level;
+    s.deity = ci->Deity;
+    s.aa_unspent = ci->AlternateAdvancementUnspent;
+    s.str = ci->BaseSTR;
+    s.sta = ci->BaseSTA;
+    s.dex = ci->BaseDEX;
+    s.agi = ci->BaseAGI;
+    s.wis = ci->BaseWIS;
+    s.intel = ci->BaseINT;
+    s.cha = ci->BaseCHA;
+
+    ZealService *zeal = ZealService::get_instance();
+    std::string offense;
+    if (zeal->labels_hook && zeal->labels_hook->GetLabel(23, offense)) {  // 23 = CurrentOffense (attack rating).
+      s.have_attack = true;
+      s.attack = atoll(offense.c_str());
+    }
+    Zeal::GameStructures::Entity *self = Zeal::Game::get_self();
+    if (self) {
+      // ModifyAttackSpeed applies total effective haste (worn + spell + overhaste) to a reference
+      // delay; derive the haste percentage from the ratio.
+      unsigned int modified = self->ModifyAttackSpeed(1000, 0);
+      long long haste = (modified > 0) ? static_cast<long long>((1000.0 - modified) * 100.0 / modified + 0.5) : 0;
+      s.have_haste = true;
+      s.haste = haste < 0 ? 0 : haste;
+    }
+  }
+
+  std::lock_guard<std::mutex> lock(snapshot_mutex);
+  snapshot = std::move(s);
+}
+
+// Builds the OTLP resource attributes shared by all signals from the cached snapshot: the service
+// identity plus, when in game, the character context (identity + slowly-changing stats). Per OTLP
+// guidance this belongs on the Resource — low cardinality, describes the entity producing telemetry,
+// and enriches logs and metrics alike without inflating metric attribute cardinality.
+nlohmann::json OtlpExporter::build_resource_attributes() const {
+  nlohmann::json attrs = nlohmann::json::array();
+  attrs.push_back(string_attr("service.name", "everquest"));
+  attrs.push_back(string_attr("service.version", ZEAL_VERSION));
+  attrs.push_back(string_attr("telemetry.sdk.name", "zeal"));
+
+  Snapshot s;
+  {
+    std::lock_guard<std::mutex> lock(snapshot_mutex);
+    s = snapshot;
+  }
+  if (s.in_game) {
+    // Character name doubles as the service instance id so a shared backend can tell players apart.
+    attrs.push_back(string_attr("service.instance.id", s.name));
+    attrs.push_back(string_attr(everquest_semconv::kEverquestCharacterName, s.name));
+    attrs.push_back(string_attr(everquest_semconv::kEverquestCharacterClass, s.class_name));
+    attrs.push_back(int_attr(everquest_semconv::kEverquestCharacterLevel, s.level));
+    attrs.push_back(int_attr(everquest_semconv::kEverquestCharacterDeity, s.deity));
+    attrs.push_back(int_attr(everquest_semconv::kEverquestCharacterAaUnspent, s.aa_unspent));
+    attrs.push_back(int_attr("everquest.character.stat.strength", s.str));
+    attrs.push_back(int_attr("everquest.character.stat.stamina", s.sta));
+    attrs.push_back(int_attr("everquest.character.stat.dexterity", s.dex));
+    attrs.push_back(int_attr("everquest.character.stat.agility", s.agi));
+    attrs.push_back(int_attr("everquest.character.stat.wisdom", s.wis));
+    attrs.push_back(int_attr("everquest.character.stat.intelligence", s.intel));
+    attrs.push_back(int_attr("everquest.character.stat.charisma", s.cha));
+  }
+  return attrs;
+}
+
+std::string OtlpExporter::build_logs_payload(const std::vector<LogRecord> &records) const {
+  nlohmann::json log_records = nlohmann::json::array();
+  for (const auto &r : records) {
+    // Character identity now lives on the Resource; keep only per-line context here.
+    nlohmann::json attributes = nlohmann::json::array();
+    attributes.push_back(int_attr(everquest_semconv::kEverquestChatColor, r.color_index));
+    if (r.zone_id >= 0) attributes.push_back(int_attr(everquest_semconv::kEverquestZoneId, r.zone_id));
+
+    log_records.push_back({{"timeUnixNano", std::to_string(r.time_unix_nano)},
+                           {"severityNumber", 9},  // INFO
+                           {"severityText", "INFO"},
+                           {"body", {{"stringValue", r.body}}},
+                           {"attributes", attributes}});
+  }
+
+  nlohmann::json payload = {
+      {"resourceLogs",
+       {{{"resource", {{"attributes", build_resource_attributes()}}},
+         {"scopeLogs",
+          {{{"scope", {{"name", "zeal"}, {"version", ZEAL_VERSION}}}, {"logRecords", log_records}}}}}}}};
+  // EQ log lines can contain stray non-printable bytes; replace invalid UTF-8 rather than letting
+  // dump() throw and drop the whole batch.
+  return payload.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
+}
+
+bool OtlpExporter::in_combat_scope(const std::string &source) const {
+  if (setting_combat_scope.get() != "self") return true;  // "all" (or anything non-"self") records everyone.
+  // Self scope: only the local character and its pet (runs on the game thread via the chat callback).
+  Zeal::GameStructures::GAMECHARINFO *ci = Zeal::Game::get_char_info();
+  if (ci && source == ci->Name) return true;
+  std::string pet;
+  if (ZealService::get_instance()->labels_hook &&
+      ZealService::get_instance()->labels_hook->GetLabel(68, pet) && !pet.empty() && source == pet)
+    return true;  // 68 = PlayerPetName
+  return false;
+}
+
+void OtlpExporter::record_combat_damage(const std::string &source, const std::string &source_type,
+                                        const std::string &direction, const std::string &type,
+                                        const std::string &target, long long amount) {
+  const std::string zone = current_zone_name();  // where the hit happened (game thread)
+  std::lock_guard<std::mutex> lock(metrics_mutex);
+  CombatTotal &entry = combat_damage[{source, source_type, direction, type, zone, target}];
+  entry.total += amount;
+  entry.last_ms = GetTickCount64();
+}
+
+void OtlpExporter::record_heal(const std::string &source, const std::string &direction, long long amount) {
+  const std::string zone = current_zone_name();
+  std::lock_guard<std::mutex> lock(metrics_mutex);
+  combat_heal[{source, direction, zone}] += amount;
+}
+
+// Extracts the positive integer that starts at line[pos] (returns 0 if none).
+static long long read_number(const std::string &line, size_t pos) {
+  size_t end = pos;
+  while (end < line.size() && isdigit(static_cast<unsigned char>(line[end]))) end++;
+  return (end > pos) ? atoll(line.substr(pos, end - pos).c_str()) : 0;
+}
+
+void OtlpExporter::parse_dot_or_heal(const std::string &line) {
+  const char *self = Zeal::Game::get_self() ? Zeal::Game::get_self()->Name : nullptr;
+  if (!self) return;
+
+  // DoT tick (caster-side): "<target> has taken <N> damage from your <spell>."
+  // Observer form:          "<target> has taken <N> damage from <caster>'s <spell>."
+  size_t p = line.find(" has taken ");
+  if (p != std::string::npos) {
+    long long amount = read_number(line, p + 11);
+    size_t from = line.find(" damage from ", p);
+    if (amount > 0 && from != std::string::npos) {
+      const std::string dot_target = line.substr(0, p);  // display name; chat has no instance digits
+      std::string rest = line.substr(from + 13);
+      if (rest.rfind("your ", 0) == 0) {
+        record_combat_damage(self, "player", "outgoing", "dot", dot_target, amount);
+      } else {
+        size_t apos = rest.find("'s ");  // "<caster>'s <spell>"
+        if (apos != std::string::npos && setting_combat_scope.get() != "self") {
+          std::string caster = rest.substr(0, apos);
+          auto *e = ZealService::get_instance()->entity_manager->Get(caster);
+          const char *ct = (e && e->Type == Zeal::GameEnums::EntityTypes::Player) ? "player" : "npc";
+          record_combat_damage(caster, ct, "outgoing", "dot", dot_target, amount);
+        }
+      }
+    }
+    return;
+  }
+
+  // Heal done (caster-side): "You have healed <target> for <N> points."
+  p = line.find("You have healed ");
+  if (p == 0) {
+    size_t f = line.find(" for ", 16);
+    if (f != std::string::npos) {
+      long long amount = read_number(line, f + 5);
+      if (amount > 0) record_heal(self, "outgoing", amount);
+    }
+    return;
+  }
+
+  // Heal received (target-side): "You have been healed for <N> points."
+  p = line.find("You have been healed for ");
+  if (p == 0) {
+    long long amount = read_number(line, 25);
+    if (amount > 0) record_heal(self, "incoming", amount);
+  }
+}
+
+// Builds a single-value gauge metric as an OTLP metric object (zone attached when known).
+static nlohmann::json gauge_metric(const char *name, const char *unit, const std::string &now, long long value,
+                                   const std::string &zone) {
+  nlohmann::json point = {{"timeUnixNano", now}, {"asInt", std::to_string(value)}};
+  // NOTE: must be an explicit array — a braced-init with a single object collapses into an object,
+  // which the OTLP receiver rejects ("ReadArray: expect [ ..."), failing the whole payload.
+  if (!zone.empty()) point["attributes"] = nlohmann::json::array({string_attr(everquest_semconv::kEverquestZoneName, zone)});
+  nlohmann::json metric;
+  metric["name"] = name;
+  metric["unit"] = unit;
+  metric["gauge"] = {{"dataPoints", nlohmann::json::array({point})}};
+  return metric;
+}
+
+std::string OtlpExporter::build_metrics_payload() {
+  const std::string now = std::to_string(now_unix_nano());
+  const std::string start = std::to_string(start_time_unix_nano);
+  nlohmann::json metrics = nlohmann::json::array();
+
+  // Combat damage counter (cumulative monotonic Sum).
+  nlohmann::json data_points = nlohmann::json::array();
+  {
+    const unsigned long long now_ms = GetTickCount64();
+    std::lock_guard<std::mutex> lock(metrics_mutex);
+    for (auto it = combat_damage.begin(); it != combat_damage.end();) {
+      // Per-target series are unbounded over a session; stop exporting (and free) fights that have
+      // been idle. Prometheus keeps the history; if the same mob reappears rate() sees a reset.
+      if (now_ms - it->second.last_ms > kSeriesIdleMs) {
+        it = combat_damage.erase(it);
+        continue;
+      }
+      const auto &key = it->first;
+      data_points.push_back({{"attributes",
+                              {string_attr(everquest_semconv::kEverquestCombatSource, std::get<0>(key)),
+                               string_attr(everquest_semconv::kEverquestCombatSourceType, std::get<1>(key)),
+                               string_attr(everquest_semconv::kEverquestCombatDirection, std::get<2>(key)),
+                               string_attr(everquest_semconv::kEverquestCombatDamageType, std::get<3>(key)),
+                               string_attr(everquest_semconv::kEverquestZoneName, std::get<4>(key)),
+                               string_attr(everquest_semconv::kEverquestCombatTarget, std::get<5>(key))}},
+                             {"startTimeUnixNano", start},
+                             {"timeUnixNano", now},
+                             {"asInt", std::to_string(it->second.total)}});
+      ++it;
+    }
+  }
+  if (!data_points.empty()) {
+    nlohmann::json metric;
+    metric["name"] = everquest_semconv::kEverquestCombatDamageMetric;
+    metric["unit"] = "{hitpoint}";
+    metric["sum"] = {{"dataPoints", data_points}, {"aggregationTemporality", 2}, {"isMonotonic", true}};
+    metrics.push_back(metric);
+  }
+
+  // Healing counter (cumulative monotonic Sum), keyed by {source, direction}.
+  nlohmann::json heal_points = nlohmann::json::array();
+  {
+    std::lock_guard<std::mutex> lock(metrics_mutex);
+    for (const auto &[key, total] : combat_heal) {
+      heal_points.push_back({{"attributes",
+                              {string_attr(everquest_semconv::kEverquestCombatSource, std::get<0>(key)),
+                               string_attr(everquest_semconv::kEverquestCombatDirection, std::get<1>(key)),
+                               string_attr(everquest_semconv::kEverquestZoneName, std::get<2>(key))}},
+                             {"startTimeUnixNano", start},
+                             {"timeUnixNano", now},
+                             {"asInt", std::to_string(total)}});
+    }
+  }
+  if (!heal_points.empty()) {
+    nlohmann::json metric;
+    metric["name"] = everquest_semconv::kEverquestCombatHealMetric;
+    metric["unit"] = "{hitpoint}";
+    metric["sum"] = {{"dataPoints", heal_points}, {"aggregationTemporality", 2}, {"isMonotonic", true}};
+    metrics.push_back(metric);
+  }
+
+  // Attack (offense) and haste gauges for DPS correlation, read from the game-thread snapshot.
+  {
+    Snapshot s;
+    {
+      std::lock_guard<std::mutex> lock(snapshot_mutex);
+      s = snapshot;
+    }
+    if (s.have_attack) metrics.push_back(gauge_metric(everquest_semconv::kEverquestCharacterAttackMetric, "1", now, s.attack, s.zone));
+    if (s.have_haste) metrics.push_back(gauge_metric(everquest_semconv::kEverquestCharacterHasteMetric, "%", now, s.haste, s.zone));
+  }
+
+  if (metrics.empty()) return "";
+
+  nlohmann::json scope_metrics;
+  scope_metrics["scope"] = {{"name", "zeal"}, {"version", ZEAL_VERSION}};
+  scope_metrics["metrics"] = metrics;
+
+  nlohmann::json resource_metrics;
+  resource_metrics["resource"] = {{"attributes", build_resource_attributes()}};
+  resource_metrics["scopeMetrics"] = nlohmann::json::array({scope_metrics});
+
+  nlohmann::json payload;
+  payload["resourceMetrics"] = nlohmann::json::array({resource_metrics});
+  return payload.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
+}
+
+
+void OtlpExporter::note_fight_damage(const std::string &raw_target, bool outgoing, long long dmg) {
+  const unsigned long long now = now_unix_nano();
+  ActiveFight &f = active_fights[raw_target];
+  if (f.start_ns == 0) {
+    f.span_id = hex_id(8);
+    f.display = display_of(raw_target);
+    f.start_ns = now;
+  }
+  f.last_ns = now;
+  (outgoing ? f.dmg_out : f.dmg_in) += dmg;
+}
+
+void OtlpExporter::end_fight(const std::string &key, const char *outcome, unsigned long long end_ns) {
+  auto it = active_fights.find(key);
+  if (it == active_fights.end()) return;
+  const ActiveFight &f = it->second;
+  FightSpan sp;
+  sp.trace_id = zone_trace_id.empty() ? hex_id(16) : zone_trace_id;
+  sp.span_id = f.span_id;
+  sp.parent_span_id = zone_span_id;  // child of the zone-session span ("" when none)
+  sp.name = "fight " + f.display;
+  sp.start_ns = f.start_ns;
+  sp.end_ns = end_ns ? end_ns : f.last_ns;
+  sp.str_attrs = {{everquest_semconv::kEverquestCombatTarget, key}, {everquest_semconv::kEverquestZoneName, zone_active}, {"everquest.fight.outcome", outcome}};
+  sp.int_attrs = {{"everquest.fight.damage.dealt", f.dmg_out}, {"everquest.fight.damage.taken", f.dmg_in}};
+  {
+    std::lock_guard<std::mutex> lock(spans_mutex);
+    completed_spans.push_back(std::move(sp));
+  }
+  active_fights.erase(it);
+}
+
+void OtlpExporter::fight_tick() {
+  const unsigned long long now = now_unix_nano();
+  const std::string zone = current_zone_name();
+
+  if (zone != zone_active) {  // zone transition (incl. entering/leaving the world)
+    for (auto it = active_fights.begin(); it != active_fights.end();) {
+      const std::string key = it->first;
+      ++it;
+      end_fight(key, "zoned", 0);
+    }
+    if (!zone_active.empty() && zone_start_ns) {  // close the previous zone-session span
+      FightSpan sp;
+      sp.trace_id = zone_trace_id;
+      sp.span_id = zone_span_id;
+      sp.name = "zone " + zone_active;
+      sp.start_ns = zone_start_ns;
+      sp.end_ns = now;
+      sp.str_attrs = {{everquest_semconv::kEverquestZoneName, zone_active}};
+      std::lock_guard<std::mutex> lock(spans_mutex);
+      completed_spans.push_back(std::move(sp));
+    }
+    zone_active = zone;
+    if (!zone.empty()) {
+      zone_trace_id = hex_id(16);
+      zone_span_id = hex_id(8);
+      zone_start_ns = now;
+    } else {
+      zone_trace_id.clear();
+      zone_span_id.clear();
+      zone_start_ns = 0;
+    }
+    return;
+  }
+
+  // Idle sweep: a fight with no damage for kFightIdleNs is over (mob fled/reset/we moved on).
+  for (auto it = active_fights.begin(); it != active_fights.end();) {
+    const std::string key = it->first;
+    const bool idle = (now - it->second.last_ns) > kFightIdleNs;
+    ++it;
+    if (idle) end_fight(key, "idle", 0);
+  }
+}
+
+void OtlpExporter::handle_slain_line(const std::string &line) {
+  if (active_fights.empty()) return;
+  std::string dead;
+  size_t p = line.find(" has been slain");
+  if (p != std::string::npos) {
+    dead = line.substr(0, p);
+  } else if (line.rfind("You have slain ", 0) == 0) {
+    size_t bang = line.find('!');
+    dead = line.substr(15, (bang == std::string::npos ? line.size() : bang) - 15);
+  } else {
+    return;
+  }
+  for (auto &c : dead) c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  for (auto &[key, f] : active_fights) {
+    if (f.display == dead) {
+      end_fight(key, "killed", now_unix_nano());
+      return;
+    }
+  }
+}
+
+std::string OtlpExporter::build_traces_payload() {
+  std::vector<FightSpan> batch;
+  {
+    std::lock_guard<std::mutex> lock(spans_mutex);
+    if (completed_spans.empty()) return "";
+    batch.swap(completed_spans);
+  }
+  nlohmann::json spans = nlohmann::json::array();
+  for (const auto &sp : batch) {
+    nlohmann::json attrs = nlohmann::json::array();
+    for (const auto &[k, v] : sp.str_attrs) attrs.push_back(string_attr(k.c_str(), v));
+    for (const auto &[k, v] : sp.int_attrs) attrs.push_back(int_attr(k.c_str(), v));
+    nlohmann::json j;
+    j["traceId"] = sp.trace_id;
+    j["spanId"] = sp.span_id;
+    if (!sp.parent_span_id.empty()) j["parentSpanId"] = sp.parent_span_id;
+    j["name"] = sp.name;
+    j["kind"] = 1;  // SPAN_KIND_INTERNAL
+    j["startTimeUnixNano"] = std::to_string(sp.start_ns);
+    j["endTimeUnixNano"] = std::to_string(sp.end_ns);
+    j["attributes"] = attrs;
+    j["status"] = nlohmann::json::object();
+    spans.push_back(j);
+  }
+  nlohmann::json scope_spans;
+  scope_spans["scope"] = {{"name", "zeal"}, {"version", ZEAL_VERSION}};
+  scope_spans["spans"] = spans;
+  nlohmann::json resource_spans;
+  resource_spans["resource"] = {{"attributes", build_resource_attributes()}};
+  resource_spans["scopeSpans"] = nlohmann::json::array({scope_spans});
+  nlohmann::json payload;
+  payload["resourceSpans"] = nlohmann::json::array({resource_spans});
+  return payload.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
+}
+
+bool OtlpExporter::post_json(const std::string &path, const std::string &json_body) {
+  std::string url = setting_endpoint.get() + path;
+  std::wstring wurl(url.begin(), url.end());
+
+  URL_COMPONENTS uc = {0};
+  uc.dwStructSize = sizeof(uc);
+  wchar_t host[256] = {0};
+  wchar_t url_path[1024] = {0};
+  uc.lpszHostName = host;
+  uc.dwHostNameLength = _countof(host);
+  uc.lpszUrlPath = url_path;
+  uc.dwUrlPathLength = _countof(url_path);
+  if (!WinHttpCrackUrl(wurl.c_str(), 0, 0, &uc)) return false;
+
+  bool ok = false;
+  HINTERNET session = WinHttpOpen(L"Zeal-OTLP/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME,
+                                  WINHTTP_NO_PROXY_BYPASS, 0);
+  if (session) {
+    // Bound every phase so a slow/unreachable endpoint can't hang the sender thread (and thus the
+    // join() on shutdown). Values in ms: resolve, connect, send, receive.
+    WinHttpSetTimeouts(session, 2000, 2000, 2000, 3000);
+    HINTERNET connect = WinHttpConnect(session, host, uc.nPort, 0);
+    if (connect) {
+      DWORD flags = (uc.nScheme == INTERNET_SCHEME_HTTPS) ? WINHTTP_FLAG_SECURE : 0;
+      HINTERNET request = WinHttpOpenRequest(connect, L"POST", url_path, nullptr, WINHTTP_NO_REFERER,
+                                             WINHTTP_DEFAULT_ACCEPT_TYPES, flags);
+      if (request) {
+        const wchar_t *headers = L"Content-Type: application/json";
+        if (WinHttpSendRequest(request, headers, -1L, (LPVOID)json_body.data(),
+                               static_cast<DWORD>(json_body.size()), static_cast<DWORD>(json_body.size()), 0) &&
+            WinHttpReceiveResponse(request, nullptr)) {
+          DWORD status = 0, size = sizeof(status);
+          WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX,
+                              &status, &size, WINHTTP_NO_HEADER_INDEX);
+          last_http_status.store(static_cast<int>(status));
+          ok = (status >= 200 && status < 300);
+          if (!ok) {
+            // Keep the server's explanation — it names the exact problem (e.g. a malformed field),
+            // which is otherwise invisible from in-game.
+            std::string body;
+            char buf[512];
+            DWORD read = 0;
+            while (body.size() < 400 && WinHttpReadData(request, buf, sizeof(buf), &read) && read > 0)
+              body.append(buf, read);
+            std::lock_guard<std::mutex> lock(last_error_mutex);
+            last_error = path + " -> " + std::to_string(status) + " " + body.substr(0, 300);
+          }
+        }
+        WinHttpCloseHandle(request);
+      }
+      WinHttpCloseHandle(connect);
+    }
+    WinHttpCloseHandle(session);
+  }
+  return ok;
+}

--- a/Zeal/otlp_exporter.h
+++ b/Zeal/otlp_exporter.h
@@ -1,0 +1,159 @@
+#pragma once
+#include <Windows.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "json.hpp"
+#include "zeal_settings.h"
+
+// OtlpExporter emits telemetry from Zeal directly over OTLP/HTTP using the JSON encoding, so the
+// game client can talk to an OpenTelemetry backend (e.g. Ourios) or Collector without an external
+// pipe-reading sidecar.
+//
+// This first iteration implements the logs signal only: game log/chat lines are queued on the game
+// thread (non-blocking) and flushed by a background worker thread that POSTs an OTLP/HTTP JSON
+// payload to <endpoint>/v1/logs. Metrics and traces will follow the same queue+worker pattern.
+class OtlpExporter {
+ public:
+  OtlpExporter(class ZealService *zeal);
+  ~OtlpExporter();
+
+  bool is_enabled() const { return setting_enabled.get(); }
+
+  // Queues a single log record. Thread-safe and non-blocking; returns immediately (and drops the
+  // record) when disabled so callers can gate cheaply on is_enabled(). color_index is the EQ chat
+  // color, recorded as a log attribute.
+  void log(const std::string &body, int color_index);
+
+ private:
+  struct LogRecord {
+    unsigned long long time_unix_nano = 0;
+    std::string body;
+    int color_index = 0;
+    int zone_id = -1;
+  };
+
+  // Cached game-state read on the game thread and consumed by the sender thread, so the sender never
+  // touches live game memory (which the game thread may be mutating/freeing during zone/camp/logout).
+  struct Snapshot {
+    bool in_game = false;
+    std::string name;
+    std::string zone;  // full zone name, e.g. "Mons Letalis"
+    const char *class_name = "Unknown";
+    int level = 0, deity = 0, aa_unspent = 0;
+    int str = 0, sta = 0, dex = 0, agi = 0, wis = 0, intel = 0, cha = 0;
+    bool have_attack = false;
+    long long attack = 0;
+    bool have_haste = false;
+    long long haste = 0;
+  };
+
+  static constexpr int kMinFlushMs = 100;  // Floor on the flush interval; metrics are periodic snapshots.
+
+  // Runs on the game thread (MainLoop callback); refreshes `snapshot`.
+  void sample_game_state();
+
+  void worker_loop();
+  bool post_json(const std::string &path, const std::string &json_body);
+  std::string build_logs_payload(const std::vector<LogRecord> &records) const;
+  nlohmann::json build_resource_attributes() const;
+
+  // Accumulates the `eq.combat.damage` counter, keyed by
+  // {source, source_type, direction, damage_type, zone, target}. `target` is the raw spawn name
+  // (instance digits included, e.g. "a_temple_guard00") so individual mobs are distinguishable.
+  void record_combat_damage(const std::string &source, const std::string &source_type, const std::string &direction,
+                            const std::string &type, const std::string &target, long long amount);
+  // Parses caster-side DoT ticks and heal messages from a chat line (they have no hit event).
+  void parse_dot_or_heal(const std::string &line);
+  // Accumulates the `eq.combat.heal` counter, keyed by {source, direction, zone}.
+  void record_heal(const std::string &source, const std::string &direction, long long amount);
+  // True if `source` should be recorded given the current scope setting (self+pet vs all attackers).
+  bool in_combat_scope(const std::string &source) const;
+  // Serializes the current cumulative counter snapshot as an OTLP metrics payload ("" if empty).
+  std::string build_metrics_payload();
+
+  // --- Fight/zone tracing (spans) -------------------------------------------------------------
+  struct FightSpan {  // a completed span, queued for export
+    std::string trace_id, span_id, parent_span_id, name;
+    unsigned long long start_ns = 0, end_ns = 0;
+    std::vector<std::pair<std::string, std::string>> str_attrs;
+    std::vector<std::pair<std::string, long long>> int_attrs;
+  };
+  struct ActiveFight {
+    std::string span_id;
+    std::string display;  // normalized display name, for matching "slain" chat lines
+    unsigned long long start_ns = 0, last_ns = 0;
+    long long dmg_out = 0, dmg_in = 0;
+  };
+
+  // Called from the hit event (game thread); opens the fight span on first damage.
+  void note_fight_damage(const std::string &raw_target, bool outgoing, long long dmg);
+  // Game-thread tick: zone-session transitions and idle-fight sweep.
+  void fight_tick();
+  // Ends one active fight into completed_spans. Caller holds no lock (game thread only state).
+  void end_fight(const std::string &key, const char *outcome, unsigned long long end_ns);
+  // Chat hook: "X has been slain..." / "You have slain X!" closes the matching fight.
+  void handle_slain_line(const std::string &line);
+  // Drains completed spans into an OTLP traces payload ("" if none).
+  std::string build_traces_payload();
+
+  ZealSetting<bool> setting_enabled = {false, "Zeal", "OtlpEnabled", false};
+  ZealSetting<std::string> setting_endpoint = {"http://127.0.0.1:4318", "Zeal", "OtlpEndpoint", false};
+  ZealSetting<int> setting_flush_ms = {2000, "Zeal", "OtlpFlushMs", false};
+  ZealSetting<int> setting_max_batch = {512, "Zeal", "OtlpMaxBatch", false};
+
+  std::deque<LogRecord> queue;
+  mutable std::mutex queue_mutex;
+  std::condition_variable queue_cv;
+  std::thread worker;
+  bool end_thread = false;
+
+  // Fixed start time for cumulative metric streams (set at construction).
+  unsigned long long start_time_unix_nano = 0;
+  static constexpr unsigned long long kSeriesIdleMs = 10 * 60 * 1000;  // stop exporting fights idle >10min
+
+  struct CombatTotal {
+    long long total = 0;
+    unsigned long long last_ms = 0;  // GetTickCount64 of last hit; prunes stale per-target series
+  };
+
+  std::mutex metrics_mutex;
+  // {source, source_type, direction, type, zone, target} -> running total.
+  std::map<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>, CombatTotal>
+      combat_damage;
+  // {source, direction(outgoing=done, incoming=received), zone} -> total hitpoints.
+  std::map<std::tuple<std::string, std::string, std::string>, long long> combat_heal;
+
+  // "self" = record only the local character + its pet (authoritative per-player, no double counting
+  // when the whole guild reports). "all" = record every attacker seen in the log (solo experiment).
+  ZealSetting<std::string> setting_combat_scope = {"self", "Zeal", "OtlpCombatScope", false};
+
+  // Lightweight send stats surfaced by `/otlp status`.
+  std::atomic<unsigned long long> logs_posted{0};
+  std::atomic<unsigned long long> metrics_posted{0};
+  std::atomic<unsigned long long> failed_posts{0};
+  std::atomic<int> last_http_status{0};
+  std::mutex last_error_mutex;
+  std::string last_error;  // response body / failure reason of the most recent failed post
+
+  mutable std::mutex snapshot_mutex;
+  Snapshot snapshot;
+
+  // Fight tracing state. active_* is touched ONLY on the game thread; completed_spans is the
+  // handoff queue to the sender thread (guarded by spans_mutex).
+  static constexpr unsigned long long kFightIdleNs = 30ULL * 1000000000ULL;  // fight ends after 30s without damage
+  std::string zone_trace_id, zone_span_id, zone_active;
+  unsigned long long zone_start_ns = 0;
+  std::map<std::string, ActiveFight> active_fights;  // key: raw target name
+  std::mutex spans_mutex;
+  std::vector<FightSpan> completed_spans;
+};

--- a/Zeal/otlp_exporter.h
+++ b/Zeal/otlp_exporter.h
@@ -7,21 +7,24 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <memory>
 #include <thread>
 #include <tuple>
 #include <utility>
 #include <vector>
 
 #include "json.hpp"
+#include "otlp_client.h"
 #include "zeal_settings.h"
 
-// OtlpExporter emits telemetry from Zeal directly over OTLP/HTTP using the JSON encoding, so the
-// game client can talk to an OpenTelemetry backend (e.g. Ourios) or Collector without an external
-// pipe-reading sidecar.
+// OtlpExporter is the instrumentation half of the exporter: it hooks the game, decides what a hit,
+// heal, or fight means, and encodes those into OTLP payloads. Everything that touches the network -
+// the worker thread, the flush timer, delivery and send statistics - lives in OtlpClient, which
+// knows nothing about EverQuest.
 //
-// This first iteration implements the logs signal only: game log/chat lines are queued on the game
-// thread (non-blocking) and flushed by a background worker thread that POSTs an OTLP/HTTP JSON
-// payload to <endpoint>/v1/logs. Metrics and traces will follow the same queue+worker pattern.
+// All three signals are emitted: logs (chat lines), metrics (combat, character, group) and traces
+// (zone sessions parenting fight spans). Game-thread callbacks only ever append to state; the
+// worker thread reads it through collect().
 class OtlpExporter {
  public:
   OtlpExporter(class ZealService *zeal);
@@ -55,15 +58,19 @@ class OtlpExporter {
     long long attack = 0;
     bool have_haste = false;
     long long haste = 0;
+    // The group's leader names the group; empty when ungrouped. Members includes the local
+    // character, and names people who are not running Zeal at all - which is the point: without it
+    // a group only ever appears as the subset of it that reports telemetry.
+    std::string group_leader;
+    std::vector<std::string> group_members;
   };
-
-  static constexpr int kMinFlushMs = 100;  // Floor on the flush interval; metrics are periodic snapshots.
 
   // Runs on the game thread (MainLoop callback); refreshes `snapshot`.
   void sample_game_state();
 
-  void worker_loop();
-  bool post_json(const std::string &path, const std::string &json_body);
+  // Called on the worker thread each flush: drains the log queue and snapshots the metric/span
+  // state into ready-to-send payloads.
+  std::vector<OtlpClient::Payload> collect();
   std::string build_logs_payload(const std::vector<LogRecord> &records) const;
   nlohmann::json build_resource_attributes() const;
 
@@ -71,9 +78,12 @@ class OtlpExporter {
   // {source, source_type, direction, damage_type, zone, target}. `target` is the raw spawn name
   // (instance digits included, e.g. "a_temple_guard00") so individual mobs are distinguishable.
   void record_combat_damage(const std::string &source, const std::string &source_type, const std::string &direction,
-                            const std::string &type, const std::string &target, long long amount);
+                            const std::string &type, const std::string &target, const std::string &pet,
+                            long long amount);
   // Parses caster-side DoT ticks and heal messages from a chat line (they have no hit event).
   void parse_dot_or_heal(const std::string &line);
+  // Parses a raid lockout notice ("... lockout for <target> that expires in <n> Hours.").
+  void parse_lockout(const std::string &line);
   // Accumulates the `eq.combat.heal` counter, keyed by {source, direction, zone}.
   void record_heal(const std::string &source, const std::string &direction, long long amount);
   // True if `source` should be recorded given the current scope setting (self+pet vs all attackers).
@@ -93,10 +103,15 @@ class OtlpExporter {
     std::string display;  // normalized display name, for matching "slain" chat lines
     unsigned long long start_ns = 0, last_ns = 0;
     long long dmg_out = 0, dmg_in = 0;
+    // Per attacker: when they last landed a hit, and how long they have been engaged. This is the
+    // community parser's "Sec" column - the denominator that turns damage into DPS rather than
+    // SDPS, and the reason those two numbers differ for a caster who nukes twice in a long fight.
+    std::map<std::string, std::pair<unsigned long long, double>> attacker_activity;
   };
 
   // Called from the hit event (game thread); opens the fight span on first damage.
-  void note_fight_damage(const std::string &raw_target, bool outgoing, long long dmg);
+  void note_fight_damage(const std::string &raw_target, const std::string &attacker, bool outgoing,
+                         long long dmg);
   // Game-thread tick: zone-session transitions and idle-fight sweep.
   void fight_tick();
   // Ends one active fight into completed_spans. Caller holds no lock (game thread only state).
@@ -108,17 +123,41 @@ class OtlpExporter {
 
   ZealSetting<bool> setting_enabled = {false, "Zeal", "OtlpEnabled", false};
   ZealSetting<std::string> setting_endpoint = {"http://127.0.0.1:4318", "Zeal", "OtlpEndpoint", false};
-  ZealSetting<int> setting_flush_ms = {2000, "Zeal", "OtlpFlushMs", false};
+  // Drives both transports. 5s is a deliberate middle: the dashboard refreshes at 10s, and every
+  // export re-sends every series, so faster mostly buys upstream bandwidth nobody sees.
+  ZealSetting<int> setting_flush_ms = {5000, "Zeal", "OtlpFlushMs", false};
   ZealSetting<int> setting_max_batch = {512, "Zeal", "OtlpMaxBatch", false};
+  // The ingest token, sealed with DPAPI so what lands in zeal.ini is inert on
+  // any other machine or Windows account. That matters because the ini is the
+  // file people paste when asking for help with their UI.
+  ZealSetting<std::string> setting_token_sealed = {"", "Zeal", "OtlpTokenSealed", false};
+
+  // Unsealed once, lazily, and kept in memory for the transport.
+  mutable std::string token_plain;
+  mutable bool token_loaded = false;
+
+  // DPAPI, both directions. Either failing yields an empty string rather than
+  // an error: an ini copied from a friend degrades to unauthenticated uploads
+  // instead of breaking the client.
+  static std::string seal_token(const std::string &plain);
+  static std::string unseal_token(const std::string &sealed);
+  const std::string &auth_token() const;
+  // Drops the SDK providers so the next sampler tick rebuilds them with the current endpoint and
+  // token. Both are captured at construction, so nothing else makes a change take effect.
+  void restart_pipeline();
 
   std::deque<LogRecord> queue;
   mutable std::mutex queue_mutex;
-  std::condition_variable queue_cv;
-  std::thread worker;
-  bool end_thread = false;
+
+  // Transport: owns the worker thread, the flush timer and delivery. Constructed last so the worker
+  // never observes a half-built exporter, and destroyed first so collect() cannot run during
+  // teardown.
+  std::unique_ptr<OtlpClient> client;
 
   // Fixed start time for cumulative metric streams (set at construction).
   unsigned long long start_time_unix_nano = 0;
+  // Longer than a slow two-hander, short enough that a pause reads as downtime.
+  static constexpr unsigned long long kAttackerIdleNs = 12ULL * 1000000000ULL;
   static constexpr unsigned long long kSeriesIdleMs = 10 * 60 * 1000;  // stop exporting fights idle >10min
 
   struct CombatTotal {
@@ -127,23 +166,41 @@ class OtlpExporter {
   };
 
   std::mutex metrics_mutex;
-  // {source, source_type, direction, type, zone, target} -> running total.
-  std::map<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>, CombatTotal>
+  // {source, source_type, direction, type, zone, target, group_leader} -> running total.
+  // The group is part of the key rather than stamped on at export time so damage stays attributed to
+  // the group it was dealt in, even if the player regroups before the next flush.
+  std::map<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string, std::string>,
+           CombatTotal>
       combat_damage;
-  // {source, direction(outgoing=done, incoming=received), zone} -> total hitpoints.
-  std::map<std::tuple<std::string, std::string, std::string>, long long> combat_heal;
+  // {source, direction(outgoing=done, incoming=received), zone, group_leader} -> total hitpoints.
+  std::map<std::tuple<std::string, std::string, std::string, std::string>, long long> combat_heal;
 
   // "self" = record only the local character + its pet (authoritative per-player, no double counting
   // when the whole guild reports). "all" = record every attacker seen in the log (solo experiment).
   ZealSetting<std::string> setting_combat_scope = {"self", "Zeal", "OtlpCombatScope", false};
 
-  // Lightweight send stats surfaced by `/otlp status`.
+  // `/otlp debug`: echo the raw fields of every recorded hit to chat, so a classification can be
+  // checked against what the server actually sent rather than against what we believe it sends.
+  // Deliberately not persisted - it is spammy, and should not survive a session by accident.
+  std::atomic<bool> debug_hits{false};
+
+  // Raid lockouts: target -> unix seconds at which the lockout expires. The expiry is stored as an
+  // absolute instant rather than a remaining duration, so a dashboard can keep counting down from
+  // the last reported value even after the player logs off and the series goes stale.
+  std::map<std::string, long long> lockouts;
+  // target -> unix seconds the target died. The server sends the lockout notice from
+  // NPC::CreateCorpse, so the moment it arrives is the time of death - which is the number guilds
+  // currently ask people to type into Discord by hand.
+  std::map<std::string, long long> raid_kills;
+
+  // Damage shield pairing state (game thread only, via the chat callback): the amount from the most
+  // recent "was hit by non-melee" message, claimed by a shield flavour line naming the same target.
+  std::string ds_pending_target;
+  long long ds_pending_amount = 0;
+  unsigned long long ds_pending_ms = 0;
+
+  // Log lines delivered, counted here because the client only counts payloads, not records.
   std::atomic<unsigned long long> logs_posted{0};
-  std::atomic<unsigned long long> metrics_posted{0};
-  std::atomic<unsigned long long> failed_posts{0};
-  std::atomic<int> last_http_status{0};
-  std::mutex last_error_mutex;
-  std::string last_error;  // response body / failure reason of the most recent failed post
 
   mutable std::mutex snapshot_mutex;
   Snapshot snapshot;

--- a/Zeal/otlp_exporter.h
+++ b/Zeal/otlp_exporter.h
@@ -166,10 +166,15 @@ class OtlpExporter {
   };
 
   std::mutex metrics_mutex;
-  // {source, source_type, direction, type, zone, target, group_leader} -> running total.
+  // {source, source_type, direction, type, zone, target, group_leader, pet} -> running total.
   // The group is part of the key rather than stamped on at export time so damage stays attributed to
   // the group it was dealt in, even if the player regroups before the next flush.
-  std::map<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string, std::string>,
+  //
+  // So is the pet, and for a blunter reason: without it every pet's damage collapsed into its
+  // owner's row and the pet name was lost on export. An enchanter's whole output arrives through
+  // charmed pets, so the attribute that says which one is not decoration.
+  std::map<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string, std::string,
+                      std::string>,
            CombatTotal>
       combat_damage;
   // {source, direction(outgoing=done, incoming=received), zone, group_leader} -> total hitpoints.

--- a/Zeal/telemetry.cpp
+++ b/Zeal/telemetry.cpp
@@ -1,0 +1,205 @@
+#include "telemetry.h"
+
+#include <algorithm>
+
+// The SDK's headers use std::min/max, which the Windows macros break. Zeal deliberately does NOT
+// define NOMINMAX globally - 164 call sites rely on the macros - so it is scoped to these includes
+// and restored afterwards.
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+
+#include "opentelemetry/exporters/otlp/otlp_http_exporter.h"
+#include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
+#include "opentelemetry/exporters/otlp/otlp_http_metric_exporter.h"
+#include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
+#include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/sdk/metrics/meter_provider_factory.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_options.h"
+#include "opentelemetry/sdk/trace/tracer_provider_factory.h"
+#include "opentelemetry/trace/provider.h"
+
+#pragma pop_macro("max")
+#pragma pop_macro("min")
+
+#include "winhttp_client.h"
+
+#include <memory>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <iomanip>
+
+namespace otlp = opentelemetry::exporter::otlp;
+namespace metrics_sdk = opentelemetry::sdk::metrics;
+namespace trace_sdk = opentelemetry::sdk::trace;
+
+namespace {
+
+std::mutex g_mutex;
+bool g_running = false;
+std::shared_ptr<metrics_sdk::MeterProvider> g_meter_provider;
+std::shared_ptr<trace_sdk::TracerProvider> g_tracer_provider;
+
+// service.instance.id must be unique per instance and stable for its lifetime. The semconv registry
+// recommends a random v4 UUID, and deliberately warns against deriving it from something meaningful:
+// the underlying data "should be treated as confidential, being the user's choice to expose it".
+// A character name would leak identity into every series for no benefit - the character travels as a
+// measurement attribute instead, where it can change without redefining the entity.
+std::string NewInstanceId() {
+  std::random_device rd;
+  std::uniform_int_distribution<unsigned> hex(0, 15);
+  std::ostringstream out;
+  out << std::hex;
+  for (int i = 0; i < 32; ++i) {
+    if (i == 8 || i == 12 || i == 16 || i == 20) out << '-';
+    if (i == 12) { out << '4'; continue; }                      // version 4
+    if (i == 16) { out << (8 + (hex(rd) & 3)); continue; }      // variant 1
+    out << hex(rd);
+  }
+  return out.str();
+}
+
+}  // namespace
+
+namespace zeal::telemetry {
+
+bool Start(const std::string &endpoint, const std::string &token, int export_interval_ms,
+           const std::string &service_version, std::string &error) {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  if (g_running) return true;
+
+  try {
+    // One transport for all three signals. Constructing the exporters with it explicitly is
+    // required, not stylistic: the *Factory helpers reach for the SDK's default HTTP backend, which
+    // is not compiled in with WITH_HTTP_CLIENT_CURL=OFF, and the SDK's response to its absence is to
+    // terminate the process - which in a game client means the player loses their session.
+    auto transport = std::make_shared<winhttp_client::HttpClient>();
+
+    // The gateway authenticates per member. Every signal carries the same credential, so the
+    // headers are built once and copied into each exporter's options below.
+    otlp::OtlpHeaders auth_headers;
+    if (!token.empty()) auth_headers.insert(std::make_pair("Authorization", "Bearer " + token));
+
+    // telemetry.sdk.{name,language,version} are filled in by the SDK itself.
+    auto resource = opentelemetry::sdk::resource::Resource::Create({
+        {"service.name", "everquest"},
+        {"service.version", service_version},
+        {"service.instance.id", NewInstanceId()},
+    });
+
+    // --- metrics ---------------------------------------------------------------------------------
+    otlp::OtlpHttpMetricExporterOptions metric_options;
+    metric_options.url = endpoint + "/v1/metrics";
+    metric_options.content_type = otlp::HttpRequestContentType::kJson;
+    metric_options.http_headers = auth_headers;
+    // Cumulative, despite what it costs in retained state - measured against live combat, delta was
+    // worse in a way that matters more.
+    //
+    // Under delta the SDK only exports attribute sets that saw activity in the cycle, so a mob killed
+    // inside one 10s window produces a single point. rate() needs two points in its window to return
+    // anything at all, so those fights contributed *zero* DPS while the dashboard looked healthy.
+    // That is the same silent-undercount failure the cardinality limit would cause, arriving sooner
+    // and on ordinary short fights rather than only on long sessions.
+    //
+    // Cumulative re-exports every attribute set every cycle, which is what keeps rate() well defined
+    // and matches what the hand-rolled exporter did. The cost is that state is never reclaimed: at
+    // 2000 attribute sets the SDK folds the rest into otel.metric.overflow=true, dropping target and
+    // source. That ceiling is monitorable - alert on otel_metric_overflow - whereas a wrong rate() is
+    // not visible at all.
+    metric_options.aggregation_temporality = otlp::PreferredAggregationTemporality::kCumulative;
+    auto metric_exporter = std::unique_ptr<metrics_sdk::PushMetricExporter>(
+        new otlp::OtlpHttpMetricExporter(metric_options, transport));
+
+    metrics_sdk::PeriodicExportingMetricReaderOptions reader_options;
+    // Comparisons, not std::min/max: windows.h arrives with the transport header below the
+    // push/pop guard above, so min and max are macros by the time this line is compiled.
+    int interval = export_interval_ms;
+    if (interval < kMinExportIntervalMs) interval = kMinExportIntervalMs;
+    if (interval > kMaxExportIntervalMs) interval = kMaxExportIntervalMs;
+    reader_options.export_interval_millis = std::chrono::milliseconds(interval);
+    // Must stay below the interval or the reader can start an export while the previous one is
+    // still running; half of it, capped, leaves room for a slow round trip without overlapping.
+    const int timeout = interval / 2 < 5000 ? interval / 2 : 5000;
+    reader_options.export_timeout_millis = std::chrono::milliseconds(timeout);
+    auto reader = metrics_sdk::PeriodicExportingMetricReaderFactory::Create(std::move(metric_exporter),
+                                                                            reader_options);
+    auto meter_provider = metrics_sdk::MeterProviderFactory::Create(
+        std::unique_ptr<metrics_sdk::ViewRegistry>(new metrics_sdk::ViewRegistry()), resource);
+    meter_provider->AddMetricReader(std::move(reader));
+    g_meter_provider = std::move(meter_provider);
+    std::shared_ptr<opentelemetry::metrics::MeterProvider> meter_api = g_meter_provider;
+    opentelemetry::metrics::Provider::SetMeterProvider(meter_api);
+
+    // No LoggerProvider: chat is not collected, and nothing else in Zeal emits log records. An
+    // exporter that exists but is never fed is a thing to explain and a thing to get wrong later.
+
+    // --- traces ----------------------------------------------------------------------------------
+    // Fight spans.
+    otlp::OtlpHttpExporterOptions trace_options;
+    trace_options.url = endpoint + "/v1/traces";
+    trace_options.content_type = otlp::HttpRequestContentType::kJson;
+    trace_options.http_headers = auth_headers;
+    auto span_exporter = std::unique_ptr<trace_sdk::SpanExporter>(
+        new otlp::OtlpHttpExporter(trace_options, transport));
+    trace_sdk::BatchSpanProcessorOptions span_batch;
+    span_batch.schedule_delay_millis = std::chrono::milliseconds(5000);
+    auto span_processor =
+        trace_sdk::BatchSpanProcessorFactory::Create(std::move(span_exporter), span_batch);
+    g_tracer_provider = trace_sdk::TracerProviderFactory::Create(std::move(span_processor), resource);
+    std::shared_ptr<opentelemetry::trace::TracerProvider> tracer_api = g_tracer_provider;
+    opentelemetry::trace::Provider::SetTracerProvider(tracer_api);
+
+    g_running = true;
+    return true;
+  } catch (const std::exception &e) {
+    error = e.what();
+    return false;
+  } catch (...) {
+    error = "unknown exception initialising OpenTelemetry";
+    return false;
+  }
+}
+
+void Stop() {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  if (!g_running) return;
+  const auto timeout = std::chrono::microseconds(2000000);
+
+  // Shutdown, not just flush: each of these owns a thread, and the game will not wait for them.
+  if (g_meter_provider) g_meter_provider->Shutdown(timeout);
+  if (g_tracer_provider) g_tracer_provider->Shutdown(timeout);
+
+  opentelemetry::metrics::Provider::SetMeterProvider(
+      std::shared_ptr<opentelemetry::metrics::MeterProvider>());
+  opentelemetry::trace::Provider::SetTracerProvider(
+      std::shared_ptr<opentelemetry::trace::TracerProvider>());
+
+  g_meter_provider.reset();
+  g_tracer_provider.reset();
+  g_running = false;
+}
+
+ExportStats Stats() {
+  const auto raw = winhttp_client::GetStats();
+  ExportStats out;
+  out.posted = raw.posted;
+  out.failed = raw.failed;
+  out.last_status = raw.last_status;
+  out.last_error = raw.last_error;
+  return out;
+}
+
+bool Running() {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  return g_running;
+}
+
+}  // namespace zeal::telemetry

--- a/Zeal/telemetry.h
+++ b/Zeal/telemetry.h
@@ -1,0 +1,62 @@
+// OpenTelemetry SDK setup - the only place in Zeal that configures telemetry.
+//
+// This is the "application owner" half of OpenTelemetry's API/SDK split: it constructs the
+// providers, exporters and Resource once, and registers them globally. Instrumentation elsewhere in
+// Zeal calls the *API* only (opentelemetry::metrics::Provider::GetMeterProvider(), etc.) and must
+// not include any sdk/ or exporters/ header. Per the client design principles: "Instrumentation
+// authors MUST NOT directly reference any SDK package of any kind, only the API."
+//
+// The practical benefit is not purity. Because the API is a no-op until an SDK is registered,
+// instrumented call sites compile and run whether or not telemetry is built in, so the game code
+// carries no #ifdefs and no null checks.
+#pragma once
+
+#include <string>
+
+namespace zeal::telemetry {
+
+// Configures and registers the global MeterProvider, LoggerProvider and TracerProvider, all
+// exporting OTLP/HTTP to `endpoint` (a base URL; the signal paths are appended) over one shared
+// WinHTTP transport. Safe to call repeatedly - only the first call builds anything.
+//
+// The Resource is fixed for the lifetime of the process, which is what lets instruments be cached
+// at call sites: a Resource is immutable and bound at provider creation, so anything that changes
+// while the game runs - the character, above all - belongs on measurements, not here.
+// `token` is the guild gateway's bearer credential, sent as an Authorization header on every
+// export; empty means send none, which is what a local collector wants. It is passed in rather
+// than read here because this file owns the SDK, not the settings.
+//
+// Both `endpoint` and `token` are captured when the providers are built and cannot be changed
+// afterwards - the exporters hold their own copies. Changing either at runtime therefore means
+// Stop() and a fresh Start(), which is what /otlp endpoint and /otlp token do.
+// `export_interval_ms` is how often metrics are pushed. Metrics here are cumulative, so every
+// export re-sends every series - the payload is proportional to the total, not to what changed -
+// which is why this is clamped rather than free: a raider running `scope all` carries a few
+// thousand series, and at 1 Hz that is around a megabyte a second of upstream, competing with the
+// game's own traffic. Anything below the dashboard's refresh is also invisible.
+bool Start(const std::string &endpoint, const std::string &token, int export_interval_ms,
+           const std::string &service_version, std::string &error);
+
+// The floor and ceiling applied to that interval.
+constexpr int kMinExportIntervalMs = 1000;
+constexpr int kMaxExportIntervalMs = 300000;
+
+// Flushes and shuts down all three providers. Must run before the DLL unloads: the metric reader
+// and the batch processors own threads that would otherwise export from freed memory.
+void Stop();
+
+// True once Start() has succeeded.
+bool Running();
+
+// What the exporters' transport has actually delivered. Surfaced here rather than by including the
+// transport header elsewhere: this file is the SDK boundary, and instrumentation must not reach
+// past it.
+struct ExportStats {
+  unsigned long long posted = 0;
+  unsigned long long failed = 0;
+  int last_status = 0;
+  std::string last_error;
+};
+ExportStats Stats();
+
+}  // namespace zeal::telemetry

--- a/Zeal/zeal.cpp
+++ b/Zeal/zeal.cpp
@@ -42,6 +42,7 @@
 #include "nameplate.h"
 #include "netstat.h"
 #include "npc_give.h"
+#include "otlp_exporter.h"
 #include "outputfile.h"
 #include "page10_binds.h"
 #include "patches.h"
@@ -185,7 +186,8 @@ ZealService::ZealService() {
   AddBinds();     // Register custom keybinds.
 
   // Connect up the pipe last since it spawns another thread (paranoia).
-  pipe = MakeCheckedUnique(NamedPipe);  // Modify so it registers callbacks with labels, ticks, chat.
+  pipe = MakeCheckedUnique(NamedPipe);
+  otlp = MakeCheckedUnique(OtlpExporter);  // Native OTLP/HTTP export; opt-in via /otlp on.  // Modify so it registers callbacks with labels, ticks, chat.
 }
 
 ZealService::~ZealService() { ZealService::ptr_service = nullptr; }

--- a/Zeal/zeal.h
+++ b/Zeal/zeal.h
@@ -92,6 +92,7 @@ class ZealService {
   std::unique_ptr<class Survey> survey = nullptr;
 
   std::unique_ptr<class NamedPipe> pipe = nullptr;
+  std::unique_ptr<class OtlpExporter> otlp = nullptr;
 
  private:
   void AddCommands();  // Registers module dependent chat commands.

--- a/ci/fixtures/logs.json
+++ b/ci/fixtures/logs.json
@@ -1,0 +1,6 @@
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"everquest"}}]},
+ "scopeLogs":[{"scope":{"name":"zeal","version":"1.4.5"},"logRecords":[
+  {"timeUnixNano":"1785540000000000000","severityNumber":9,"severityText":"INFO",
+   "body":{"stringValue":"You slash a temple guard for 42 points of damage."},
+   "attributes":[{"key":"everquest.chat.color","value":{"intValue":"273"}},
+                 {"key":"everquest.zone.id","value":{"intValue":"169"}}]}]}]}]}

--- a/ci/fixtures/metrics.json
+++ b/ci/fixtures/metrics.json
@@ -1,25 +1,333 @@
-{"resourceMetrics":[{"resource":{"attributes":[
- {"key":"service.name","value":{"stringValue":"everquest"}},
- {"key":"service.instance.id","value":{"stringValue":"Controels"}},
- {"key":"everquest.character.class","value":{"stringValue":"Bard"}},
- {"key":"everquest.character.level","value":{"intValue":"60"}}]},
- "scopeMetrics":[{"scope":{"name":"zeal","version":"1.4.5"},"metrics":[
-  {"name":"everquest.combat.damage","unit":"{hitpoint}","sum":{"dataPoints":[{"attributes":[
-    {"key":"everquest.combat.source","value":{"stringValue":"Controels"}},
-    {"key":"everquest.combat.source_type","value":{"stringValue":"player"}},
-    {"key":"everquest.combat.direction","value":{"stringValue":"outgoing"}},
-    {"key":"everquest.combat.damage.type","value":{"stringValue":"slash"}},
-    {"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}},
-    {"key":"everquest.combat.target","value":{"stringValue":"a_temple_guard00"}}],
-    "startTimeUnixNano":"1785540000000000000","timeUnixNano":"1785540000000000000","asInt":"1234"}],
-    "aggregationTemporality":2,"isMonotonic":true}},
-  {"name":"everquest.combat.heal","unit":"{hitpoint}","sum":{"dataPoints":[{"attributes":[
-    {"key":"everquest.combat.source","value":{"stringValue":"Controels"}},
-    {"key":"everquest.combat.direction","value":{"stringValue":"outgoing"}},
-    {"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}}],
-    "startTimeUnixNano":"1785540000000000000","timeUnixNano":"1785540000000000000","asInt":"500"}],
-    "aggregationTemporality":2,"isMonotonic":true}},
-  {"name":"everquest.character.attack","unit":"1","gauge":{"dataPoints":[{"timeUnixNano":"1785540000000000000","asInt":"1280",
-    "attributes":[{"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}}]}]}},
-  {"name":"everquest.character.haste","unit":"%","gauge":{"dataPoints":[{"timeUnixNano":"1785540000000000000","asInt":"91",
-    "attributes":[{"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}}]}]}}]}]}]}
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "everquest"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "Controels"
+            }
+          },
+          {
+            "key": "everquest.character.class",
+            "value": {
+              "stringValue": "Bard"
+            }
+          },
+          {
+            "key": "everquest.character.level",
+            "value": {
+              "intValue": "60"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {
+            "name": "zeal",
+            "version": "1.4.5"
+          },
+          "metrics": [
+            {
+              "name": "everquest.combat.damage",
+              "unit": "{hitpoint}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "everquest.combat.source",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.source_type",
+                        "value": {
+                          "stringValue": "player"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.direction",
+                        "value": {
+                          "stringValue": "outgoing"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.damage.type",
+                        "value": {
+                          "stringValue": "slash"
+                        }
+                      },
+                      {
+                        "key": "everquest.zone.name",
+                        "value": {
+                          "stringValue": "Dawnshroud Peaks"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.target",
+                        "value": {
+                          "stringValue": "a_temple_guard00"
+                        }
+                      },
+                      {
+                        "key": "everquest.group.leader",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1785540000000000000",
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "1234"
+                  },
+                  {
+                    "attributes": [
+                      {
+                        "key": "everquest.combat.source",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.source_type",
+                        "value": {
+                          "stringValue": "player"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.direction",
+                        "value": {
+                          "stringValue": "outgoing"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.damage.type",
+                        "value": {
+                          "stringValue": "damage_shield"
+                        }
+                      },
+                      {
+                        "key": "everquest.zone.name",
+                        "value": {
+                          "stringValue": "Dawnshroud Peaks"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.target",
+                        "value": {
+                          "stringValue": "a_temple_guard00"
+                        }
+                      },
+                      {
+                        "key": "everquest.group.leader",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1785540000000000000",
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "37"
+                  }
+                ],
+                "aggregationTemporality": 2,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "everquest.combat.heal",
+              "unit": "{hitpoint}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "everquest.combat.source",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      },
+                      {
+                        "key": "everquest.combat.direction",
+                        "value": {
+                          "stringValue": "outgoing"
+                        }
+                      },
+                      {
+                        "key": "everquest.zone.name",
+                        "value": {
+                          "stringValue": "Dawnshroud Peaks"
+                        }
+                      },
+                      {
+                        "key": "everquest.group.leader",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1785540000000000000",
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "500"
+                  }
+                ],
+                "aggregationTemporality": 2,
+                "isMonotonic": true
+              }
+            },
+            {
+              "name": "everquest.character.attack",
+              "unit": "1",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "1280",
+                    "attributes": [
+                      {
+                        "key": "everquest.zone.name",
+                        "value": {
+                          "stringValue": "Dawnshroud Peaks"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "everquest.character.haste",
+              "unit": "%",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "91",
+                    "attributes": [
+                      {
+                        "key": "everquest.zone.name",
+                        "value": {
+                          "stringValue": "Dawnshroud Peaks"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "name": "everquest.group.member",
+              "unit": "{member}",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "everquest.group.leader",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      },
+                      {
+                        "key": "everquest.character.name",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      },
+                      {
+                        "key": "everquest.zone.name",
+                        "value": {
+                          "stringValue": "Dawnshroud Peaks"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1785540000000000000",
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "1"
+                  },
+                  {
+                    "attributes": [
+                      {
+                        "key": "everquest.group.leader",
+                        "value": {
+                          "stringValue": "Controels"
+                        }
+                      },
+                      {
+                        "key": "everquest.character.name",
+                        "value": {
+                          "stringValue": "Zigzap"
+                        }
+                      },
+                      {
+                        "key": "everquest.zone.name",
+                        "value": {
+                          "stringValue": "Dawnshroud Peaks"
+                        }
+                      }
+                    ],
+                    "startTimeUnixNano": "1785540000000000000",
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "1"
+                  }
+                ],
+                "aggregationTemporality": 2,
+                "isMonotonic": false
+              }
+            },
+            {
+              "name": "everquest.raid.lockout.expiry",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "everquest.raid.target",
+                        "value": {
+                          "stringValue": "Prince Selrach Di`zok"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "1785700000"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "everquest.raid.kill.timestamp",
+              "unit": "s",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "everquest.raid.target",
+                        "value": {
+                          "stringValue": "Prince Selrach Di`zok"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1785540000000000000",
+                    "asInt": "1785635200"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/ci/fixtures/metrics.json
+++ b/ci/fixtures/metrics.json
@@ -1,0 +1,25 @@
+{"resourceMetrics":[{"resource":{"attributes":[
+ {"key":"service.name","value":{"stringValue":"everquest"}},
+ {"key":"service.instance.id","value":{"stringValue":"Controels"}},
+ {"key":"everquest.character.class","value":{"stringValue":"Bard"}},
+ {"key":"everquest.character.level","value":{"intValue":"60"}}]},
+ "scopeMetrics":[{"scope":{"name":"zeal","version":"1.4.5"},"metrics":[
+  {"name":"everquest.combat.damage","unit":"{hitpoint}","sum":{"dataPoints":[{"attributes":[
+    {"key":"everquest.combat.source","value":{"stringValue":"Controels"}},
+    {"key":"everquest.combat.source_type","value":{"stringValue":"player"}},
+    {"key":"everquest.combat.direction","value":{"stringValue":"outgoing"}},
+    {"key":"everquest.combat.damage.type","value":{"stringValue":"slash"}},
+    {"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}},
+    {"key":"everquest.combat.target","value":{"stringValue":"a_temple_guard00"}}],
+    "startTimeUnixNano":"1785540000000000000","timeUnixNano":"1785540000000000000","asInt":"1234"}],
+    "aggregationTemporality":2,"isMonotonic":true}},
+  {"name":"everquest.combat.heal","unit":"{hitpoint}","sum":{"dataPoints":[{"attributes":[
+    {"key":"everquest.combat.source","value":{"stringValue":"Controels"}},
+    {"key":"everquest.combat.direction","value":{"stringValue":"outgoing"}},
+    {"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}}],
+    "startTimeUnixNano":"1785540000000000000","timeUnixNano":"1785540000000000000","asInt":"500"}],
+    "aggregationTemporality":2,"isMonotonic":true}},
+  {"name":"everquest.character.attack","unit":"1","gauge":{"dataPoints":[{"timeUnixNano":"1785540000000000000","asInt":"1280",
+    "attributes":[{"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}}]}]}},
+  {"name":"everquest.character.haste","unit":"%","gauge":{"dataPoints":[{"timeUnixNano":"1785540000000000000","asInt":"91",
+    "attributes":[{"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}}]}]}}]}]}]}

--- a/ci/fixtures/traces.json
+++ b/ci/fixtures/traces.json
@@ -1,0 +1,11 @@
+{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"everquest"}}]},
+ "scopeSpans":[{"scope":{"name":"zeal","version":"1.4.5"},"spans":[
+  {"traceId":"5b8efff798038103d269b633813fc60c","spanId":"eee19b7ec3c1b174",
+   "name":"zone Dawnshroud Peaks","kind":1,"startTimeUnixNano":"1785540000000000000","endTimeUnixNano":"1785540000000000000",
+   "attributes":[{"key":"everquest.zone.name","value":{"stringValue":"Dawnshroud Peaks"}}],"status":{}},
+  {"traceId":"5b8efff798038103d269b633813fc60c","spanId":"aaa19b7ec3c1b175",
+   "parentSpanId":"eee19b7ec3c1b174","name":"fight a temple guard","kind":1,
+   "startTimeUnixNano":"1785540000000000000","endTimeUnixNano":"1785540000000000000","attributes":[
+    {"key":"everquest.combat.target","value":{"stringValue":"a_temple_guard00"}},
+    {"key":"everquest.fight.outcome","value":{"stringValue":"killed"}},
+    {"key":"everquest.fight.damage.dealt","value":{"intValue":"1234"}}],"status":{}}]}]}]}

--- a/ci/otlp_validate.py
+++ b/ci/otlp_validate.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Validate OTLP/JSON payloads against the OFFICIAL OpenTelemetry protobuf schema.
+
+The hand-rolled exporter builds OTLP JSON by hand, so the spec is the contract. This checks our
+payload shapes against opentelemetry-proto itself — the same definitions the collector uses — which
+catches the whole class of "valid JSON, invalid OTLP" bugs (e.g. a single attribute serialized as
+an object instead of a one-element array) *before* they ship, offline and in milliseconds.
+
+    pip install opentelemetry-proto
+    python ci/otlp_validate.py ci/fixtures/*.json        # or any captured payload
+
+File names decide the signal: *metrics*.json, *logs*.json, *traces*.json.
+"""
+import glob
+import sys
+
+from google.protobuf import json_format
+from opentelemetry.proto.collector.logs.v1 import logs_service_pb2
+from opentelemetry.proto.collector.metrics.v1 import metrics_service_pb2
+from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+
+SIGNALS = {
+    "metrics": metrics_service_pb2.ExportMetricsServiceRequest,
+    "logs": logs_service_pb2.ExportLogsServiceRequest,
+    "traces": trace_service_pb2.ExportTraceServiceRequest,
+}
+
+
+def signal_for(path: str):
+    for name, msg in SIGNALS.items():
+        if name in path:
+            return name, msg
+    return None, None
+
+
+def semantic_checks(name, path, raw):
+    """Invariants the protobuf schema accepts but real backends reject."""
+    import json
+    problems = []
+    d = json.loads(raw)
+    if name == "traces":
+        for rs in d.get("resourceSpans", []):
+            for ss in rs.get("scopeSpans", []):
+                for sp in ss.get("spans", []):
+                    tid, sid = sp.get("traceId", ""), sp.get("spanId", "")
+                    if len(tid) != 32 or set(tid) == {"0"}:
+                        problems.append(f"span {sp.get('name')!r}: traceId must be 32 non-zero hex chars, got {len(tid)}")
+                    if len(sid) != 16 or set(sid) == {"0"}:
+                        problems.append(f"span {sp.get('name')!r}: spanId must be 16 non-zero hex chars, got {len(sid)}")
+                    psid = sp.get("parentSpanId", "")
+                    if psid and len(psid) != 16:
+                        problems.append(f"span {sp.get('name')!r}: parentSpanId must be 16 hex chars, got {len(psid)}")
+                    if int(sp.get("endTimeUnixNano", 0)) < int(sp.get("startTimeUnixNano", 0)):
+                        problems.append(f"span {sp.get('name')!r}: endTime precedes startTime")
+    if name == "metrics":
+        for rm in d.get("resourceMetrics", []):
+            for sm in rm.get("scopeMetrics", []):
+                for m in sm.get("metrics", []):
+                    if "sum" in m and m["sum"].get("aggregationTemporality") not in (1, 2):
+                        problems.append(f"metric {m.get('name')!r}: sum needs aggregationTemporality 1 or 2")
+                    for dp in m.get("sum", {}).get("dataPoints", []):
+                        if "startTimeUnixNano" not in dp:
+                            problems.append(f"metric {m.get('name')!r}: cumulative sum needs startTimeUnixNano")
+    return problems
+
+
+def main(paths):
+    files = [f for p in paths for f in (glob.glob(p) or [p])]
+    if not files:
+        print("no payloads to validate", file=sys.stderr)
+        return 1
+    failures = 0
+    for path in sorted(files):
+        name, msg = signal_for(path)
+        if not msg:
+            print(f"SKIP  {path} (name must contain metrics/logs/traces)")
+            continue
+        try:
+            raw = open(path).read()
+            json_format.Parse(raw, msg())
+            issues = semantic_checks(name, path, raw)
+            if issues:
+                failures += 1
+                print(f"FAIL  {path} ({name}) — schema ok, but:")
+                for i in issues:
+                    print(f"      {i}")
+            else:
+                print(f"OK    {path} ({name})")
+        except Exception as exc:  # noqa: BLE001 - report any schema violation verbatim
+            failures += 1
+            print(f"FAIL  {path} ({name})\n      {str(exc).splitlines()[0]}")
+    print(f"\n{len(files) - failures}/{len(files)} payloads valid per official OTLP schema")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:] or ["ci/fixtures/*.json"]))

--- a/docs/decisions/otlp-sdk-vs-hand-rolled.md
+++ b/docs/decisions/otlp-sdk-vs-hand-rolled.md
@@ -1,0 +1,77 @@
+# Why Zeal's OTLP exporter is hand-rolled and not opentelemetry-cpp
+
+**Status:** decided (2026-08-01) — hand-rolled, with spec validation in CI.
+**Evaluated on:** branch `otlp-sdk` (a complete, working SDK implementation) and the
+`spike-otel-cpp` / `build-sdk` workflows.
+
+## The question
+
+The exporter builds OTLP/JSON by hand with `nlohmann::json` and posts it with WinHTTP. Should it use
+the official `opentelemetry-cpp` SDK instead? The SDK would give spec-correct serialization, proper
+instruments, batching, retry and cardinality limits for free — and a hand-rolled serializer had
+already shipped one real bug (a single attribute emitted as an object instead of a one-element
+array, which invalidated *every* metrics payload whenever a zone name was attached).
+
+So this was evaluated properly rather than argued from taste.
+
+## What was measured
+
+`opentelemetry-cpp[otlp-http]` **does** build for Zeal's exact target (`x86-windows-static`, i.e.
+32-bit with the static CRT). It is not impossible, only expensive:
+
+| | |
+|---|---|
+| vcpkg build time | **29 min** (protobuf + abseil + curl from source) |
+| static libs produced | **122 files, 667 MB** unlinked (`libprotobuf.lib` alone is 194 MB) |
+| transitive deps | protobuf, abseil, **libcurl**, zlib |
+
+A full SDK-backed implementation was written (`Zeal/otlp_exporter_sdk.cpp`): same `/otlp` commands,
+same metric names and `eq.*` attributes, OTLP HTTP metric + log exporters, a periodic reader, counters
+for damage/heal and observable gauges for attack/haste. It compiles.
+
+## What stopped it
+
+Integration failures, in order — the first three were ours to fix, the last one is structural:
+
+1. A project-wide `NOMINMAX` broke 164 existing call sites (Zeal uses the Windows `min`/`max` macros).
+2. `ObserverResult` passed to a `void*` trampoline — our glue.
+3. `InitSecurityInterfaceW` / `if_nametoindex` unresolved → **libcurl** needs `secur32` + `iphlpapi`.
+4. **`zs.lib(inflate.c.obj)`: `_inflate` already defined in `d3dx8.lib(inflate.obj)`.**
+
+That last one is the finding. **libcurl pulls in zlib, and zlib is already statically baked into
+`d3dx8.lib`** — the 2003-era DirectX 8 library the game links against. Two copies of the same C
+library in one binary. The only ways through are `/FORCE:MULTIPLE` (the linker silently picks one
+zlib; curl may then call 2003 code through modern headers — memory corruption risk inside a DLL
+injected into the game) or permanently maintaining a custom vcpkg feature set that builds curl
+without zlib, surviving every upstream Zeal sync.
+
+Note that problems 3 and 4 both come from **libcurl**, which exists only because the SDK's OTLP HTTP
+exporter uses it. The hand-rolled path uses **WinHTTP** — already in the OS, no dependency tail, and
+already proven under Wine, where this client actually runs.
+
+## Decision
+
+Keep the hand-rolled exporter. Additionally:
+
+- **`ci/otlp_validate.py`** validates our payload shapes against the official `opentelemetry-proto`
+  schema — the same definitions the collector uses — on every build. The bug that motivated this
+  evaluation is rejected offline, instantly, with an exact field path.
+- The same check enforces **semantic invariants** the schema can't express (trace/span id widths and
+  non-zero-ness, `endTime >= startTime`, cumulative sums carrying `startTimeUnixNano`).
+- Planned: generate `eq.*` name constants from the semconv registry with **OTel Weaver**, so a typo'd
+  attribute becomes a compile error rather than a silently split timeseries.
+
+Together these recover most of what the SDK offered, with no new dependencies.
+
+## Secondary consideration
+
+This repo is a fork that stays mergeable with upstream `coastalredwood/Zeal`. A PR adding vcpkg,
+protobuf, abseil and libcurl to a lean injected `.asi` — roughly doubling the binary users download —
+is unlikely to be accepted, and reasonably so. ~600 self-contained lines using the already-vendored
+`json.hpp` is a plausible contribution.
+
+## If this is ever revisited
+
+The SDK branch is preserved. Revisit if: histograms or exemplars are needed (hand-rolling those is
+genuinely hairy), several more serialization bugs slip past the CI validation, or upstream adopts a
+package manager and the dependency tree stops being a fork-local cost.

--- a/docs/decisions/otlp-sdk-vs-hand-rolled.md
+++ b/docs/decisions/otlp-sdk-vs-hand-rolled.md
@@ -1,8 +1,8 @@
 # Why Zeal's OTLP exporter is hand-rolled and not opentelemetry-cpp
 
 **Status:** decided (2026-08-01) — hand-rolled, with spec validation in CI.
-**Evaluated by:** building a complete, working SDK-backed implementation of this exporter and
-linking it into Zeal (kept at https://github.com/jensholdgaard/NewZeal, branch `otlp-sdk`).
+**Evaluated on:** branch `otlp-sdk` (a complete, working SDK implementation) and the
+`spike-otel-cpp` / `build-sdk` workflows.
 
 ## The question
 
@@ -40,10 +40,33 @@ Integration failures, in order — the first three were ours to fix, the last on
 
 That last one is the finding. **libcurl pulls in zlib, and zlib is already statically baked into
 `d3dx8.lib`** — the 2003-era DirectX 8 library the game links against. Two copies of the same C
-library in one binary. The only ways through are `/FORCE:MULTIPLE` (the linker silently picks one
+library in one binary. The ways through looked bad: `/FORCE:MULTIPLE` (the linker silently picks one
 zlib; curl may then call 2003 code through modern headers — memory corruption risk inside a DLL
 injected into the game) or permanently maintaining a custom vcpkg feature set that builds curl
 without zlib, surviving every upstream Zeal sync.
+
+> **Correction (2026-08-05).** That last sentence was wrong, and the conclusion it supported was
+> reached too quickly. curl is *optional*, and so is the zlib it drags in. `spike/otel-winhttp`
+> builds opentelemetry-cpp v1.28.0 for **x86** with `WITH_HTTP_CLIENT_CURL=OFF` and a WinHTTP
+> transport supplied instead, then delivers a real OTLP payload end to end:
+>
+> ```
+> WITH_HTTP_CLIENT_CURL:BOOL=OFF
+> installed libs: 24 · no curl libraries in the install tree · zlib is absent
+> PASS: OTLP payload delivered over WinHTTP, HTTP 200
+> ```
+>
+> Two things made this look impossible at the time. The option is **recent**: on v1.24.0 a plain
+> `set(WITH_HTTP_CLIENT_CURL ON)` overwrites anything passed on the command line, so curl is
+> mandatory and `-D` is silently ignored. And zlib enters *only* through curl — it is gated behind
+> `WITH_HTTP_CLIENT_CURL AND WITH_OTLP_HTTP_COMPRESSION` — so removing curl removes the collision
+> outright, with no `/FORCE:MULTIPLE` and no vcpkg patching.
+>
+> This does not reverse the decision below: protobuf and abseil still roughly double the `.asi`, and
+> that remains the deciding cost for a binary guildmates download. What it does change is the
+> *reason*. The SDK was rejected here for size and dependency weight, not because its HTTP layer
+> cannot be replaced — it can, through an extension point upstream provides deliberately
+> ("set OFF to supply a custom transport").
 
 Note that problems 3 and 4 both come from **libcurl**, which exists only because the SDK's OTLP HTTP
 exporter uses it. The hand-rolled path uses **WinHTTP** — already in the OS, no dependency tail, and
@@ -65,12 +88,166 @@ Together these recover most of what the SDK offered, with no new dependencies.
 
 ## Secondary consideration
 
-Adopting the SDK would introduce vcpkg, protobuf, abseil and libcurl to a lean injected `.asi` and
-roughly double the binary users download, for a feature that is off by default. The hand-rolled
-exporter is ~600 self-contained lines using the already-vendored `json.hpp` and WinHTTP.
+This repo is a fork that stays mergeable with upstream `coastalredwood/Zeal`. A PR adding vcpkg,
+protobuf, abseil and libcurl to a lean injected `.asi` — roughly doubling the binary users download —
+is unlikely to be accepted, and reasonably so. ~600 self-contained lines using the already-vendored
+`json.hpp` is a plausible contribution.
 
 ## If this is ever revisited
 
-The SDK implementation is preserved in the fork linked above. Revisit if: histograms or exemplars are needed (hand-rolling those is
+The SDK branch is preserved. Revisit if: histograms or exemplars are needed (hand-rolling those is
 genuinely hairy), several more serialization bugs slip past the CI validation, or upstream adopts a
 package manager and the dependency tree stops being a fork-local cost.
+
+## Measurement (2026-08-05): the SDK does link, over WinHTTP, for +1.2 MB
+
+The Correction above argued curl was never mandatory. That has now been built rather than reasoned
+about, in two steps:
+
+1. `spike/winhttp-client` — a WinHTTP implementation of the SDK's `HttpClient`/`Session`/`Request`
+   abstractions, built against opentelemetry-cpp v1.28.0 with `-DWITH_HTTP_CLIENT_CURL=OFF`. CI
+   (`otel-winhttp-spike.yml`) delivers a real payload to a local listener on **x64 and x86**.
+2. `spike/zeal-sdk` — that SDK linked into `Zeal.asi` itself: 32-bit, `/MT`, alongside `d3dx8.lib`,
+   with a `MeterProvider` and one counter reachable from `/otlp sdkprobe`.
+
+Result — a valid PE32 i386 DLL:
+
+| | shipping (hand-rolled) | with the SDK |
+|---|---|---|
+| `Zeal.asi` | ~11.2 MB | **12.86 MB** |
+| imports | — | `WINHTTP.dll`, no libcurl |
+| static archives linked | — | 119 (24 OpenTelemetry, 95 abseil/protobuf) |
+
+The first measurement read 12.38 MB, but the probe had no call site then, so the linker discarded
+most of what it had just linked. With `/otlp sdkprobe` actually reachable the figure is 12.86 MB -
+**+1.66 MB**. Measure a dependency with its entry point live, or the linker flatters it.
+
+So the two strongest arguments in "Problems with the SDK path" are now **measured as wrong**: the
+dependency tail does not require libcurl, and it does not double the download. `+1.2 MB` is what the
+linker actually keeps. (The `zlib` strings in the binary are Zeal's own vendored `miniz.c`, present
+in the shipping build too — not a dependency the SDK dragged in.)
+
+### What this does *not* settle
+
+- **The probe is a single counter, not a port.** It is reachable from `/otlp sdkprobe`. The hand-rolled exporter's real work — the parsing,
+  the semconv attributes, the fight/group/raid model — is untouched and still running.
+- **The WinHTTP adapter is unexercised** on cancellation, timeouts, TLS failure and concurrent
+  sessions. It moves one payload on a happy path. That gap is the blocker for contributing it
+  upstream, where those paths are not optional.
+- **Build cost is real**: ~25 minutes for the SDK, and 119 archives is a meaningful step up in what
+  a contributor must set up to build this fork.
+
+The decision to keep the hand-rolled exporter stands — but it now rests on scope and build cost,
+which are true, rather than on binary size and libcurl, which were not.
+
+## Correction (2026-08-06): what the first spike actually proved, and the crash it hid
+
+The section above claimed the SDK works over WinHTTP. It did not prove that. The standalone test
+drove `winhttp_client::HttpClient` **directly** and never went near the path the SDK itself uses, so
+it validated the transport while leaving the SDK's route to that transport completely untested.
+
+Loaded into the game, `/otlp sdkprobe` killed the client instantly - no crash handler, no minidump.
+The cause was not Wine, threading, or the transport:
+
+    No default HTTP client backend is compiled in. Use the HttpClientFactory or
+    HttpClient constructor overloads, or enable curl support (WITH_HTTP_CLIENT_CURL=ON).
+
+`OtlpHttpMetricExporterFactory::Create(options)` reaches for the SDK's *default* HTTP backend, which
+with `WITH_HTTP_CLIENT_CURL=OFF` is not compiled in - and the SDK's response is to terminate the
+process. Standalone that is an error line and exit 9. Inside a game client it is the player losing
+their session with nothing written down. Supplying a custom transport requires the injection
+constructor, `OtlpHttpMetricExporter(options, http_client)`; switching curl off and implementing
+`HttpClientFactory` is not sufficient on its own.
+
+With the transport injected, verified end to end under Wine against a live collector:
+
+    periodic mode: 12 seconds, exporting every 2s ... PASS (~6 exports)
+    everquest_sdk_probe_total{service_version="sdk-probe-periodic"} = 12   # in Prometheus
+
+### The testing lesson, which outlived the bug
+
+A passing test that bypasses the integration point is worse than no test: it converts an unknown
+into false confidence. The single-shot test passed under Wine on the same machine, minutes after the
+game died on the same code - because it exercised the component and not the wiring. Two `terminate`
+paths were found and fixed while reasoning from the symptom; both were real, neither was the cause.
+
+Anything claiming the SDK path works must drive `MeterProvider` -> reader -> exporter, the way the
+game does, for more than one export cycle.
+
+## The constraint that actually shapes an SDK port: cardinality and temporality
+
+Checked against the spec, not assumed. Two SDK behaviours interact badly with this workload:
+
+**A Resource is immutable and bound at MeterProvider creation.** The hand-rolled exporter rebuilds
+resource attributes on every payload - free when writing the JSON yourself. This pipeline carries
+the character in `service.instance.id` (Prometheus promotes it to `instance`), so camping to
+character select is a *different service instance*: the provider must be rebuilt, not mutated.
+
+**Under cumulative temporality the SDK never reclaims aggregation state.** Every attribute set ever
+observed stays resident and is re-exported every cycle:
+
+> With cumulative temporality, the SDK retains state across cycles, so once the limit is reached,
+> new combinations keep overflowing until the process restarts.
+
+The C++ SDK caps this at **2000 attribute sets** (`kAggregationCardinalityLimit`, hard-coded in
+`sdk/metrics/state/attributes_hashmap.h`; v1.28's View API exposes no override) and folds everything
+past it into `otel.metric.overflow=true`. That drops the whole attribute set, including `target` and
+`source`. The damage metric is keyed on a per-mob `target`, so a long raid night can plausibly reach
+2000 - after which target-filtered panels silently undercount while totals still look correct.
+
+`kSeriesIdleMs` eviction in the hand-rolled exporter is therefore not housekeeping. It is what keeps
+a session bounded, and the SDK has no cumulative-mode equivalent.
+
+### Resolution
+
+Export **delta** temporality from the SDK, and convert in the local collector:
+
+```yaml
+processors:
+  deltatocumulative:
+    max_stale: 5m
+```
+
+Delta lets the SDK reset state each cycle, so the 2000 limit bounds one cycle rather than the
+session; `max_stale` performs the idle eviction, in a component designed for it. `deltatocumulative`
+already ships in the collector build the guild runs, so this is configuration, not a redeploy.
+
+This is the clearest example of the spike's general lesson: the SDK is not a drop-in for a
+hand-rolled exporter whose behaviour was tuned to this workload. Each such behaviour has to be
+re-derived from the SDK's model, and some - like idle eviction - move to a different component.
+
+## Temporality: cumulative, and the spec says so
+
+Briefly changed to delta to bound the SDK's retained state, then reverted after live combat. Both
+the failure and the guidance are worth recording, because the reasoning for delta was superficially
+good.
+
+**What broke.** Under delta the SDK only exports attribute sets with activity in the cycle, so a mob
+killed inside one 10s window produces a single data point. `rate()` needs two points in its window to
+return anything, so those fights contributed **zero** DPS - while totals and the dashboard looked
+healthy. Observed directly: several series with `samples=1` over ten minutes.
+
+**What the docs say** - all of which predates the experiment:
+
+- OTLP Metrics Exporter (Stable): "MUST set temporality preference to Cumulative for all instrument
+  kinds by default."
+- `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` defaults to `cumulative`.
+- Prometheus compatibility: "Prometheus metrics are always cumulative ... the Prometheus exporter
+  enforces cumulative for all instruments."
+- Prometheus Exporter spec (Stable): "MUST set the MetricReader `temporality` ... to be `cumulative`
+  for all instrument kinds."
+
+And the data model names the cost that motivated the change in the first place:
+
+> Cumulative data requires the sender to remember all previous measurements, an "up-front" memory
+> cost proportional to cardinality.
+
+So the retained state is the documented, accepted price of cumulative - not a defect to engineer
+around. Delta plus a collector-side `deltatocumulative` remains a legitimate pattern for genuinely
+large cardinality, but it is the deviation, and it needs the sample-density consequence understood
+before it is chosen.
+
+**The general lesson.** The hand-rolled exporter already did this correctly. The change was made from
+reasoning rather than from the guidance, and the guidance was one search away. Check the spec before
+"improving" a behaviour that already works - especially when the improvement targets a cost the spec
+explicitly names as expected.

--- a/docs/decisions/otlp-sdk-vs-hand-rolled.md
+++ b/docs/decisions/otlp-sdk-vs-hand-rolled.md
@@ -1,8 +1,8 @@
 # Why Zeal's OTLP exporter is hand-rolled and not opentelemetry-cpp
 
 **Status:** decided (2026-08-01) — hand-rolled, with spec validation in CI.
-**Evaluated on:** branch `otlp-sdk` (a complete, working SDK implementation) and the
-`spike-otel-cpp` / `build-sdk` workflows.
+**Evaluated by:** building a complete, working SDK-backed implementation of this exporter and
+linking it into Zeal (kept at https://github.com/jensholdgaard/NewZeal, branch `otlp-sdk`).
 
 ## The question
 
@@ -65,13 +65,12 @@ Together these recover most of what the SDK offered, with no new dependencies.
 
 ## Secondary consideration
 
-This repo is a fork that stays mergeable with upstream `coastalredwood/Zeal`. A PR adding vcpkg,
-protobuf, abseil and libcurl to a lean injected `.asi` — roughly doubling the binary users download —
-is unlikely to be accepted, and reasonably so. ~600 self-contained lines using the already-vendored
-`json.hpp` is a plausible contribution.
+Adopting the SDK would introduce vcpkg, protobuf, abseil and libcurl to a lean injected `.asi` and
+roughly double the binary users download, for a feature that is off by default. The hand-rolled
+exporter is ~600 self-contained lines using the already-vendored `json.hpp` and WinHTTP.
 
 ## If this is ever revisited
 
-The SDK branch is preserved. Revisit if: histograms or exemplars are needed (hand-rolling those is
+The SDK implementation is preserved in the fork linked above. Revisit if: histograms or exemplars are needed (hand-rolling those is
 genuinely hairy), several more serialization bugs slip past the CI validation, or upstream adopts a
 package manager and the dependency tree stops being a fork-local cost.

--- a/docs/otlp-exporter.md
+++ b/docs/otlp-exporter.md
@@ -1,0 +1,95 @@
+# OTLP exporter
+
+Zeal can export telemetry directly over **OTLP/HTTP (JSON)** — metrics, traces, and logs — instead
+of writing to the named pipe and relying on a sidecar app to read it. The exporter lives in
+`Zeal/otlp_exporter.{h,cpp}` and is off unless you turn it on.
+
+```
+/otlp on                      # start exporting (persists across sessions)
+/otlp off
+/otlp status                  # endpoint, flush interval, scope, posts sent/failed, last error
+/otlp endpoint <url>          # default http://127.0.0.1:4318
+/otlp flush <milliseconds>    # default 2000
+/otlp scope self|all          # default self
+```
+
+Settings persist in the Zeal ini (`OtlpEnabled`, `OtlpEndpoint`, `OtlpFlushMs`, `OtlpMaxBatch`,
+`OtlpCombatScope`).
+
+## Design
+
+A worker thread owns a queue; the game thread only ever appends to it and samples state into a
+snapshot. Payloads are posted with WinHTTP (`https` supported), so nothing blocks the render loop
+and no game structure is read off-thread.
+
+Names come from [everquest-semconv](https://github.com/jensholdgaard/everquest-semconv) via
+Weaver-generated constants in `Zeal/everquest_semconv.h` — a typo becomes a compile error rather
+than a silently split timeseries. The JSON is hand-built with nlohmann rather than the OpenTelemetry
+C++ SDK; see [docs/decisions/otlp-sdk-vs-hand-rolled.md](decisions/otlp-sdk-vs-hand-rolled.md) for
+why. `ci/otlp_validate.py` validates the payload fixtures against the official `opentelemetry-proto`
+schema on every build, which is what keeps a hand-rolled encoder honest.
+
+## What it emits
+
+**Metrics** — `everquest.combat.damage` and `.heal` (cumulative counters), `everquest.character.attack`
+and `.haste` (gauges), and `everquest.group.member` (a non-monotonic sum: the group roster, one point
+of value 1 per member).
+
+**Traces** — a `zone session` span parenting a `fight` span per encounter. A fight opens on first
+damage and closes on a kill message, 30s of no damage, or zoning.
+
+**Logs** — chat lines, only if you route them somewhere. The reference client config drops them
+locally and never uploads them.
+
+## Combat scope
+
+`scope self` (the default) records only damage dealt by you and your pet. This is the correct
+setting when a whole guild reports: each player is the authority on their own output, and nothing
+is double-counted. `scope all` records every attacker visible in the log, which is useful solo but
+double-counts as soon as two people in the same group report.
+
+A consequence worth knowing: under `scope self`, *incoming* damage from a mob is filtered out
+(its source is the mob, not you), so damage-taken panels stay empty unless someone runs `scope all`.
+
+## Damage classification
+
+`everquest.combat.damage.type` is the melee skill (`slash`, `crush`, `pierce`, …), `spell`, `dot`,
+or `damage_shield`.
+
+Damage shields need an explicit test because the server puts a `DmgShieldType` where a `SkillType`
+normally goes:
+
+```cpp
+// EQMacEmu zone/attack.cpp, Mob::DamageShield()
+cds->type    = spellbonuses.DamageShieldType;   // DS_DECAY(244) .. DS_THORNS(249)
+cds->spellid = spellid;                         // the DS spell, or SPELL_UNKNOWN
+```
+
+so the 244–249 test runs *before* the spell-id check — a buff-granted shield carries a spell id and
+would otherwise be indistinguishable from a nuke, while item and innate shields carry none and fall
+through into `melee`. Chat text cannot substitute: the client's damage shield strings (`12133 YOU
+are pierced by thorns!`, `12134 %1 was pierced by thorns.`) carry no number at all.
+
+This range is read from EQMacEmu and has **not** been confirmed against a live Quarm server. Check
+that the `damage_shield` value actually appears before trusting it.
+
+## Groups
+
+`everquest.group.leader` is attached to each damage point at record time, not stamped on at export,
+so damage stays attributed to the group it was dealt in even if the player regroups before the next
+flush. It is omitted entirely when solo, so ungrouped play drops out of group-scoped queries.
+
+The leader identifies the group in preference to a hash of the roster: a roster identifier changes
+the moment anyone joins or leaves, splitting a timeseries mid-fight. Raids are not modelled — each
+of a raid's groups reports its own leader.
+
+`everquest.group.member` reports the roster from `GroupInfo`, including members who do not run Zeal
+and therefore emit nothing else. That is deliberate — it is what lets a dashboard distinguish "the
+group did poorly" from "half the group isn't reporting" — but it does send other players' character
+names, which client-facing documentation should disclose.
+
+## Privacy
+
+The exporter can emit every chat line as a log record, which includes tells, guild, and officer
+chat. Point it at a local collector that drops the logs pipeline (as the reference client config
+does) unless you have a specific reason not to, and be deliberate about where the endpoint points.

--- a/spike/winhttp-client/CMakeLists.txt
+++ b/spike/winhttp-client/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Builds the WinHTTP transport against opentelemetry-cpp with the curl backend switched OFF.
+#
+# The point of the spike: WITH_HTTP_CLIENT_CURL=OFF is an upstream-supported configuration ("set OFF
+# to supply a custom transport"), so if this links and the smoke test passes, the SDK is usable in
+# a process that cannot take curl - which is what blocked it inside the game client, where curl's
+# zlib collides with the zlib already inside d3dx8.lib.
+cmake_minimum_required(VERSION 3.16)
+project(otel_winhttp_spike CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(opentelemetry-cpp CONFIG REQUIRED)
+
+add_library(winhttp_client STATIC winhttp_client.cpp)
+target_include_directories(winhttp_client PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# Deliberately no http_client_curl: that target does not exist in this configuration, which is the
+# whole point of the exercise.
+target_link_libraries(winhttp_client PUBLIC opentelemetry-cpp::api opentelemetry-cpp::sdk winhttp)
+
+add_executable(smoke_test smoke_test.cpp)
+# --periodic mode drives a real MeterProvider, so the metric exporter comes along too.
+target_link_libraries(smoke_test PRIVATE winhttp_client opentelemetry-cpp::otlp_http_client
+                      opentelemetry-cpp::otlp_http_metric_exporter opentelemetry-cpp::metrics winhttp)

--- a/spike/winhttp-client/smoke_test.cpp
+++ b/spike/winhttp-client/smoke_test.cpp
@@ -1,0 +1,155 @@
+// Proves the WinHTTP transport carries a real OTLP export end to end.
+//
+// It builds an OtlpHttpClient with our client injected (the constructor upstream provides for
+// exactly this), sends one metrics payload at a local listener, and reports the status it got back.
+// Success means the SDK produced a payload, our transport delivered it, and the response came back
+// through the SDK's own handler - which is the whole question this spike exists to answer.
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <thread>
+
+#include <cstdlib>
+
+#include "opentelemetry/exporters/otlp/otlp_http_client.h"
+#include "opentelemetry/exporters/otlp/otlp_http_metric_exporter.h"
+#include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
+#include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/sdk/metrics/meter_provider_factory.h"
+#include "opentelemetry/sdk/resource/resource.h"
+#include "winhttp_client.h"
+
+namespace otlp = opentelemetry::exporter::otlp;
+namespace metrics_sdk = opentelemetry::sdk::metrics;
+namespace metrics_api = opentelemetry::metrics;
+
+// Replicates what the in-game probe does: a real MeterProvider with a PeriodicExportingMetricReader
+// exporting on a timer, for several export cycles. The single-shot test below never exercised a
+// second export, and that is exactly where a session gets reused - the case that killed the game
+// client. One delivery proving the transport works says nothing about the tenth.
+static int RunPeriodic(const std::string &endpoint, int seconds);
+
+int main(int argc, char **argv) {
+  const std::string endpoint = (argc > 1) ? argv[1] : "http://127.0.0.1:4318/v1/metrics";
+  if (argc > 2 && std::string(argv[2]) == "--periodic") {
+    return RunPeriodic(endpoint, (argc > 3) ? std::atoi(argv[3]) : 10);
+  }
+
+  auto transport = std::make_shared<winhttp_client::HttpClient>();
+  if (!transport->winhttp_session()) {
+    std::fprintf(stderr, "FAIL: WinHttpOpen returned no session\n");
+    return 2;
+  }
+  std::printf("winhttp session opened\n");
+
+  // A direct exchange through the transport, so a failure here is unambiguously ours rather than
+  // the SDK's serialisation.
+  auto session = transport->CreateSession(endpoint);
+  auto request = session->CreateRequest();
+  request->SetMethod(opentelemetry::ext::http::client::Method::Post);
+  request->SetUri(endpoint.substr(endpoint.find('/', endpoint.find("//") + 2)));
+  request->AddHeader("Content-Type", "application/json");
+  std::string payload =
+      R"({"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"winhttp-spike"}}]},)"
+      R"("scopeMetrics":[{"metrics":[{"name":"spike.counter","unit":"1","sum":{"aggregationTemporality":2,)"
+      R"("isMonotonic":true,"dataPoints":[{"asInt":"1","timeUnixNano":"1700000000000000000",)"
+      R"("startTimeUnixNano":"1700000000000000000"}]}}]}]}]})";
+  opentelemetry::ext::http::client::Body body(payload.begin(), payload.end());
+  request->SetBody(body);
+
+  struct Handler : public opentelemetry::ext::http::client::EventHandler {
+    std::atomic<int> status{0};
+    std::atomic<bool> done{false};
+    std::string last_event;
+    void OnResponse(opentelemetry::ext::http::client::Response &response) noexcept override {
+      status.store(static_cast<int>(response.GetStatusCode()));
+      done.store(true);
+    }
+    void OnEvent(opentelemetry::ext::http::client::SessionState state,
+                 opentelemetry::nostd::string_view reason) noexcept override {
+      last_event.assign(reason.data(), reason.size());
+      using S = opentelemetry::ext::http::client::SessionState;
+      if (state == S::ConnectFailed || state == S::SendFailed || state == S::NetworkError ||
+          state == S::TimedOut || state == S::ReadError || state == S::SSLHandshakeFailed ||
+          state == S::CreateFailed) {
+        done.store(true);
+      }
+    }
+  };
+  auto handler = std::make_shared<Handler>();
+  session->SendRequest(handler);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+  while (!handler->done.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+  session->FinishSession();
+  transport->FinishAllSessions();
+
+  const int status = handler->status.load();
+  if (status >= 200 && status < 300) {
+    std::printf("PASS: OTLP payload delivered over WinHTTP, HTTP %d\n", status);
+    return 0;
+  }
+  std::fprintf(stderr, "FAIL: status=%d last_event=%s\n", status, handler->last_event.c_str());
+  return 1;
+}
+
+// --- periodic mode ------------------------------------------------------------------------------
+// Mirrors spike/zeal-sdk/otel_sdk_probe.cpp as closely as a standalone process can, so a failure
+// here is the failure that happens in the game, minus the game.
+static int RunPeriodic(const std::string &endpoint, int seconds) {
+  otlp::OtlpHttpMetricExporterOptions options;
+  options.url = endpoint;
+  options.content_type = otlp::HttpRequestContentType::kJson;
+  // Delta, matching the in-game path: the collector's deltatocumulative rebuilds the cumulative
+  // series Prometheus wants, and this test is what verifies that conversion actually happens.
+  options.aggregation_temporality = otlp::PreferredAggregationTemporality::kDelta;
+
+  // Inject our transport rather than going through the Factory, which reaches for a default HTTP
+  // backend that does not exist in this configuration and kills the process.
+  auto transport = std::make_shared<winhttp_client::HttpClient>();
+  auto exporter = std::unique_ptr<metrics_sdk::PushMetricExporter>(
+      new otlp::OtlpHttpMetricExporter(options, transport));
+
+  metrics_sdk::PeriodicExportingMetricReaderOptions reader_options;
+  reader_options.export_interval_millis = std::chrono::milliseconds(2000);
+  reader_options.export_timeout_millis = std::chrono::milliseconds(1500);
+  auto reader =
+      metrics_sdk::PeriodicExportingMetricReaderFactory::Create(std::move(exporter), reader_options);
+
+  auto resource = opentelemetry::sdk::resource::Resource::Create({
+      {"service.name", "everquest"},
+      {"service.version", "sdk-probe-periodic"},
+      {"service.instance.id", "smoke-test"},
+  });
+
+  auto provider = metrics_sdk::MeterProviderFactory::Create(
+      std::unique_ptr<metrics_sdk::ViewRegistry>(new metrics_sdk::ViewRegistry()), resource);
+  provider->AddMetricReader(std::move(reader));
+
+  std::shared_ptr<metrics_api::MeterProvider> api_provider(std::move(provider));
+  metrics_api::Provider::SetMeterProvider(api_provider);
+
+  auto meter = api_provider->GetMeter("zeal.sdk.probe", "sdk-probe");
+  auto counter = meter->CreateUInt64Counter("everquest.sdk.probe", "probe emitted by the SDK", "1");
+
+  std::printf("periodic mode: %d seconds, exporting every 2s\n", seconds);
+  std::fflush(stdout);
+  for (int i = 0; i < seconds; ++i) {
+    counter->Add(1);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::printf("  t=%ds still alive\n", i + 1);
+    std::fflush(stdout);  // unbuffered: if it dies mid-run, the last line must already be on disk
+  }
+
+  static_cast<metrics_sdk::MeterProvider *>(api_provider.get())->ForceFlush(std::chrono::microseconds(2000000));
+  metrics_api::Provider::SetMeterProvider(std::shared_ptr<metrics_api::MeterProvider>());
+  std::printf("PASS: survived %d seconds of periodic export (~%d exports)\n", seconds, seconds / 2);
+  return 0;
+}

--- a/spike/winhttp-client/winhttp_client.cpp
+++ b/spike/winhttp-client/winhttp_client.cpp
@@ -1,0 +1,336 @@
+#include "winhttp_client.h"
+
+#include <algorithm>
+#include <exception>
+
+#pragma comment(lib, "winhttp.lib")
+
+namespace winhttp_client {
+
+namespace {
+std::mutex g_stats_mutex;
+Stats g_stats;
+}  // namespace
+
+Stats GetStats() {
+  std::lock_guard<std::mutex> lock(g_stats_mutex);
+  return g_stats;
+}
+
+void RecordResult(int status, const std::string &error) {
+  std::lock_guard<std::mutex> lock(g_stats_mutex);
+  g_stats.last_status = status;
+  if (status >= 200 && status < 300) {
+    g_stats.posted++;
+    g_stats.last_error.clear();
+  } else {
+    g_stats.failed++;
+    // A rejected export explains itself in the body (a 401 says which auth failed); keeping it is
+    // the difference between "something is wrong" and knowing what.
+    g_stats.last_error = error;
+  }
+}
+
+namespace {
+
+std::wstring Widen(const std::string &s) { return std::wstring(s.begin(), s.end()); }
+
+const wchar_t *MethodName(http_client::Method method) {
+  switch (method) {
+    case http_client::Method::Get: return L"GET";
+    case http_client::Method::Put: return L"PUT";
+    case http_client::Method::Head: return L"HEAD";
+    case http_client::Method::Delete: return L"DELETE";
+    case http_client::Method::Patch: return L"PATCH";
+    case http_client::Method::Options: return L"OPTIONS";
+    case http_client::Method::Post:
+    default: return L"POST";
+  }
+}
+
+// WinHTTP hands back all response headers as one CRLF-separated block; the SDK wants them keyed.
+void ParseHeaders(const std::wstring &raw, http_client::Headers &out) {
+  std::string block(raw.begin(), raw.end());
+  size_t pos = 0;
+  bool first = true;
+  while (pos < block.size()) {
+    size_t end = block.find("\r\n", pos);
+    if (end == std::string::npos) end = block.size();
+    const std::string line = block.substr(pos, end - pos);
+    pos = end + 2;
+    if (first) {  // status line, not a header
+      first = false;
+      continue;
+    }
+    const size_t colon = line.find(':');
+    if (colon == std::string::npos) continue;
+    std::string name = line.substr(0, colon);
+    std::string value = line.substr(colon + 1);
+    while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(value.begin());
+    out.insert({name, value});
+  }
+}
+
+}  // namespace
+
+// --- Session ----------------------------------------------------------------------------------
+
+Session::Session(std::weak_ptr<HttpClient> parent, std::string host, uint16_t port, bool https)
+    : parent_(std::move(parent)), host_(std::move(host)), port_(port), https_(https) {}
+
+Session::~Session() { FinishSession(); }
+
+std::shared_ptr<http_client::Request> Session::CreateRequest() noexcept {
+  request_ = std::make_shared<Request>();
+  return request_;
+}
+
+void Session::SendRequest(std::shared_ptr<http_client::EventHandler> callback) noexcept {
+  if (!request_) {
+    callback->OnEvent(http_client::SessionState::CreateFailed, "no request");
+    return;
+  }
+  // Reusing a session for a second request would assign over a joinable std::thread, which calls
+  // std::terminate() - the process dies with no SEH exception, so no crash handler sees it and no
+  // minidump is written. Retire the previous worker first.
+  if (worker_.joinable()) {
+    if (worker_.get_id() == std::this_thread::get_id())
+      worker_.detach();
+    else
+      worker_.join();
+  }
+  active_.store(true);
+  // The contract is asynchronous: return promptly, report through the handler later. WinHTTP's own
+  // async mode would avoid the thread, but a thread per in-flight export is simpler to get right and
+  // the exporter batches, so there are few of them.
+  auto self = shared_from_this();
+  worker_ = std::thread([self, callback]() {
+    // An exception escaping a thread function is also std::terminate, and this one runs inside a
+    // game process where that means the player loses their session. Nothing here is worth a crash.
+    try {
+      self->Exchange(callback);
+    } catch (const std::exception &e) {
+      self->active_.store(false);
+      callback->OnEvent(http_client::SessionState::CreateFailed, e.what());
+    } catch (...) {
+      self->active_.store(false);
+      callback->OnEvent(http_client::SessionState::CreateFailed, "unknown exception in WinHTTP worker");
+    }
+  });
+}
+
+void Session::Exchange(std::shared_ptr<http_client::EventHandler> handler) {
+  auto parent = parent_.lock();
+  if (!parent || !parent->winhttp_session()) {
+    handler->OnEvent(http_client::SessionState::ConnectFailed, "no winhttp session");
+    active_.store(false);
+    return;
+  }
+
+  handler->OnEvent(http_client::SessionState::Connecting, "");
+  HINTERNET connect = WinHttpConnect(parent->winhttp_session(), Widen(host_).c_str(), port_, 0);
+  if (!connect) {
+    handler->OnEvent(http_client::SessionState::ConnectFailed, "WinHttpConnect failed");
+    active_.store(false);
+    return;
+  }
+  handler->OnEvent(http_client::SessionState::Connected, "");
+
+  const DWORD flags = https_ ? WINHTTP_FLAG_SECURE : 0;
+  HINTERNET request = WinHttpOpenRequest(connect, MethodName(request_->method_), Widen(request_->uri_).c_str(),
+                                         nullptr, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags);
+  if (!request) {
+    WinHttpCloseHandle(connect);
+    handler->OnEvent(http_client::SessionState::CreateFailed, "WinHttpOpenRequest failed");
+    active_.store(false);
+    return;
+  }
+
+  const DWORD timeout = static_cast<DWORD>(request_->timeout_ms_.count());
+  WinHttpSetTimeouts(request, timeout, timeout, timeout, timeout);
+
+  std::wstring headers;
+  for (const auto &header : request_->headers_) {
+    headers += Widen(header.first) + L": " + Widen(header.second) + L"\r\n";
+  }
+
+  auto fail = [&](http_client::SessionState state, const char *why) {
+    RecordResult(0, why ? why : "transport error");
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connect);
+    handler->OnEvent(state, why);
+    active_.store(false);
+  };
+
+  handler->OnEvent(http_client::SessionState::Sending, "");
+  if (cancelled_.load()) return fail(http_client::SessionState::Cancelled, "cancelled");
+
+  const void *body = request_->body_.empty() ? nullptr : request_->body_.data();
+  const DWORD body_len = static_cast<DWORD>(request_->body_.size());
+  if (!WinHttpSendRequest(request, headers.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : headers.c_str(),
+                          headers.empty() ? 0 : static_cast<DWORD>(-1), const_cast<void *>(body), body_len, body_len,
+                          0)) {
+    const DWORD err = GetLastError();
+    return fail(err == ERROR_WINHTTP_TIMEOUT ? http_client::SessionState::TimedOut
+                                             : http_client::SessionState::SendFailed,
+                "WinHttpSendRequest failed");
+  }
+
+  if (!WinHttpReceiveResponse(request, nullptr)) {
+    const DWORD err = GetLastError();
+    return fail(err == ERROR_WINHTTP_TIMEOUT      ? http_client::SessionState::TimedOut
+                : err == ERROR_WINHTTP_SECURE_FAILURE ? http_client::SessionState::SSLHandshakeFailed
+                                                      : http_client::SessionState::NetworkError,
+                "WinHttpReceiveResponse failed");
+  }
+
+  auto response = std::unique_ptr<Response>(new Response());
+
+  DWORD status = 0, status_size = sizeof(status);
+  WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX,
+                      &status, &status_size, WINHTTP_NO_HEADER_INDEX);
+  response->status_code_ = static_cast<http_client::StatusCode>(status);
+
+  DWORD header_size = 0;
+  WinHttpQueryHeaders(request, WINHTTP_QUERY_RAW_HEADERS_CRLF, WINHTTP_HEADER_NAME_BY_INDEX, nullptr, &header_size,
+                      WINHTTP_NO_HEADER_INDEX);
+  if (header_size > 0 && GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+    std::wstring raw(header_size / sizeof(wchar_t), L'\0');
+    if (WinHttpQueryHeaders(request, WINHTTP_QUERY_RAW_HEADERS_CRLF, WINHTTP_HEADER_NAME_BY_INDEX, &raw[0],
+                            &header_size, WINHTTP_NO_HEADER_INDEX)) {
+      ParseHeaders(raw, response->headers_);
+    }
+  }
+
+  for (;;) {
+    DWORD available = 0;
+    if (!WinHttpQueryDataAvailable(request, &available)) {
+      return fail(http_client::SessionState::ReadError, "WinHttpQueryDataAvailable failed");
+    }
+    if (available == 0) break;
+    const size_t offset = response->body_.size();
+    response->body_.resize(offset + available);
+    DWORD read = 0;
+    if (!WinHttpReadData(request, response->body_.data() + offset, available, &read)) {
+      return fail(http_client::SessionState::ReadError, "WinHttpReadData failed");
+    }
+    response->body_.resize(offset + read);
+    if (read == 0) break;
+  }
+
+  // The exchange completed: record what the server said. A non-2xx keeps up to 300 characters of
+  // the body, which is where a gateway names the actual problem.
+  {
+    const int code = static_cast<int>(response->status_code_);
+    std::string why;
+    if (code < 200 || code >= 300) {
+      why = std::string(response->body_.begin(), response->body_.end());
+      if (why.size() > 300) why.resize(300);
+      why = std::to_string(code) + " " + why;
+    }
+    RecordResult(code, why);
+  }
+
+  WinHttpCloseHandle(request);
+  WinHttpCloseHandle(connect);
+
+  handler->OnEvent(http_client::SessionState::Response, "");
+  handler->OnResponse(*response);
+  active_.store(false);
+}
+
+bool Session::CancelSession() noexcept {
+  cancelled_.store(true);
+  return FinishSession();
+}
+
+bool Session::FinishSession() noexcept {
+  if (worker_.joinable()) {
+    if (worker_.get_id() == std::this_thread::get_id()) {
+      worker_.detach();  // called from the handler on our own thread: joining would deadlock
+    } else {
+      worker_.join();
+    }
+  }
+  active_.store(false);
+  if (auto parent = parent_.lock()) parent->Forget(this);
+  return true;
+}
+
+// --- HttpClient -------------------------------------------------------------------------------
+
+HttpClient::HttpClient() {
+  winhttp_session_ = WinHttpOpen(L"opentelemetry-cpp-winhttp/1.0", WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+                                 WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+  if (!winhttp_session_) {  // pre-Win8.1 has no automatic proxy detection
+    winhttp_session_ = WinHttpOpen(L"opentelemetry-cpp-winhttp/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                                   WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+  }
+}
+
+HttpClient::~HttpClient() {
+  FinishAllSessions();
+  if (winhttp_session_) WinHttpCloseHandle(winhttp_session_);
+}
+
+std::shared_ptr<http_client::Session> HttpClient::CreateSession(opentelemetry::nostd::string_view url) noexcept {
+  const std::string full(url.data(), url.size());
+  URL_COMPONENTS parts = {};
+  parts.dwStructSize = sizeof(parts);
+  wchar_t host[256] = {}, path[2048] = {};
+  parts.lpszHostName = host;
+  parts.dwHostNameLength = _countof(host);
+  parts.lpszUrlPath = path;
+  parts.dwUrlPathLength = _countof(path);
+
+  const std::wstring wide = Widen(full);
+  if (!WinHttpCrackUrl(wide.c_str(), 0, 0, &parts)) {
+    return std::make_shared<Session>(weak_from_this(), "", 0, false);
+  }
+  const std::wstring whost(host);
+  auto session = std::make_shared<Session>(weak_from_this(), std::string(whost.begin(), whost.end()), parts.nPort,
+                                           parts.nScheme == INTERNET_SCHEME_HTTPS);
+  Track(session);
+  return session;
+}
+
+void HttpClient::Track(const std::shared_ptr<Session> &session) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  sessions_.push_back(session);
+}
+
+void HttpClient::Forget(Session *session) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  sessions_.erase(std::remove_if(sessions_.begin(), sessions_.end(),
+                                 [session](const std::weak_ptr<Session> &weak) {
+                                   auto locked = weak.lock();
+                                   return !locked || locked.get() == session;
+                                 }),
+                  sessions_.end());
+}
+
+bool HttpClient::CancelAllSessions() noexcept {
+  std::vector<std::shared_ptr<Session>> live;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto &weak : sessions_) {
+      if (auto session = weak.lock()) live.push_back(session);
+    }
+  }
+  for (auto &session : live) session->CancelSession();
+  return true;
+}
+
+bool HttpClient::FinishAllSessions() noexcept {
+  std::vector<std::shared_ptr<Session>> live;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto &weak : sessions_) {
+      if (auto session = weak.lock()) live.push_back(session);
+    }
+  }
+  for (auto &session : live) session->FinishSession();
+  return true;
+}
+
+}  // namespace winhttp_client

--- a/spike/winhttp-client/winhttp_client.h
+++ b/spike/winhttp-client/winhttp_client.h
@@ -1,0 +1,180 @@
+// A WinHTTP transport for opentelemetry-cpp, supplied in place of the curl one.
+//
+// Upstream supports this directly - the CMake option says so:
+//
+//   WITH_HTTP_CLIENT_CURL  "Use the curl HTTP client backend. Defaults to ON when any HTTP
+//                           exporter is enabled; set OFF to supply a custom transport."
+//
+// Why bother: curl is the only transport shipped, and on Windows it arrives with a vendored TLS
+// stack and zlib. Static zlib is what made the SDK unusable inside this game client - the 2003-era
+// d3dx8.lib the game links already contains zlib, and two copies of `_inflate` will not link. More
+// generally, a Windows process that must not grow new DLL dependencies (a plugin, an OT/industrial
+// agent, an injected library) cannot take curl at all, while WinHTTP is part of the OS: no vendored
+// crypto, system proxy and certificate store honoured for free, patched by Windows Update.
+//
+// The SDK's HttpClient contract is asynchronous: SendRequest() must return promptly and the handler
+// is notified later. Each session therefore owns a thread that performs the blocking WinHTTP
+// exchange and then calls OnResponse/OnEvent.
+#pragma once
+
+#include <windows.h>
+#include <winhttp.h>
+
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "opentelemetry/ext/http/client/http_client.h"
+#include "opentelemetry/ext/http/client/http_client_factory.h"
+#include "opentelemetry/version.h"
+
+namespace winhttp_client {
+
+namespace http_client = opentelemetry::ext::http::client;
+
+// Delivery statistics for the whole transport, aggregated across every session.
+//
+// The SDK reports export failures only through its internal log handler, so without this there is
+// no way to ask, from in game, whether telemetry is actually arriving - which is how an
+// unauthenticated exporter posted into the void unnoticed. `/otlp status` reads these.
+struct Stats {
+  unsigned long long posted = 0;  // responses with a 2xx status
+  unsigned long long failed = 0;  // everything else, transport errors included
+  int last_status = 0;            // most recent HTTP status, 0 if none completed
+  std::string last_error;         // most recent failure, with the server's explanation if it gave one
+};
+
+Stats GetStats();
+// Called by the session as each request finishes; `status` of 0 means it never got a response.
+void RecordResult(int status, const std::string &error);
+
+class Request final : public http_client::Request {
+ public:
+  void SetMethod(http_client::Method method) noexcept override { method_ = method; }
+  void SetBody(http_client::Body &body) noexcept override { body_.swap(body); }
+  void SetUri(opentelemetry::nostd::string_view uri) noexcept override { uri_.assign(uri.data(), uri.size()); }
+  void SetSslOptions(const http_client::HttpSslOptions &options) noexcept override { ssl_options_ = options; }
+  void SetTimeoutMs(std::chrono::milliseconds timeout_ms) noexcept override { timeout_ms_ = timeout_ms; }
+  void EnableLogging(bool) noexcept override {}
+  void SetCompression(const http_client::Compression &compression) noexcept override { compression_ = compression; }
+  void SetRetryPolicy(const http_client::RetryPolicy &retry_policy) noexcept override {
+    retry_policy_ = retry_policy;
+  }
+
+  void AddHeader(opentelemetry::nostd::string_view name, opentelemetry::nostd::string_view value) noexcept override {
+    headers_.insert({std::string(name.data(), name.size()), std::string(value.data(), value.size())});
+  }
+  void ReplaceHeader(opentelemetry::nostd::string_view name,
+                     opentelemetry::nostd::string_view value) noexcept override {
+    std::string key(name.data(), name.size());
+    headers_.erase(key);
+    headers_.insert({key, std::string(value.data(), value.size())});
+  }
+
+  http_client::Method method_ = http_client::Method::Post;
+  http_client::Body body_;
+  std::string uri_;
+  http_client::Headers headers_;
+  http_client::HttpSslOptions ssl_options_;
+  http_client::Compression compression_ = http_client::Compression::kNone;
+  http_client::RetryPolicy retry_policy_;
+  std::chrono::milliseconds timeout_ms_{30000};
+};
+
+class Response final : public http_client::Response {
+ public:
+  const http_client::Body &GetBody() const noexcept override { return body_; }
+  http_client::StatusCode GetStatusCode() const noexcept override { return status_code_; }
+
+  bool ForEachHeader(opentelemetry::nostd::function_ref<bool(opentelemetry::nostd::string_view name,
+                                                             opentelemetry::nostd::string_view value)> callable)
+      const noexcept override {
+    for (const auto &header : headers_) {
+      if (!callable(header.first, header.second)) return false;
+    }
+    return true;
+  }
+
+  bool ForEachHeader(const opentelemetry::nostd::string_view &name,
+                     opentelemetry::nostd::function_ref<bool(opentelemetry::nostd::string_view name,
+                                                             opentelemetry::nostd::string_view value)> callable)
+      const noexcept override {
+    const std::string key(name.data(), name.size());
+    auto range = headers_.equal_range(key);
+    for (auto it = range.first; it != range.second; ++it) {
+      if (!callable(it->first, it->second)) return false;
+    }
+    return true;
+  }
+
+  http_client::Body body_;
+  http_client::Headers headers_;
+  http_client::StatusCode status_code_ = 0;
+};
+
+class HttpClient;
+
+class Session final : public http_client::Session, public std::enable_shared_from_this<Session> {
+ public:
+  Session(std::weak_ptr<HttpClient> parent, std::string host, uint16_t port, bool https);
+  ~Session() override;
+
+  std::shared_ptr<http_client::Request> CreateRequest() noexcept override;
+  void SendRequest(std::shared_ptr<http_client::EventHandler> callback) noexcept override;
+  bool IsSessionActive() noexcept override { return active_.load(); }
+  bool CancelSession() noexcept override;
+  bool FinishSession() noexcept override;
+
+ private:
+  // Runs on the worker thread: performs the exchange and reports through the handler exactly once.
+  void Exchange(std::shared_ptr<http_client::EventHandler> handler);
+
+  std::weak_ptr<HttpClient> parent_;
+  std::string host_;
+  uint16_t port_;
+  bool https_;
+  std::shared_ptr<Request> request_;
+  std::thread worker_;
+  std::atomic<bool> active_{false};
+  std::atomic<bool> cancelled_{false};
+};
+
+class HttpClient final : public http_client::HttpClient, public std::enable_shared_from_this<HttpClient> {
+ public:
+  HttpClient();
+  ~HttpClient() override;
+
+  std::shared_ptr<http_client::Session> CreateSession(opentelemetry::nostd::string_view url) noexcept override;
+  bool CancelAllSessions() noexcept override;
+  bool FinishAllSessions() noexcept override;
+  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+  // Shared across sessions: WinHTTP session handles are expensive and thread-safe to reuse.
+  HINTERNET winhttp_session() const noexcept { return winhttp_session_; }
+
+  void Track(const std::shared_ptr<Session> &session);
+  void Forget(Session *session);
+
+ private:
+  HINTERNET winhttp_session_ = nullptr;
+  std::mutex mutex_;
+  std::vector<std::weak_ptr<Session>> sessions_;
+};
+
+// Factory, so the client can be handed to OtlpHttpClient the same way the curl one is.
+class HttpClientFactory final : public http_client::HttpClientFactory {
+ public:
+  std::shared_ptr<http_client::HttpClientSync> CreateSync() override { return nullptr; }
+  std::shared_ptr<http_client::HttpClient> Create() override { return std::make_shared<HttpClient>(); }
+  std::shared_ptr<http_client::HttpClient> Create(
+      const std::shared_ptr<opentelemetry::sdk::common::ThreadInstrumentation> &) override {
+    return std::make_shared<HttpClient>();
+  }
+};
+
+}  // namespace winhttp_client

--- a/spike/zeal-sdk/otel_sdk.props
+++ b/spike/zeal-sdk/otel_sdk.props
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Imported by Zeal.vcxproj only when ZEAL_OTEL_SDK=1, so the shipping build never sees it.
+     Everything here must be /MT to match Zeal's <RuntimeLibrary>MultiThreaded</RuntimeLibrary>;
+     the earlier spike used a -md triplet and would have failed to link on the CRT alone. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- The 119 archive names are written to a generated props by the workflow rather than passed on
+       the command line: MSBuild treats ';' in a /p: value as an argument separator, and escaping it
+       corrupted the link inputs. A file has no such quoting layer. -->
+  <Import Project="$(SolutionDir)spike\zeal-sdk\otel_libs.generated.props"
+          Condition="Exists('$(SolutionDir)spike\zeal-sdk\otel_libs.generated.props')" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(OTEL_INSTALL)\include;$(VCPKG_INSTALL)\include;$(SolutionDir)spike\winhttp-client;$(SolutionDir)spike\zeal-sdk;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>ZEAL_OTEL_SDK;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OTEL_INSTALL)\lib;$(VCPKG_INSTALL)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>$(OTEL_LIBS)winhttp.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
## What this adds

An opt-in OTLP/HTTP exporter, so Zeal can send telemetry to any OpenTelemetry-compatible backend
(a collector, Prometheus, Grafana/Perses, …) over a standard protocol.

Zeal already exposes rich data over the named pipe, but consuming it needs an application that
understands Zeal's private format and runs on the same machine. OTLP is the industry-standard wire
format, so existing tooling works out of the box and several players' data can be aggregated
centrally — the motivating use case was a shared guild DPS/healing dashboard.

Signals: **metrics** (combat damage and healing counters, attack/haste gauges, character stats),
**traces** (a span per fight, nested under a zone-session span), and chat/combat **logs**.
Damage is attributed to the attacker, with pets credited to their owner via `PetOwnerSpawnId`.

Usage: `/otlp on|off|status|endpoint <url>|token <token>|flush <ms>|scope self|all`

## Nothing changes unless you ask for it

- **Off by default.** Nothing is transmitted until `/otlp on`; the setting persists in the ini.
- **The SDK is opt-in at build time.** Without `ZEAL_OTEL_SDK=1` there is no new dependency at all:
  `telemetry.cpp`, `instrumentation.cpp`, the WinHTTP transport and the props file are every one of
  them conditioned on it, and the default artifact is unchanged. Both shapes are built in CI.
- The named pipe is untouched, and the exporter registers its own callbacks.

## Why the SDK, when the decision record said hand-rolled

`docs/decisions/otlp-sdk-vs-hand-rolled.md` originally chose a hand-rolled serializer, because
`opentelemetry-cpp` pulls in libcurl, which pulls in zlib — and zlib is already statically baked
into the 2003-era `d3dx8.lib` the game links against. `_inflate` defined twice in one binary, with
`/FORCE:MULTIPLE` as the only obvious way through.

**That conclusion was wrong, and the record now carries the correction.** curl is optional. Built
with `WITH_HTTP_CLIENT_CURL=OFF` and a WinHTTP transport supplied instead, the SDK links into the
injected 32-bit `/MT` DLL with no curl and no zlib anywhere in the install tree.

What that buys over hand-rolled JSON: spec-correct serialization, real instruments, batching and
cardinality limits. The hand-rolled version had already shipped a bug where a single attribute was
emitted as an object rather than a one-element array, which invalidated *every* metrics payload
carrying a zone name — exactly the class of mistake the SDK removes.

## Cost to be aware of

CI builds `opentelemetry-cpp` v1.28.0 from source for `x86-windows-static`. It is cached on the
pinned version and triplet, so it is ~25 minutes cold and fast afterwards, and it only runs on PRs
touching the telemetry paths. That is a real cost and worth weighing.

## Also here, independent of telemetry

`io_ini`'s `getValue` used a fixed 256-byte buffer. `GetPrivateProfileStringA` does not report
truncation — it returns `nSize-1` and hands back a short string — so **any** setting longer than
255 characters was silently corrupted on read. It now grows until the value fits. Happy to split
this into its own PR if you would rather review it separately.

## Testing

Built and run against a live guild deployment: several players reporting to a shared gateway with
per-player tokens, metrics into Prometheus and traces into Jaeger, dashboards in Perses. CI
validates emitted payloads against fixtures (`ci/otlp_validate.py`) and builds both the default and
the SDK configuration.